### PR TITLE
Fix parsing of minimal strings: '', '-', '?', ':'

### DIFF
--- a/__tests__/corner-cases.js
+++ b/__tests__/corner-cases.js
@@ -254,3 +254,8 @@ test('fake node should respect setOrigRanges()', () => {
     origEnd: 2
   })
 })
+
+test('parse an empty string as null', () => {
+  const value = YAML.parse('')
+  expect(value).toBeNull()
+})

--- a/__tests__/cst/corner-cases.js
+++ b/__tests__/cst/corner-cases.js
@@ -202,3 +202,11 @@ describe('collection indicator as last char', () => {
     })
   })
 })
+
+test('parse an empty string as an empty document', () => {
+  const doc = parse('')[0]
+  expect(doc).toMatchObject({
+    error: null,
+    contents: []
+  })
+})

--- a/__tests__/cst/corner-cases.js
+++ b/__tests__/cst/corner-cases.js
@@ -161,3 +161,44 @@ test('eemeli/yaml#56', () => {
     type: 'PLAIN'
   })
 })
+
+describe('collection indicator as last char', () => {
+  test('seq item', () => {
+    const src = '-'
+    const doc = parse(src)[0]
+    expect(doc.contents[0]).toMatchObject({
+      type: 'SEQ',
+      items: [{ type: 'SEQ_ITEM', node: null }]
+    })
+  })
+
+  test('explicit map key', () => {
+    const src = '?'
+    const doc = parse(src)[0]
+    expect(doc.contents[0]).toMatchObject({
+      type: 'MAP',
+      items: [{ type: 'MAP_KEY', node: null }]
+    })
+  })
+
+  test('empty map value', () => {
+    const src = ':'
+    const doc = parse(src)[0]
+    expect(doc.contents[0]).toMatchObject({
+      type: 'MAP',
+      items: [{ type: 'MAP_VALUE', node: null }]
+    })
+  })
+
+  test('indented seq-in-seq', () => {
+    const src = ` -\n - - a\n -`
+    const doc = parse(src)[0]
+    expect(doc.contents[0]).toMatchObject({
+      items: [
+        { error: null },
+        { node: { items: [{ node: { type: 'PLAIN', strValue: 'a' } }] } },
+        { error: null }
+      ]
+    })
+  })
+})

--- a/src/cst/Node.js
+++ b/src/cst/Node.js
@@ -110,15 +110,16 @@ export default class Node {
     return null
   }
 
-  static atBlank(src, offset) {
+  static atBlank(src, offset, endAsBlank) {
     const ch = src[offset]
-    return ch === '\n' || ch === '\t' || ch === ' '
+    return ch === '\n' || ch === '\t' || ch === ' ' || (endAsBlank && !ch)
   }
 
   static atCollectionItem(src, offset) {
     const ch = src[offset]
     return (
-      (ch === '?' || ch === ':' || ch === '-') && Node.atBlank(src, offset + 1)
+      (ch === '?' || ch === ':' || ch === '-') &&
+      Node.atBlank(src, offset + 1, true)
     )
   }
 

--- a/src/cst/ParseContext.js
+++ b/src/cst/ParseContext.js
@@ -33,15 +33,15 @@ export default class ParseContext {
       case '[':
         return Type.FLOW_SEQ
       case '?':
-        return !inFlow && Node.atBlank(src, offset + 1)
+        return !inFlow && Node.atBlank(src, offset + 1, true)
           ? Type.MAP_KEY
           : Type.PLAIN
       case ':':
-        return !inFlow && Node.atBlank(src, offset + 1)
+        return !inFlow && Node.atBlank(src, offset + 1, true)
           ? Type.MAP_VALUE
           : Type.PLAIN
       case '-':
-        return !inFlow && Node.atBlank(src, offset + 1)
+        return !inFlow && Node.atBlank(src, offset + 1, true)
           ? Type.SEQ_ITEM
           : Type.PLAIN
       case '"':
@@ -146,7 +146,8 @@ export default class ParseContext {
       ch = src[offset]
     }
     // '- &a : b' has an anchor on an empty node
-    if (lineHasProps && ch === ':' && Node.atBlank(src, offset + 1)) offset -= 1
+    if (lineHasProps && ch === ':' && Node.atBlank(src, offset + 1, true))
+      offset -= 1
     const type = ParseContext.parseType(src, offset, inFlow)
     trace: 'props', type, { props, offset }
     return { props, type, valueStart: offset }

--- a/src/cst/parse.js
+++ b/src/cst/parse.js
@@ -14,11 +14,11 @@ export default function parse(src) {
   const context = new ParseContext({ src })
   const documents = []
   let offset = 0
-  while (offset < src.length) {
+  do {
     const doc = new Document()
     offset = doc.parse(context, offset)
     documents.push(doc)
-  }
+  } while (offset < src.length)
   documents.setOrigRanges = () => {
     if (cr.length === 0) return false
     for (let i = 1; i < cr.length; ++i) cr[i] -= i


### PR DESCRIPTION
This fixes two bugs:
- Parsing an empty string should not fail, but be considered as `null`.
- `-`, `?`, or `:` at the very end of input (i.e. input without a terminal newline) should be parsed as collection entry indicators rather than strings.