### PR TITLE
 Add setOrigRanges() to YAML.parseCST() output

### DIFF
--- a/__tests__/cst/corner-cases.js
+++ b/__tests__/cst/corner-cases.js
@@ -129,8 +129,10 @@ test('eemeli/yaml#20', () => {
   const a = docStream[0].contents[0].items[1].node
   expect(a.strValue).toBe('123')
   expect(docStream.setOrigRanges()).toBe(true)
-  expect(a.valueRange.applyOrig(src)).toBe('123')
+  const { origStart: a0, origEnd: a1 } = a.valueRange
+  expect(src.slice(a0, a1)).toBe('123')
   const b = docStream[0].contents[0].items[3].node
   expect(b.strValue).toBe('456')
-  expect(b.valueRange.applyOrig(src)).toBe('456')
+  const { origStart: b0, origEnd: b1 } = b.valueRange
+  expect(src.slice(b0, b1)).toBe('456')
 })

--- a/__tests__/cst/corner-cases.js
+++ b/__tests__/cst/corner-cases.js
@@ -122,3 +122,15 @@ test('eemeli/yaml#l19', () => {
   expect(items).toHaveLength(2)
   expect(items[1].comment).toBe(' 123')
 })
+
+test('eemeli/yaml#20', () => {
+  const src = 'a:\r\n  123\r\nb:\r\n  456\r\n'
+  const docStream = parse(src)
+  const a = docStream[0].contents[0].items[1].node
+  expect(a.strValue).toBe('123')
+  expect(docStream.setOrigRanges()).toBe(true)
+  expect(a.valueRange.applyOrig(src)).toBe('123')
+  const b = docStream[0].contents[0].items[3].node
+  expect(b.strValue).toBe('456')
+  expect(b.valueRange.applyOrig(src)).toBe('456')
+})

--- a/__tests__/cst/parse.js
+++ b/__tests__/cst/parse.js
@@ -55,7 +55,7 @@ test('return value', () => {
     range: null,
     type: 'DOCUMENT',
     value: null,
-    valueRange: { end: 11, start: 0 }
+    valueRange: { end: 12, start: 0 }
   })
 })
 
@@ -85,7 +85,7 @@ describe('setOrigRanges()', () => {
     const src = '- foo\n- bar\n'
     const cst = parse(src)
     expect(cst.setOrigRanges()).toBe(false)
-    expect(cst[0].valueRange).toMatchObject({ start: 0, end: 11 })
+    expect(cst[0].valueRange).toMatchObject({ start: 0, end: 12 })
     expect(cst[0].valueRange.origStart).toBeUndefined()
     expect(cst[0].valueRange.origEnd).toBeUndefined()
   })
@@ -149,7 +149,7 @@ describe('setOrigRanges()', () => {
       range: null,
       type: 'DOCUMENT',
       value: null,
-      valueRange: { end: 11, origEnd: 12, origStart: 0, start: 0 }
+      valueRange: { end: 12, origEnd: 14, origStart: 0, start: 0 }
     })
   })
 
@@ -178,7 +178,7 @@ describe('setOrigRanges()', () => {
       range: null,
       type: 'DOCUMENT',
       value: null,
-      valueRange: { end: 3, origEnd: 3, origStart: 0, start: 0 }
+      valueRange: { end: 4, origEnd: 5, origStart: 0, start: 0 }
     })
     expect(cst[1]).toMatchObject({
       contents: [
@@ -197,7 +197,7 @@ describe('setOrigRanges()', () => {
       range: null,
       type: 'DOCUMENT',
       value: null,
-      valueRange: { end: 11, origEnd: 13, origStart: 10, start: 8 }
+      valueRange: { end: 12, origEnd: 15, origStart: 10, start: 8 }
     })
   })
 })

--- a/__tests__/cst/parse.js
+++ b/__tests__/cst/parse.js
@@ -1,0 +1,203 @@
+import parse from '../../src/cst/parse'
+
+test('return value', () => {
+  const src = '- foo\n- bar\n'
+  const cst = parse(src)
+  expect(cst).toHaveLength(1)
+  expect(cst[0]).toMatchObject({
+    contents: [
+      {
+        error: null,
+        items: [
+          {
+            error: null,
+            node: {
+              error: null,
+              props: [],
+              range: { end: 6, start: 2 },
+              type: 'PLAIN',
+              value: null,
+              valueRange: { end: 5, start: 2 }
+            },
+            props: [],
+            range: { end: 6, start: 0 },
+            type: 'SEQ_ITEM',
+            value: null,
+            valueRange: { end: 5, start: 0 }
+          },
+          {
+            error: null,
+            node: {
+              error: null,
+              props: [],
+              range: { end: 12, start: 8 },
+              type: 'PLAIN',
+              value: null,
+              valueRange: { end: 11, start: 8 }
+            },
+            props: [],
+            range: { end: 12, start: 6 },
+            type: 'SEQ_ITEM',
+            value: null,
+            valueRange: { end: 11, start: 6 }
+          }
+        ],
+        props: [],
+        range: { end: 12, start: 0 },
+        type: 'SEQ',
+        value: null,
+        valueRange: { end: 11, start: 0 }
+      }
+    ],
+    directives: [],
+    error: null,
+    props: [],
+    range: null,
+    type: 'DOCUMENT',
+    value: null,
+    valueRange: { end: 11, start: 0 }
+  })
+})
+
+describe('toString()', () => {
+  test('plain document', () => {
+    const src = '- foo\n- bar\n'
+    const cst = parse(src)
+    expect(String(cst)).toBe(src)
+  })
+
+  test('stream of two documents', () => {
+    const src = 'foo\n...\nbar\n'
+    const cst = parse(src)
+    expect(cst).toHaveLength(2)
+    expect(String(cst)).toBe(src)
+  })
+
+  test('document with CRLF line separators', () => {
+    const src = '- foo\r\n- bar\r\n'
+    const cst = parse(src)
+    expect(cst.toString()).toBe('- foo\n- bar\n')
+  })
+})
+
+describe('setOrigRanges()', () => {
+  test('return false for no CRLF', () => {
+    const src = '- foo\n- bar\n'
+    const cst = parse(src)
+    expect(cst.setOrigRanges()).toBe(false)
+    expect(cst[0].valueRange).toMatchObject({ start: 0, end: 11 })
+    expect(cst[0].valueRange.origStart).toBeUndefined()
+    expect(cst[0].valueRange.origEnd).toBeUndefined()
+  })
+
+  test('single document', () => {
+    const src = '- foo\r\n- bar\r\n'
+    const cst = parse(src)
+    expect(cst.setOrigRanges()).toBe(true)
+    expect(cst).toHaveLength(1)
+    const { range, valueRange } = cst[0].contents[0].items[1].node
+    expect(src.slice(range.origStart, range.origEnd)).toBe('bar\r\n')
+    expect(src.slice(valueRange.origStart, valueRange.origEnd)).toBe('bar')
+    expect(cst[0]).toMatchObject({
+      contents: [
+        {
+          error: null,
+          items: [
+            {
+              error: null,
+              node: {
+                error: null,
+                props: [],
+                range: { end: 6, origEnd: 7, origStart: 2, start: 2 },
+                type: 'PLAIN',
+                value: null,
+                valueRange: { end: 5, origEnd: 5, origStart: 2, start: 2 }
+              },
+              props: [],
+              range: { end: 6, origEnd: 7, origStart: 0, start: 0 },
+              type: 'SEQ_ITEM',
+              value: null,
+              valueRange: { end: 5, origEnd: 5, origStart: 0, start: 0 }
+            },
+            {
+              error: null,
+              node: {
+                error: null,
+                props: [],
+                range: { end: 12, origEnd: 14, origStart: 9, start: 8 },
+                type: 'PLAIN',
+                value: null,
+                valueRange: { end: 11, origEnd: 12, origStart: 9, start: 8 }
+              },
+              props: [],
+              range: { end: 12, origEnd: 14, origStart: 7, start: 6 },
+              type: 'SEQ_ITEM',
+              value: null,
+              valueRange: { end: 11, origEnd: 12, origStart: 7, start: 6 }
+            }
+          ],
+          props: [],
+          range: { end: 12, origEnd: 14, origStart: 0, start: 0 },
+          type: 'SEQ',
+          value: null,
+          valueRange: { end: 11, origEnd: 12, origStart: 0, start: 0 }
+        }
+      ],
+      directives: [],
+      error: null,
+      props: [],
+      range: null,
+      type: 'DOCUMENT',
+      value: null,
+      valueRange: { end: 11, origEnd: 12, origStart: 0, start: 0 }
+    })
+  })
+
+  test('stream of two documents', () => {
+    const src = 'foo\r\n...\r\nbar\r\n'
+    const cst = parse(src)
+    expect(cst.setOrigRanges()).toBe(true)
+    expect(cst).toHaveLength(2)
+    const { range, valueRange } = cst[1].contents[0]
+    expect(src.slice(range.origStart, range.origEnd)).toBe('bar\r\n')
+    expect(src.slice(valueRange.origStart, valueRange.origEnd)).toBe('bar')
+    expect(cst[0]).toMatchObject({
+      contents: [
+        {
+          error: null,
+          props: [],
+          range: { end: 4, origEnd: 5, origStart: 0, start: 0 },
+          type: 'PLAIN',
+          value: null,
+          valueRange: { end: 3, origEnd: 3, origStart: 0, start: 0 }
+        }
+      ],
+      directives: [],
+      error: null,
+      props: [],
+      range: null,
+      type: 'DOCUMENT',
+      value: null,
+      valueRange: { end: 3, origEnd: 3, origStart: 0, start: 0 }
+    })
+    expect(cst[1]).toMatchObject({
+      contents: [
+        {
+          error: null,
+          props: [],
+          range: { end: 12, origEnd: 15, origStart: 10, start: 8 },
+          type: 'PLAIN',
+          value: null,
+          valueRange: { end: 11, origEnd: 13, origStart: 10, start: 8 }
+        }
+      ],
+      directives: [],
+      error: null,
+      props: [],
+      range: null,
+      type: 'DOCUMENT',
+      value: null,
+      valueRange: { end: 11, origEnd: 13, origStart: 10, start: 8 }
+    })
+  })
+})

--- a/src/Document.js
+++ b/src/Document.js
@@ -107,7 +107,7 @@ export default class Document {
     const comments = { before: [], after: [] }
     const contentNodes = []
     contents.forEach(node => {
-      if (node.valueRange && !node.valueRange.isEmpty) {
+      if (node.valueRange && !node.valueRange.isEmpty()) {
         if (contentNodes.length === 1) {
           const msg = 'Document is not valid YAML (bad indentation?)'
           this.errors.push(new YAMLSyntaxError(node, msg))

--- a/src/cst/BlockValue.js
+++ b/src/cst/BlockValue.js
@@ -179,4 +179,9 @@ export default class BlockValue extends Node {
       JSON.stringify(this.rawValue)
     return offset
   }
+
+  setOrigRanges(cr, offset) {
+    offset = super.setOrigRanges(cr, offset)
+    return this.header ? this.header.setOrigRange(cr, offset) : offset
+  }
 }

--- a/src/cst/BlockValue.js
+++ b/src/cst/BlockValue.js
@@ -19,7 +19,7 @@ export default class BlockValue extends Node {
     if (!this.valueRange || !this.context) return null
     let { start, end } = this.valueRange
     const { indent, src } = this.context
-    if (this.valueRange.isEmpty) return ''
+    if (this.valueRange.isEmpty()) return ''
     let lastNewLine = null
     let ch = src[end - 1]
     while (ch === '\n' || ch === '\t' || ch === ' ') {

--- a/src/cst/Collection.js
+++ b/src/cst/Collection.js
@@ -115,6 +115,14 @@ export default class Collection extends Node {
     return offset
   }
 
+  setOrigRanges(cr, offset) {
+    offset = super.setOrigRanges(cr, offset)
+    this.items.forEach(node => {
+      offset = node.setOrigRanges(cr, offset)
+    })
+    return offset
+  }
+
   toString() {
     const {
       context: { src },

--- a/src/cst/CollectionItem.js
+++ b/src/cst/CollectionItem.js
@@ -65,6 +65,11 @@ export default class CollectionItem extends Node {
     return offset
   }
 
+  setOrigRanges(cr, offset) {
+    offset = super.setOrigRanges(cr, offset)
+    return this.node ? this.node.setOrigRanges(cr, offset) : offset
+  }
+
   toString() {
     const {
       context: { src },

--- a/src/cst/Document.js
+++ b/src/cst/Document.js
@@ -162,6 +162,17 @@ export default class Document extends Node {
     return offset
   }
 
+  setOrigRanges(cr, offset) {
+    offset = super.setOrigRanges(cr, offset)
+    this.directives.forEach(node => {
+      offset = node.setOrigRanges(cr, offset)
+    })
+    this.contents.forEach(node => {
+      offset = node.setOrigRanges(cr, offset)
+    })
+    return offset
+  }
+
   toString() {
     const {
       contents,

--- a/src/cst/FlowCollection.js
+++ b/src/cst/FlowCollection.js
@@ -110,6 +110,14 @@ export default class FlowCollection extends Node {
     return offset
   }
 
+  setOrigRanges(cr, offset) {
+    offset = super.setOrigRanges(cr, offset)
+    this.items.forEach(node => {
+      offset = node.setOrigRanges(cr, offset)
+    })
+    return offset
+  }
+
   toString() {
     const {
       context: { src },

--- a/src/cst/Node.js
+++ b/src/cst/Node.js
@@ -288,6 +288,21 @@ export default class Node {
     return start
   }
 
+  /**
+   * Populates the `origStart` and `origEnd` values of all ranges for this
+   * node. Extended by child classes to handle descendant nodes.
+   *
+   * @param {number[]} cr - Positions of dropped CR characters
+   * @param {number} offset - Starting index of `cr` from the last call
+   * @returns {number} - The next offset, matching the one found for `origStart`
+   */
+  setOrigRanges(cr, offset) {
+    if (this.range) offset = this.range.setOrigRange(cr, offset)
+    this.valueRange.setOrigRange(cr, offset)
+    this.props.forEach(prop => prop.setOrigRange(cr, offset))
+    return offset
+  }
+
   toString() {
     const {
       context: { src },

--- a/src/cst/PlainValue.js
+++ b/src/cst/PlainValue.js
@@ -66,7 +66,7 @@ export default class PlainValue extends Node {
       if (end === null || src[end] === '#') break
       offset = PlainValue.endOfLine(src, end, inFlow)
     }
-    if (this.valueRange.isEmpty) this.valueRange.start = start
+    if (this.valueRange.isEmpty()) this.valueRange.start = start
     this.valueRange.end = offset
     trace: this.valueRange, JSON.stringify(this.rawValue)
     return offset
@@ -112,7 +112,7 @@ export default class PlainValue extends Node {
     trace: 'first line',
       { valueRange: this.valueRange, comment: this.comment },
       JSON.stringify(this.rawValue)
-    if (!this.hasComment || this.valueRange.isEmpty) {
+    if (!this.hasComment || this.valueRange.isEmpty()) {
       offset = this.parseBlockValue(offset)
     }
     trace: this.type,

--- a/src/cst/Range.js
+++ b/src/cst/Range.js
@@ -12,18 +12,6 @@ export default class Range {
     return typeof this.start !== 'number' || !this.end || this.end <= this.start
   }
 
-  apply(src) {
-    return this.isEmpty() ? '' : src.slice(this.start, this.end)
-  }
-
-  applyOrig(src) {
-    return this.isEmpty()
-      ? ''
-      : this.origEnd
-        ? src.slice(this.origStart, this.origEnd)
-        : src.slice(this.start, this.end)
-  }
-
   /**
    * Set `origStart` and `origEnd` to point to the original source range for
    * this node, which may differ due to dropped CR characters.

--- a/src/cst/Range.js
+++ b/src/cst/Range.js
@@ -8,15 +8,50 @@ export default class Range {
     this.end = end || start
   }
 
-  get isEmpty() {
+  isEmpty() {
     return typeof this.start !== 'number' || !this.end || this.end <= this.start
   }
 
-  get length() {
-    return this.isEmpty ? 0 : this.end - this.start
+  apply(src) {
+    return this.isEmpty() ? '' : src.slice(this.start, this.end)
   }
 
-  apply(src) {
-    return this.isEmpty ? '' : src.slice(this.start, this.end)
+  applyOrig(src) {
+    return this.isEmpty()
+      ? ''
+      : this.origEnd
+        ? src.slice(this.origStart, this.origEnd)
+        : src.slice(this.start, this.end)
+  }
+
+  /**
+   * Set `origStart` and `origEnd` to point to the original source range for
+   * this node, which may differ due to dropped CR characters.
+   *
+   * @param {number[]} cr - Positions of dropped CR characters
+   * @param {number} offset - Starting index of `cr` from the last call
+   * @returns {number} - The next offset, matching the one found for `origStart`
+   */
+  setOrigRange(cr, offset) {
+    const { start, end } = this
+    if (cr.length === 0 || end <= cr[0]) {
+      this.origStart = start
+      this.origEnd = end
+      return offset
+    }
+    let i = offset
+    while (i < cr.length) {
+      if (cr[i] > start) break
+      else ++i
+    }
+    this.origStart = start + i
+    const nextOffset = i
+    while (i < cr.length) {
+      // if end was at \n, it should now be at \r
+      if (cr[i] >= end) break
+      else ++i
+    }
+    this.origEnd = end + i
+    return nextOffset
   }
 }

--- a/src/cst/parse.js
+++ b/src/cst/parse.js
@@ -22,8 +22,9 @@ export default function parse(src) {
   documents.setOrigRanges = () => {
     if (cr.length === 0) return false
     for (let i = 1; i < cr.length; ++i) cr[i] -= i
+    let crOffset = 0
     for (let i = 0; i < documents.length; ++i) {
-      documents[i].setOrigRanges(cr, 0)
+      documents[i].setOrigRanges(cr, crOffset)
     }
     cr.splice(0, cr.length)
     return true

--- a/src/cst/parse.js
+++ b/src/cst/parse.js
@@ -24,7 +24,7 @@ export default function parse(src) {
     for (let i = 1; i < cr.length; ++i) cr[i] -= i
     let crOffset = 0
     for (let i = 0; i < documents.length; ++i) {
-      documents[i].setOrigRanges(cr, crOffset)
+      crOffset = documents[i].setOrigRanges(cr, crOffset)
     }
     cr.splice(0, cr.length)
     return true

--- a/src/cst/parse.js
+++ b/src/cst/parse.js
@@ -4,7 +4,13 @@ import Document from './Document'
 import ParseContext from './ParseContext'
 
 export default function parse(src) {
-  if (src.indexOf('\r') !== -1) src = src.replace(/\r\n?/g, '\n')
+  const cr = []
+  if (src.indexOf('\r') !== -1) {
+    src = src.replace(/\r\n?/g, (match, offset) => {
+      if (match.length > 1) cr.push(offset)
+      return '\n'
+    })
+  }
   const context = new ParseContext({ src })
   const documents = []
   let offset = 0
@@ -12,6 +18,15 @@ export default function parse(src) {
     const doc = new Document()
     offset = doc.parse(context, offset)
     documents.push(doc)
+  }
+  documents.setOrigRanges = () => {
+    if (cr.length === 0) return false
+    for (let i = 1; i < cr.length; ++i) cr[i] -= i
+    for (let i = 0; i < documents.length; ++i) {
+      documents[i].setOrigRanges(cr, 0)
+    }
+    cr.splice(0, cr.length)
+    return true
   }
   documents.toString = () => documents.join('...\n')
   return documents


### PR DESCRIPTION
This (hopefully) fixes #20 by adding a method `setOrigRanges()` to the array object returned by `YAML.parseCST()`. That method would set `origStart` and `origEnd` indices for all of the range objects contained within the CST, which in turn would point to the start and end of the source before the CR characters got stripped out.

@ikatyang, comment from you would be appreciated here esp. regarding the specifics of the API, as you would have an actual use case for this. In particular:
- I'm not sure about the new method and member names, and would be interested to consider alternatives.
- The current `setOrigRanges()` implementation will return a boolean indicating whether it did in fact add the ranges, to allow for a fast return for inputs that did not contain a `\r\n` string. Does this make its usage more difficult, as it's then not certain that `origStart` and `origEnd` are always set after calling?
- If a range `end` is pointing at the `\n` character that in the source was preceded by a `\r`, the corresponding `origEnd` will then point at the `\r` character to maintain the same semantic meaning as before. This has particular significance for `valueRange` values, as this makes sure that a slice of the source using the range does not get a somewhat surprising `\r` suffix if `origEnd` is left pointing at the `\n`.
- The `Range` class now has a couple of utility methods, `apply(src)` and `applyOrig(src)`, for slicing the range contents from the source. Should these be published and documented? Atm just `applyOrig` is used, and even then in just one test case.

I did try a couple of more automated methods of handling all of this, e.g. mutating the range `start` and `end` values automatically after parsing to match what's now `origX`, but that messes up the value parsing and actually breaks YAML spec a bit. I also considered calling `setOrigRanges()` internally before returning from `parseCST()`, but that would make the presence or non-presence of `origX` values unclear, as well as adding a useless tree traversal for use cases that don't need the indices into the original source.