### PR TITLE
travis; test on Node.js LTS version also

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - 'node'
+  - "lts/*"
   - '6'
 
 script:


### PR DESCRIPTION
in addiion to 'current' and 6.x. Currently this means Node.js 10.x (10.15.0 at time of writing) will be tested as well as the current (Node.js 11) and Node.js 6 (presumably the baseline for this project).