### PR TITLE
Add option to output JS Maps, add generic support for iterables

### DIFF
--- a/__tests__/createNode.js
+++ b/__tests__/createNode.js
@@ -169,3 +169,47 @@ z:
     })
   })
 })
+
+describe('Set', () => {
+  test('createNode(new Set)', () => {
+    const s = createNode(new Set())
+    expect(s).toBeInstanceOf(Seq)
+    expect(s.items).toHaveLength(0)
+  })
+  test('createNode(new Set([true]), false)', () => {
+    const s = createNode(new Set([true]), false)
+    expect(s).toBeInstanceOf(Seq)
+    expect(s.items).toMatchObject([true])
+  })
+  describe('new Set([3, new Set(["four", 5])])', () => {
+    const set = new Set([3, new Set(['four', 5])])
+    test('createNode(value, false)', () => {
+      const s = createNode(set, false)
+      expect(s).toBeInstanceOf(Seq)
+      expect(s.items).toHaveLength(2)
+      expect(s.items[0]).toBe(3)
+      expect(s.items[1]).toBeInstanceOf(Seq)
+      expect(s.items[1].items).toMatchObject(['four', 5])
+    })
+    test('createNode(value, true)', () => {
+      const s = createNode(set, true)
+      expect(s).toBeInstanceOf(Seq)
+      expect(s.items).toHaveLength(2)
+      expect(s.items[0].value).toBe(3)
+      expect(s.items[1]).toBeInstanceOf(Seq)
+      expect(s.items[1].items).toHaveLength(2)
+      expect(s.items[1].items[0].value).toBe('four')
+      expect(s.items[1].items[1].value).toBe(5)
+    })
+    test('set doc contents', () => {
+      const res = '- 3\n- - four\n  - 5\n'
+      const doc = new YAML.Document()
+      doc.contents = set
+      expect(String(doc)).toBe(res)
+      doc.contents = createNode(set, false)
+      expect(String(doc)).toBe(res)
+      doc.contents = createNode(set, true)
+      expect(String(doc)).toBe(res)
+    })
+  })
+})

--- a/__tests__/createNode.js
+++ b/__tests__/createNode.js
@@ -1,6 +1,6 @@
 import createNode from '../src/createNode'
 import YAML from '../src/index'
-import Map from '../src/schema/Map'
+import YAMLMap from '../src/schema/Map'
 import Pair from '../src/schema/Pair'
 import Scalar from '../src/schema/Scalar'
 import Seq from '../src/schema/Seq'
@@ -107,12 +107,12 @@ describe('arrays', () => {
 describe('objects', () => {
   test('createNode({})', () => {
     const s = createNode({})
-    expect(s).toBeInstanceOf(Map)
+    expect(s).toBeInstanceOf(YAMLMap)
     expect(s.items).toHaveLength(0)
   })
   test('createNode({ x: true }, false)', () => {
     const s = createNode({ x: true }, false)
-    expect(s).toBeInstanceOf(Map)
+    expect(s).toBeInstanceOf(YAMLMap)
     expect(s.items).toHaveLength(1)
     expect(s.items[0]).toBeInstanceOf(Pair)
     expect(s.items[0]).toMatchObject({ key: 'x', value: true })
@@ -121,7 +121,7 @@ describe('objects', () => {
     const object = { x: 3, y: [4], z: { w: 'five', v: 6 } }
     test('createNode(value, false)', () => {
       const s = createNode(object, false)
-      expect(s).toBeInstanceOf(Map)
+      expect(s).toBeInstanceOf(YAMLMap)
       expect(s.items).toHaveLength(3)
       expect(s.items).toMatchObject([
         { key: 'x', value: 3 },
@@ -136,7 +136,7 @@ describe('objects', () => {
     })
     test('createNode(value, true)', () => {
       const s = createNode(object, true)
-      expect(s).toBeInstanceOf(Map)
+      expect(s).toBeInstanceOf(YAMLMap)
       expect(s.items).toHaveLength(3)
       expect(s.items).toMatchObject([
         { key: { value: 'x' }, value: { value: 3 } },
@@ -181,9 +181,9 @@ describe('Set', () => {
     expect(s).toBeInstanceOf(Seq)
     expect(s.items).toMatchObject([true])
   })
-  describe('new Set([3, new Set(["four", 5])])', () => {
+  describe("Set { 3, Set { 'four', 5 } }", () => {
     const set = new Set([3, new Set(['four', 5])])
-    test('createNode(value, false)', () => {
+    test('createNode(set, false)', () => {
       const s = createNode(set, false)
       expect(s).toBeInstanceOf(Seq)
       expect(s.items).toHaveLength(2)
@@ -191,7 +191,7 @@ describe('Set', () => {
       expect(s.items[1]).toBeInstanceOf(Seq)
       expect(s.items[1].items).toMatchObject(['four', 5])
     })
-    test('createNode(value, true)', () => {
+    test('createNode(set, true)', () => {
       const s = createNode(set, true)
       expect(s).toBeInstanceOf(Seq)
       expect(s.items).toHaveLength(2)
@@ -209,6 +209,76 @@ describe('Set', () => {
       doc.contents = createNode(set, false)
       expect(String(doc)).toBe(res)
       doc.contents = createNode(set, true)
+      expect(String(doc)).toBe(res)
+    })
+  })
+})
+
+describe('Map', () => {
+  test('createNode(new Map)', () => {
+    const s = createNode(new Map())
+    expect(s).toBeInstanceOf(YAMLMap)
+    expect(s.items).toHaveLength(0)
+  })
+  test('createNode(new Map([["x", true]]), false)', () => {
+    const s = createNode(new Map([['x', true]]), false)
+    expect(s).toBeInstanceOf(YAMLMap)
+    expect(s.items).toHaveLength(1)
+    expect(s.items[0]).toBeInstanceOf(Pair)
+    expect(s.items[0]).toMatchObject({ key: 'x', value: true })
+  })
+  describe("Map { 'x' => 3, 'y' => Set { 4 }, Map { 'w' => 'five', 'v' => 6 } => 'z' }", () => {
+    const map = new Map([
+      ['x', 3],
+      ['y', new Set([4])],
+      [new Map([['w', 'five'], ['v', 6]]), 'z']
+    ])
+    test('createNode(map, false)', () => {
+      const s = createNode(map, false)
+      expect(s).toBeInstanceOf(YAMLMap)
+      expect(s.items).toHaveLength(3)
+      expect(s.items).toMatchObject([
+        { key: 'x', value: 3 },
+        { key: 'y', value: { items: [4] } },
+        {
+          key: {
+            items: [{ key: 'w', value: 'five' }, { key: 'v', value: 6 }]
+          },
+          value: 'z'
+        }
+      ])
+    })
+    test('createNode(map, true)', () => {
+      const s = createNode(map, true)
+      expect(s).toBeInstanceOf(YAMLMap)
+      expect(s.items).toHaveLength(3)
+      expect(s.items).toMatchObject([
+        { key: { value: 'x' }, value: { value: 3 } },
+        { key: { value: 'y' }, value: { items: [{ value: 4 }] } },
+        {
+          key: {
+            items: [
+              { key: { value: 'w' }, value: { value: 'five' } },
+              { key: { value: 'v' }, value: { value: 6 } }
+            ]
+          },
+          value: { value: 'z' }
+        }
+      ])
+    })
+    test('set doc contents', () => {
+      const res = `x: 3
+y:
+  - 4
+? w: five
+  v: 6
+: z\n`
+      const doc = new YAML.Document()
+      doc.contents = map
+      expect(String(doc)).toBe(res)
+      doc.contents = createNode(map, false)
+      expect(String(doc)).toBe(res)
+      doc.contents = createNode(map, true)
       expect(String(doc)).toBe(res)
     })
   })

--- a/__tests__/types.js
+++ b/__tests__/types.js
@@ -159,6 +159,34 @@ canonical: null
 english: null
 null: null key\n`)
   })
+
+  describe('!!map', () => {
+    test('mapAsMap: false', () => {
+      const src = `
+one: 1
+2: two
+{ 3: 4 }: many\n`
+      const doc = YAML.parseDocument(src)
+      expect(doc.toJSON()).toMatchObject({
+        one: 1,
+        '2': 'two',
+        '{"3":4}': 'many'
+      })
+      expect(doc.errors).toHaveLength(0)
+    })
+
+    test('mapAsMap: true', () => {
+      const src = `
+one: 1
+2: two
+{ 3: 4 }: many\n`
+      const doc = YAML.parseDocument(src, { mapAsMap: true })
+      expect(doc.toJSON()).toMatchObject(
+        new Map([['one', 1], [2, 'two'], [new Map([[3, 4]]), 'many']])
+      )
+      expect(doc.errors).toHaveLength(0)
+    })
+  })
 })
 
 describe('YAML 1.1 schema', () => {

--- a/src/Document.js
+++ b/src/Document.js
@@ -416,7 +416,7 @@ export default class Document {
     const keep =
       this.options.keepBlobsInJSON &&
       (typeof arg !== 'string' || !(this.contents instanceof Scalar))
-    return toJSON(this.contents, arg, keep)
+    return toJSON(this.contents, arg, { keep })
   }
 
   toString() {

--- a/src/Document.js
+++ b/src/Document.js
@@ -416,7 +416,8 @@ export default class Document {
     const keep =
       this.options.keepBlobsInJSON &&
       (typeof arg !== 'string' || !(this.contents instanceof Scalar))
-    return toJSON(this.contents, arg, { keep })
+    const mapAsMap = keep && !!this.options.mapAsMap
+    return toJSON(this.contents, arg, { keep, mapAsMap })
   }
 
   toString() {

--- a/src/createNode.js
+++ b/src/createNode.js
@@ -10,6 +10,13 @@ export default function createNode(value, wrapScalars = true) {
     const seq = new Seq()
     seq.items = value.map(v => createNode(v, wrapScalars))
     return seq
+  } else if (typeof Symbol !== 'undefined' && value[Symbol.iterator]) {
+    const seq = new Seq()
+    for (const it of value) {
+      const v = createNode(it, wrapScalars)
+      seq.items.push(v)
+    }
+    return seq
   } else {
     const map = new Map()
     map.items = Object.keys(value).map(key => {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { YAMLSemanticError } from './errors'
 const defaultOptions = {
   keepNodeTypes: true,
   keepBlobsInJSON: true,
+  mapAsMap: false,
   tags: null,
   version: '1.2'
 }

--- a/src/schema/Alias.js
+++ b/src/schema/Alias.js
@@ -24,7 +24,7 @@ export default class Alias extends Node {
     throw new Error('Alias nodes cannot have tags')
   }
 
-  toJSON(arg, keep) {
-    return toJSON(this.source, arg, keep)
+  toJSON(arg, opt) {
+    return toJSON(this.source, arg, opt)
   }
 }

--- a/src/schema/Map.js
+++ b/src/schema/Map.js
@@ -6,7 +6,7 @@ import Merge from './Merge'
 import Pair from './Pair'
 
 export default class YAMLMap extends Collection {
-  toJSON(_, keep) {
+  toJSON(_, opt) {
     return this.items.reduce((map, item) => {
       if (item instanceof Merge) {
         // If the value associated with a merge key is a single mapping node,
@@ -22,7 +22,7 @@ export default class YAMLMap extends Collection {
         for (let i = items.length - 1; i >= 0; --i) {
           const { source } = items[i]
           if (source instanceof YAMLMap) {
-            const obj = source.toJSON('', keep)
+            const obj = source.toJSON('', opt)
             Object.keys(obj).forEach(key => {
               if (!keys.includes(key)) map[key] = obj[key]
             })
@@ -32,7 +32,7 @@ export default class YAMLMap extends Collection {
         }
       } else {
         const { stringKey, value } = item
-        map[stringKey] = toJSON(value, stringKey, keep)
+        map[stringKey] = toJSON(value, stringKey, opt)
       }
       return map
     }, {})

--- a/src/schema/Pair.js
+++ b/src/schema/Pair.js
@@ -44,10 +44,10 @@ export default class Pair extends Node {
     return String(key)
   }
 
-  toJSON(_, keep) {
+  toJSON(_, opt) {
     const pair = {}
     const sk = this.stringKey
-    pair[sk] = toJSON(this.value, sk, keep)
+    pair[sk] = toJSON(this.value, sk, opt)
     return pair
   }
 

--- a/src/schema/Scalar.js
+++ b/src/schema/Scalar.js
@@ -9,8 +9,8 @@ export default class Scalar extends Node {
     this.value = value
   }
 
-  toJSON(arg, keep) {
-    return keep ? this.value : toJSON(this.value, arg, keep)
+  toJSON(arg, opt) {
+    return opt && opt.keep ? this.value : toJSON(this.value, arg, opt)
   }
 
   toString() {

--- a/src/schema/Seq.js
+++ b/src/schema/Seq.js
@@ -4,8 +4,8 @@ import toJSON from '../toJSON'
 import Collection from './Collection'
 
 export default class YAMLSeq extends Collection {
-  toJSON(_, keep) {
-    return this.items.map((v, i) => toJSON(v, String(i), keep))
+  toJSON(_, opt) {
+    return this.items.map((v, i) => toJSON(v, String(i), opt))
   }
 
   toString(ctx, onComment) {

--- a/src/toJSON.js
+++ b/src/toJSON.js
@@ -1,7 +1,7 @@
-export default function toJSON(value, arg, keep) {
+export default function toJSON(value, arg, opt) {
   return Array.isArray(value)
-    ? value.map((v, i) => toJSON(v, String(i), keep))
+    ? value.map((v, i) => toJSON(v, String(i), opt))
     : value && typeof value.toJSON === 'function'
-    ? value.toJSON(arg, keep)
+    ? value.toJSON(arg, opt)
     : value
 }


### PR DESCRIPTION
Fixes #46, fixes #49, fixes #50 

On the YAML -> JS side, this adds a new option `mapAsMap`, with which YAML mappings are represented in JS as `Map` rather than `Object` instances:

```js
YAML.parse('{[1, 2]: many}')
// { '[1,2]': 'many' }

YAML.parse('{[1, 2]: many}', { mapAsMap: true })
// Map { [ 1, 2 ] => 'many' }
```

The specific benefit of this is the ability to natively use non-string keys in mappings.

Then on the JS -> YAML side, iterable values are now supported by `createNode()`. The default is to parse them as sequences, but `Map` and its descendants are parsed as mappings.