### PR TITLE
fix(merge): no error when key is null

### DIFF
--- a/__tests__/anchors.js
+++ b/__tests__/anchors.js
@@ -151,6 +151,11 @@ describe('merge <<', () => {
     })
   })
 
+  test('do not throw error when key is null', () => {
+    const src = ': 123'
+    expect(() => YAML.parse(src, { merge: true })).not.toThrow()
+  })
+
   describe('parse errors', () => {
     test('non-alias merge value', () => {
       const src = '{ <<: A, B: b }'

--- a/src/schema/parseMap.js
+++ b/src/schema/parseMap.js
@@ -22,7 +22,7 @@ export default function parseMap(doc, cst) {
   resolveComments(map, comments)
   for (let i = 0; i < items.length; ++i) {
     const { key: iKey } = items[i]
-    if (doc.schema.merge && iKey.value === MERGE_KEY) {
+    if (doc.schema.merge && iKey && iKey.value === MERGE_KEY) {
       items[i] = new Merge(items[i])
       const sources = items[i].value.items
       let error = null


### PR DESCRIPTION
`iKey` is possible to be `null`.