### PR TITLE
Optionally compute lineOffsets, refs #67

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ import Seq from 'yaml/seq'
 import parseCST from 'yaml/parse-cst'
 ```
 
-* [`parseCST(str): CSTDocument[]`](https://eemeli.org/yaml/#parsecst)
-* [`YAML.parseCST(str): CSTDocument[]`](https://eemeli.org/yaml/#parsecst)
+* [`parseCST(str, options): CSTDocument[]`](https://eemeli.org/yaml/#parsecst)
+* [`YAML.parseCST(str, options): CSTDocument[]`](https://eemeli.org/yaml/#parsecst)
 
 ## YAML.parse
 

--- a/__tests__/ast/parseDocument.js
+++ b/__tests__/ast/parseDocument.js
@@ -1,0 +1,18 @@
+import { parseDocument } from '../../src/index'
+import { charPosToLineCol } from '../../src/cst/parse'
+
+describe('lineOffsets', () => {
+  test('no lineOffsets by default', () => {
+    const src = '- foo\n- bar\n'
+    const ast = parseDocument(src)
+    expect(ast.contents).toBeDefined()
+    expect(ast.lineOffsets).not.toBeDefined()
+  })
+
+  test('lineOffsets included when explicitly requested', () => {
+    const src = '- foo\n- bar\n'
+    const ast = parseDocument(src, { computeLineOffsets: true })
+    expect(ast.contents).toBeDefined()
+    expect(ast.lineOffsets).toBeDefined()
+  })
+})

--- a/__tests__/cst/parse.js
+++ b/__tests__/cst/parse.js
@@ -1,4 +1,5 @@
 import parse from '../../src/cst/parse'
+import { charPosToLineCol } from '../../src/cst/parse'
 
 test('return value', () => {
   const src = '- foo\n- bar\n'
@@ -241,6 +242,104 @@ describe('setOrigRanges()', () => {
       type: 'DOCUMENT',
       value: null,
       valueRange: { end: 7, origEnd: 9, origStart: 2, start: 1 }
+    })
+  })
+})
+
+describe('lineOffsets', () => {
+  test('no lineOffsets by default', () => {
+    const src = '- foo\n- bar\n'
+    const cst = parse(src)
+    expect(cst.lineOffsets).not.toBeDefined()
+  })
+
+  test('lineOffsets included when explicitly requested', () => {
+    const src = '- foo\n- bar\n'
+    const cst = parse(src, { computeLineOffsets: true })
+    expect(cst.lineOffsets).toBeDefined()
+    expect(cst.lineOffsets).toMatchObject([0, 6, 12])
+  })
+
+  test('lineOffsets for empty document', () => {
+    const src = ''
+    const cst = parse(src, { computeLineOffsets: true })
+    expect(cst.lineOffsets).toBeDefined()
+    expect(cst.lineOffsets).toMatchObject([0])
+  })
+
+  test('lineOffsets for multiple documents', () => {
+    const src = 'foo\n...\nbar\n'
+    const cst = parse(src, { computeLineOffsets: true })
+    expect(cst.lineOffsets).toBeDefined()
+    expect(cst.lineOffsets).toMatchObject([0, 4, 8, 12])
+  })
+
+  test('lineOffsets for malformed document', () => {
+    const src = '- foo\n\t- bar\n'
+    const cst = parse(src, { computeLineOffsets: true })
+    expect(cst).toHaveLength(1)
+    expect(cst.lineOffsets).toBeDefined()
+    expect(cst.lineOffsets).toMatchObject([0, 6, 13])
+  })
+
+  test('offset conversion to line and col', () => {
+    const src = '- foo\n- bar\n'
+    const cst = parse(src, { computeLineOffsets: true })
+    expect(charPosToLineCol()).toMatchObject({
+      line: undefined,
+      col: undefined
+    })
+    expect(charPosToLineCol(0)).toMatchObject({
+      line: undefined,
+      col: undefined
+    })
+    expect(charPosToLineCol(1)).toMatchObject({
+      line: undefined,
+      col: undefined
+    })
+    expect(charPosToLineCol(-1, cst.lineOffsets)).toMatchObject({
+      line: undefined,
+      col: undefined
+    })
+    expect(charPosToLineCol(0, cst.lineOffsets)).toMatchObject({
+      line: 0,
+      col: 0
+    })
+    expect(charPosToLineCol(1, cst.lineOffsets)).toMatchObject({
+      line: 0,
+      col: 1
+    })
+    expect(charPosToLineCol(2, cst.lineOffsets)).toMatchObject({
+      line: 0,
+      col: 2
+    })
+    expect(charPosToLineCol(5, cst.lineOffsets)).toMatchObject({
+      line: 0,
+      col: 5
+    })
+    expect(charPosToLineCol(6, cst.lineOffsets)).toMatchObject({
+      line: 1,
+      col: 0
+    })
+    expect(charPosToLineCol(7, cst.lineOffsets)).toMatchObject({
+      line: 1,
+      col: 1
+    })
+    expect(charPosToLineCol(11, cst.lineOffsets)).toMatchObject({
+      line: 1,
+      col: 5
+    })
+    expect(charPosToLineCol(12, cst.lineOffsets)).toMatchObject({
+      line: 2,
+      col: 0
+    })
+    expect(charPosToLineCol(13, cst.lineOffsets)).toMatchObject({
+      line: undefined,
+      col: undefined
+    })
+    expect(charPosToLineCol(Math.MAXINT, cst.lineOffsets)).toMatchObject({
+      line: undefined,
+      col: undefined
     })
   })
 })

--- a/src/cst/parse.js
+++ b/src/cst/parse.js
@@ -3,14 +3,22 @@
 import Document from './Document'
 import ParseContext from './ParseContext'
 
-export default function parse(src) {
+export default function parse(src, options) {
+  const defaultOptions = { computeLineOffsets: false }
+  options = Object.assign({}, defaultOptions, options)
   const cr = []
+  const lf = [0]
   if (src.indexOf('\r') !== -1) {
     src = src.replace(/\r\n?/g, (match, offset) => {
       if (match.length > 1) cr.push(offset)
       return '\n'
     })
   }
+  if (options.computeLineOffsets)
+    src = src.replace(/\n/g, (match, offset) => {
+      lf.push(offset + 1)
+      return '\n'
+    })
   const context = new ParseContext({ src })
   const documents = []
   let offset = 0
@@ -30,5 +38,25 @@ export default function parse(src) {
     return true
   }
   documents.toString = () => documents.join('...\n')
+  if (options.computeLineOffsets) documents.lineOffsets = lf
   return documents
+}
+
+export function charPosToLineCol(offset, lineOffsets) {
+  if (
+    !lineOffsets ||
+    typeof offset === 'undefined' ||
+    offset < 0 ||
+    offset > lineOffsets[lineOffsets.length - 1]
+  )
+    return { line: undefined, col: undefined }
+  const lineIndex = lineOffsets.indexOf(offset)
+  if (lineIndex >= 0)
+    return { line: lineIndex, col: offset - lineOffsets[lineIndex] }
+  for (let i = 0; i < lineOffsets.length; i++) {
+    if (lineOffsets[i] > offset) {
+      return { line: i - 1, col: offset - lineOffsets[i - 1] }
+    }
+  }
+  return { line: undefined, col: undefined }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,8 @@ const defaultOptions = {
   keepBlobsInJSON: true,
   mapAsMap: false,
   tags: null,
-  version: '1.2'
+  version: '1.2',
+  computeLineOffsets: false
 }
 
 function createNode(value, wrapScalars = true, tag) {
@@ -34,12 +35,17 @@ class Document extends YAMLDocument {
 }
 
 function parseAllDocuments(src, options) {
-  return parseCST(src).map(cstDoc => new Document(options).parse(cstDoc))
+  return parseCST(src, {
+    computeLineOffsets: options ? options.computeLineOffsets : false
+  }).map(cstDoc => new Document(options).parse(cstDoc))
 }
 
 function parseDocument(src, options) {
-  const cst = parseCST(src)
+  const cst = parseCST(src, {
+    computeLineOffsets: options ? options.computeLineOffsets : false
+  })
   const doc = new Document(options).parse(cst[0])
+  if (options && options.computeLineOffsets) doc.lineOffsets = cst.lineOffsets
   if (cst.length > 1) {
     const errMsg =
       'Source contains multiple documents; please use YAML.parseAllDocuments()'


### PR DESCRIPTION
As discussed in #67 this PR adds the optional ability to compute line offsets and provides a helper function `charPosToLineCol`.

Both the AST and CST parse(Document) functions can now accept a `computeLineOffsets` option. Tests added to ensure default behaviour is unchanged and for the new functionality.

`README.md` has been minimally updated, but not yet the docs. I'd appreciate some guidance on doing that.