### PR TITLE
Add collection accessor methods: add/delete/get/has/set

### DIFF
--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -168,169 +168,6 @@ describe('Seq', () => {
   })
 })
 
-describe('Collection', () => {
-  let map
-  beforeEach(() => {
-    map = YAML.createNode({ a: 1, b: [2, 3] })
-  })
-
-  test('deleteIn', () => {
-    expect(map.deleteIn(['a'])).toBe(true)
-    expect(map.get('a')).toBeUndefined()
-    expect(map.deleteIn(['b', 1])).toBe(true)
-    expect(map.getIn(['b', 1])).toBeUndefined()
-    expect(map.deleteIn([1])).toBe(false)
-    expect(map.deleteIn(['b', 2])).toBe(false)
-    expect(() => map.deleteIn(['a', 'e'])).toThrow(/Expected/)
-    expect(map.items).toHaveLength(1)
-    expect(map.get('b').items).toHaveLength(1)
-  })
-
-  test('getIn', () => {
-    expect(map.getIn(['a'])).toBe(1)
-    expect(map.getIn(['a'], true)).toMatchObject({ value: 1 })
-    expect(map.getIn(['b', 1])).toBe(3)
-    expect(map.getIn(['b', '1'])).toBe(3)
-    expect(map.getIn(['b', 1], true)).toMatchObject({ value: 3 })
-    expect(map.getIn(['b', 2])).toBeUndefined()
-    expect(map.getIn(['c', 'e'])).toBeUndefined()
-    expect(map.getIn(['a', 'e'])).toBeUndefined()
-  })
-
-  test('hasIn', () => {
-    expect(map.hasIn(['a'])).toBe(true)
-    expect(map.hasIn(['b', 1])).toBe(true)
-    expect(map.hasIn(['b', '1'])).toBe(true)
-    expect(map.hasIn(['b', 2])).toBe(false)
-    expect(map.hasIn(['c', 'e'])).toBe(false)
-    expect(map.hasIn(['a', 'e'])).toBe(false)
-  })
-
-  test('setIn', () => {
-    map.setIn(['a'], 2)
-    expect(map.get('a')).toBe(2)
-    expect(map.get('a', true)).toBe(2)
-    map.setIn(['b', 1], 5)
-    expect(map.getIn(['b', 1])).toBe(5)
-    map.setIn([1], 6)
-    expect(map.get(1)).toBe(6)
-    map.setIn(['b', 2], 6)
-    expect(map.getIn(['b', 2])).toBe(6)
-    expect(() => map.setIn(['a', 'e'])).toThrow(/Cannot create/)
-    expect(() => map.setIn(['e', 'e'])).toThrow(/Cannot create/)
-    expect(map.items).toHaveLength(3)
-    expect(map.get('b').items).toHaveLength(3)
-  })
-})
-
-describe('Document', () => {
-  let doc
-  beforeEach(() => {
-    doc = new YAML.Document()
-    doc.contents = YAML.createNode({ a: 1, b: [2, 3] })
-    expect(doc.contents.items).toMatchObject([
-      { key: { value: 'a' }, value: { value: 1 } },
-      {
-        key: { value: 'b' },
-        value: { items: [{ value: 2 }, { value: 3 }] }
-      }
-    ])
-  })
-
-  test('delete', () => {
-    expect(doc.delete('a')).toBe(true)
-    expect(doc.delete('a')).toBe(false)
-    expect(doc.get('a')).toBeUndefined()
-    expect(doc.contents.items).toHaveLength(1)
-
-    doc.contents = YAML.createNode('s')
-    expect(() => doc.set('a', 1)).toThrow(/document contents/)
-  })
-
-  test('deleteIn', () => {
-    expect(doc.deleteIn(['a'])).toBe(true)
-    expect(doc.get('a')).toBeUndefined()
-    expect(doc.deleteIn(['b', 1])).toBe(true)
-    expect(doc.getIn(['b', 1])).toBeUndefined()
-    expect(doc.deleteIn([1])).toBe(false)
-    expect(doc.deleteIn(['b', 2])).toBe(false)
-    expect(() => doc.deleteIn(['a', 'e'])).toThrow(/Expected/)
-    expect(doc.contents.items).toHaveLength(1)
-    expect(doc.get('b').items).toHaveLength(1)
-  })
-
-  test('get', () => {
-    expect(doc.get('a')).toBe(1)
-    expect(doc.get('a', true)).toMatchObject({ value: 1 })
-    expect(doc.get('c')).toBeUndefined()
-
-    doc.contents = YAML.createNode('s')
-    expect(doc.get('a')).toBeUndefined()
-  })
-
-  test('getIn collection', () => {
-    expect(doc.getIn(['a'])).toBe(1)
-    expect(doc.getIn(['a'], true)).toMatchObject({ value: 1 })
-    expect(doc.getIn(['b', 1])).toBe(3)
-    expect(doc.getIn(['b', 1], true)).toMatchObject({ value: 3 })
-    expect(doc.getIn(['b', 'e'])).toBeUndefined()
-    expect(doc.getIn(['c', 'e'])).toBeUndefined()
-    expect(doc.getIn(['a', 'e'])).toBeUndefined()
-  })
-
-  test('getIn scalar', () => {
-    doc.contents = YAML.createNode('s')
-    expect(doc.getIn([])).toBe('s')
-    expect(doc.getIn(null, true)).toMatchObject({ value: 's' })
-    expect(doc.getIn([0])).toBeUndefined()
-  })
-
-  test('has', () => {
-    expect(doc.has('a')).toBe(true)
-    expect(doc.has('c')).toBe(false)
-
-    doc.contents = YAML.createNode('s')
-    expect(doc.has('a')).toBe(false)
-  })
-
-  test('hasIn', () => {
-    expect(doc.hasIn(['a'])).toBe(true)
-    expect(doc.hasIn(['b', 1])).toBe(true)
-    expect(doc.hasIn(['b', 'e'])).toBe(false)
-    expect(doc.hasIn(['c', 'e'])).toBe(false)
-    expect(doc.hasIn(['a', 'e'])).toBe(false)
-  })
-
-  test('set', () => {
-    doc.set('a', 2)
-    expect(doc.get('a')).toBe(2)
-    expect(doc.get('a', true)).toBe(2)
-    doc.set('c', 6)
-    expect(doc.get('c')).toBe(6)
-    expect(doc.contents.items).toHaveLength(3)
-
-    doc.contents = YAML.createNode('s')
-    expect(() => doc.set('a', 1)).toThrow(/document contents/)
-  })
-
-  test('setIn', () => {
-    doc.setIn(['a'], 2)
-    expect(doc.getIn(['a'])).toBe(2)
-    expect(doc.getIn(['a'], true)).toBe(2)
-    doc.setIn(['b', 1], 5)
-    expect(doc.getIn(['b', 1])).toBe(5)
-    doc.setIn(['c'], 6)
-    expect(doc.getIn(['c'])).toBe(6)
-    expect(() => doc.setIn(['a', 'e'])).toThrow(/Cannot create/)
-    expect(() => doc.setIn(['e', 'e'], 1)).toThrow(/Cannot create/)
-    expect(doc.contents.items).toHaveLength(3)
-    expect(doc.get('b').items).toHaveLength(2)
-
-    doc.contents = YAML.createNode('s')
-    expect(() => doc.setIn(['a'], 1)).toThrow(/document contents/)
-  })
-})
-
 describe('Set', () => {
   let doc
   beforeAll(() => {
@@ -448,5 +285,168 @@ describe('OMap', () => {
     omap.set('c', 6)
     expect(omap.get('c')).toBe(6)
     expect(omap.items).toHaveLength(3)
+  })
+})
+
+describe('Collection', () => {
+  let map
+  beforeEach(() => {
+    map = YAML.createNode({ a: 1, b: [2, 3] })
+  })
+
+  test('deleteIn', () => {
+    expect(map.deleteIn(['a'])).toBe(true)
+    expect(map.get('a')).toBeUndefined()
+    expect(map.deleteIn(['b', 1])).toBe(true)
+    expect(map.getIn(['b', 1])).toBeUndefined()
+    expect(map.deleteIn([1])).toBe(false)
+    expect(map.deleteIn(['b', 2])).toBe(false)
+    expect(() => map.deleteIn(['a', 'e'])).toThrow(/Expected YAML collection/)
+    expect(map.items).toHaveLength(1)
+    expect(map.get('b').items).toHaveLength(1)
+  })
+
+  test('getIn', () => {
+    expect(map.getIn(['a'])).toBe(1)
+    expect(map.getIn(['a'], true)).toMatchObject({ value: 1 })
+    expect(map.getIn(['b', 1])).toBe(3)
+    expect(map.getIn(['b', '1'])).toBe(3)
+    expect(map.getIn(['b', 1], true)).toMatchObject({ value: 3 })
+    expect(map.getIn(['b', 2])).toBeUndefined()
+    expect(map.getIn(['c', 'e'])).toBeUndefined()
+    expect(map.getIn(['a', 'e'])).toBeUndefined()
+  })
+
+  test('hasIn', () => {
+    expect(map.hasIn(['a'])).toBe(true)
+    expect(map.hasIn(['b', 1])).toBe(true)
+    expect(map.hasIn(['b', '1'])).toBe(true)
+    expect(map.hasIn(['b', 2])).toBe(false)
+    expect(map.hasIn(['c', 'e'])).toBe(false)
+    expect(map.hasIn(['a', 'e'])).toBe(false)
+  })
+
+  test('setIn', () => {
+    map.setIn(['a'], 2)
+    expect(map.get('a')).toBe(2)
+    expect(map.get('a', true)).toBe(2)
+    map.setIn(['b', 1], 5)
+    expect(map.getIn(['b', 1])).toBe(5)
+    map.setIn([1], 6)
+    expect(map.get(1)).toBe(6)
+    map.setIn(['b', 2], 6)
+    expect(map.getIn(['b', 2])).toBe(6)
+    expect(() => map.setIn(['a', 'e'])).toThrow(/Expected YAML collection/)
+    expect(() => map.setIn(['e', 'e'])).toThrow(/Expected YAML collection/)
+    expect(map.items).toHaveLength(3)
+    expect(map.get('b').items).toHaveLength(3)
+  })
+})
+
+describe('Document', () => {
+  let doc
+  beforeEach(() => {
+    doc = new YAML.Document()
+    doc.contents = YAML.createNode({ a: 1, b: [2, 3] })
+    expect(doc.contents.items).toMatchObject([
+      { key: { value: 'a' }, value: { value: 1 } },
+      {
+        key: { value: 'b' },
+        value: { items: [{ value: 2 }, { value: 3 }] }
+      }
+    ])
+  })
+
+  test('delete', () => {
+    expect(doc.delete('a')).toBe(true)
+    expect(doc.delete('a')).toBe(false)
+    expect(doc.get('a')).toBeUndefined()
+    expect(doc.contents.items).toHaveLength(1)
+
+    doc.contents = YAML.createNode('s')
+    expect(() => doc.set('a', 1)).toThrow(/document contents/)
+  })
+
+  test('deleteIn', () => {
+    expect(doc.deleteIn(['a'])).toBe(true)
+    expect(doc.get('a')).toBeUndefined()
+    expect(doc.deleteIn(['b', 1])).toBe(true)
+    expect(doc.getIn(['b', 1])).toBeUndefined()
+    expect(doc.deleteIn([1])).toBe(false)
+    expect(doc.deleteIn(['b', 2])).toBe(false)
+    expect(() => doc.deleteIn(['a', 'e'])).toThrow(/Expected/)
+    expect(doc.contents.items).toHaveLength(1)
+    expect(doc.get('b').items).toHaveLength(1)
+  })
+
+  test('get', () => {
+    expect(doc.get('a')).toBe(1)
+    expect(doc.get('a', true)).toMatchObject({ value: 1 })
+    expect(doc.get('c')).toBeUndefined()
+
+    doc.contents = YAML.createNode('s')
+    expect(doc.get('a')).toBeUndefined()
+  })
+
+  test('getIn collection', () => {
+    expect(doc.getIn(['a'])).toBe(1)
+    expect(doc.getIn(['a'], true)).toMatchObject({ value: 1 })
+    expect(doc.getIn(['b', 1])).toBe(3)
+    expect(doc.getIn(['b', 1], true)).toMatchObject({ value: 3 })
+    expect(doc.getIn(['b', 'e'])).toBeUndefined()
+    expect(doc.getIn(['c', 'e'])).toBeUndefined()
+    expect(doc.getIn(['a', 'e'])).toBeUndefined()
+  })
+
+  test('getIn scalar', () => {
+    doc.contents = YAML.createNode('s')
+    expect(doc.getIn([])).toBe('s')
+    expect(doc.getIn(null, true)).toMatchObject({ value: 's' })
+    expect(doc.getIn([0])).toBeUndefined()
+  })
+
+  test('has', () => {
+    expect(doc.has('a')).toBe(true)
+    expect(doc.has('c')).toBe(false)
+
+    doc.contents = YAML.createNode('s')
+    expect(doc.has('a')).toBe(false)
+  })
+
+  test('hasIn', () => {
+    expect(doc.hasIn(['a'])).toBe(true)
+    expect(doc.hasIn(['b', 1])).toBe(true)
+    expect(doc.hasIn(['b', 'e'])).toBe(false)
+    expect(doc.hasIn(['c', 'e'])).toBe(false)
+    expect(doc.hasIn(['a', 'e'])).toBe(false)
+  })
+
+  test('set', () => {
+    doc.set('a', 2)
+    expect(doc.get('a')).toBe(2)
+    expect(doc.get('a', true)).toBe(2)
+    doc.set('c', 6)
+    expect(doc.get('c')).toBe(6)
+    expect(doc.contents.items).toHaveLength(3)
+
+    doc.contents = YAML.createNode('s')
+    expect(() => doc.set('a', 1)).toThrow(/document contents/)
+  })
+
+  test('setIn', () => {
+    doc.setIn(['a'], 2)
+    expect(doc.getIn(['a'])).toBe(2)
+    expect(doc.getIn(['a'], true)).toBe(2)
+    doc.setIn(['b', 1], 5)
+    expect(doc.getIn(['b', 1])).toBe(5)
+    doc.setIn(['c'], 6)
+    expect(doc.getIn(['c'])).toBe(6)
+    expect(() => doc.setIn(['a', 'e'])).toThrow(/Expected YAML collection/)
+    expect(() => doc.setIn(['e', 'e'], 1)).toThrow(/Expected YAML collection/)
+    expect(doc.contents.items).toHaveLength(3)
+    expect(doc.get('b').items).toHaveLength(2)
+
+    doc.contents = YAML.createNode('s')
+    expect(() => doc.setIn(['a'], 1)).toThrow(/document contents/)
   })
 })

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -158,6 +158,18 @@ describe('Collection', () => {
     map = YAML.createNode({ a: 1, b: [2, 3] })
   })
 
+  test('deleteIn', () => {
+    expect(map.deleteIn(['a'])).toBe(true)
+    expect(map.get('a')).toBeUndefined()
+    expect(map.deleteIn(['b', 1])).toBe(true)
+    expect(map.getIn(['b', 1])).toBeUndefined()
+    expect(map.deleteIn([1])).toBe(false)
+    expect(map.deleteIn(['b', 2])).toBe(false)
+    expect(() => map.deleteIn(['a', 'e'])).toThrow(/Expected/)
+    expect(map.items).toHaveLength(1)
+    expect(map.get('b').items).toHaveLength(1)
+  })
+
   test('getIn', () => {
     expect(map.getIn(['a'])).toBe(1)
     expect(map.getIn(['a'], true)).toMatchObject({ value: 1 })
@@ -207,6 +219,28 @@ describe('Document', () => {
         value: { items: [{ value: 2 }, { value: 3 }] }
       }
     ])
+  })
+
+  test('delete', () => {
+    expect(doc.delete('a')).toBe(true)
+    expect(doc.delete('a')).toBe(false)
+    expect(doc.get('a')).toBeUndefined()
+    expect(doc.contents.items).toHaveLength(1)
+
+    doc.contents = YAML.createNode('s')
+    expect(() => doc.set('a', 1)).toThrow(/document contents/)
+  })
+
+  test('deleteIn', () => {
+    expect(doc.deleteIn(['a'])).toBe(true)
+    expect(doc.get('a')).toBeUndefined()
+    expect(doc.deleteIn(['b', 1])).toBe(true)
+    expect(doc.getIn(['b', 1])).toBeUndefined()
+    expect(doc.deleteIn([1])).toBe(false)
+    expect(doc.deleteIn(['b', 2])).toBe(false)
+    expect(() => doc.deleteIn(['a', 'e'])).toThrow(/Expected/)
+    expect(doc.contents.items).toHaveLength(1)
+    expect(doc.get('b').items).toHaveLength(1)
   })
 
   test('get', () => {
@@ -260,7 +294,7 @@ describe('Document', () => {
     expect(doc.contents.items).toHaveLength(3)
 
     doc.contents = YAML.createNode('s')
-    expect(() => doc.set('a', 1)).toThrow(/Document contents/)
+    expect(() => doc.set('a', 1)).toThrow(/document contents/)
   })
 
   test('setIn', () => {
@@ -277,7 +311,7 @@ describe('Document', () => {
     expect(doc.get('b').items).toHaveLength(2)
 
     doc.contents = YAML.createNode('s')
-    expect(() => doc.setIn(['a'], 1)).toThrow(/Document contents/)
+    expect(() => doc.setIn(['a'], 1)).toThrow(/document contents/)
   })
 })
 

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -113,54 +113,43 @@ describe('Seq', () => {
 })
 
 describe('Collection', () => {
-  let map, seq
+  let map
   beforeEach(() => {
-    map = YAML.createNode({ a: 1, b: { c: 3, d: 4 } })
-    seq = YAML.createNode([1, [2, 3]])
+    map = YAML.createNode({ a: 1, b: [2, 3] })
   })
 
-  test('getIn map', () => {
+  test('getIn', () => {
     expect(map.getIn(['a'])).toBe(1)
     expect(map.getIn(['a'], true)).toMatchObject({ value: 1 })
-    expect(map.getIn(['b', 'c'])).toBe(3)
-    expect(map.getIn(['b', 'c'], true)).toMatchObject({ value: 3 })
-    expect(map.getIn(['b', 'e'])).toBeUndefined()
+    expect(map.getIn(['b', 1])).toBe(3)
+    expect(map.getIn(['b', '1'])).toBe(3)
+    expect(map.getIn(['b', 1], true)).toMatchObject({ value: 3 })
+    expect(map.getIn(['b', 2])).toBeUndefined()
     expect(map.getIn(['c', 'e'])).toBeUndefined()
     expect(() => map.getIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
   })
 
-  test('getIn seq', () => {
-    expect(seq.getIn([0])).toBe(1)
-    expect(seq.getIn([0], true)).toMatchObject({ value: 1 })
-    expect(seq.getIn([1, 1])).toBe(3)
-    expect(seq.getIn([1, 1], true)).toMatchObject({ value: 3 })
-    expect(seq.getIn([1, 2])).toBeUndefined()
-    expect(seq.getIn([2, 2])).toBeUndefined()
-    expect(() => seq.getIn([0, 1])).toThrow(/Expected a YAML collection/)
+  test('hasIn', () => {
+    expect(map.hasIn(['a'])).toBe(true)
+    expect(map.hasIn(['b', 1])).toBe(true)
+    expect(map.hasIn(['b', '1'])).toBe(true)
+    expect(map.hasIn(['b', 2])).toBe(false)
+    expect(map.hasIn(['c', 'e'])).toBe(false)
+    expect(() => map.hasIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
   })
 
-  test('setIn map', () => {
+  test('setIn', () => {
     map.setIn(['a'], 2)
     expect(map.get('a')).toBe(2)
     expect(map.get('a', true)).toBe(2)
-    map.setIn(['b', 'c'], 5)
-    expect(map.getIn(['b', 'c'])).toBe(5)
-    map.setIn(['c'], 6)
-    expect(map.get('c')).toBe(6)
+    map.setIn(['b', 1], 5)
+    expect(map.getIn(['b', 1])).toBe(5)
+    map.setIn([1], 6)
+    expect(map.get(1)).toBe(6)
+    map.setIn(['b', 2], 6)
+    expect(map.getIn(['b', 2])).toBe(6)
     expect(() => map.setIn(['a', 'e'])).toThrow(/Cannot create/)
     expect(() => map.setIn(['e', 'e'])).toThrow(/Cannot create/)
-  })
-
-  test('setIn seq', () => {
-    seq.setIn([0], 2)
-    expect(seq.get(0)).toBe(2)
-    expect(seq.get(0, true)).toBe(2)
-    seq.setIn([1, 1], 5)
-    expect(seq.getIn([1, 1])).toBe(5)
-    seq.setIn([2], 6)
-    expect(seq.get(2)).toBe(6)
-    expect(() => seq.setIn([0, 1])).toThrow(/Cannot create/)
-    expect(() => seq.setIn([3, 3])).toThrow(/Cannot create/)
   })
 })
 
@@ -193,6 +182,14 @@ describe('Document', () => {
     expect(doc.getIn([])).toBe('s')
     expect(doc.getIn(null, true)).toMatchObject({ value: 's' })
     expect(() => doc.getIn([0])).toThrow(/Document contents/)
+  })
+
+  test('hasIn', () => {
+    expect(doc.hasIn(['a'])).toBe(true)
+    expect(doc.hasIn(['b', 1])).toBe(true)
+    expect(doc.hasIn(['b', 'e'])).toBe(false)
+    expect(doc.hasIn(['c', 'e'])).toBe(false)
+    expect(() => doc.hasIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
   })
 
   test('setIn', () => {

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -187,6 +187,14 @@ describe('Document', () => {
     ])
   })
 
+  test('get', () => {
+    expect(doc.get('a')).toBe(1)
+    expect(doc.get('a', true)).toMatchObject({ value: 1 })
+    expect(doc.get('c')).toBeUndefined()
+    doc.contents = YAML.createNode('s')
+    expect(doc.get('a')).toBeUndefined()
+  })
+
   test('getIn collection', () => {
     expect(doc.getIn(['a'])).toBe(1)
     expect(doc.getIn(['a'], true)).toMatchObject({ value: 1 })
@@ -204,12 +212,29 @@ describe('Document', () => {
     expect(doc.getIn([0])).toBeUndefined()
   })
 
+  test('has', () => {
+    expect(doc.has('a')).toBe(true)
+    expect(doc.has('c')).toBe(false)
+    doc.contents = YAML.createNode('s')
+    expect(doc.has('a')).toBe(false)
+  })
+
   test('hasIn', () => {
     expect(doc.hasIn(['a'])).toBe(true)
     expect(doc.hasIn(['b', 1])).toBe(true)
     expect(doc.hasIn(['b', 'e'])).toBe(false)
     expect(doc.hasIn(['c', 'e'])).toBe(false)
     expect(doc.hasIn(['a', 'e'])).toBe(false)
+  })
+
+  test('set', () => {
+    doc.set('a', 2)
+    expect(doc.get('a')).toBe(2)
+    expect(doc.get('a', true)).toBe(2)
+    doc.set('c', 6)
+    expect(doc.get('c')).toBe(6)
+    doc.contents = YAML.createNode('s')
+    expect(() => doc.set('a', 1)).toThrow(/Document contents/)
   })
 
   test('setIn', () => {
@@ -221,7 +246,9 @@ describe('Document', () => {
     doc.setIn(['c'], 6)
     expect(doc.getIn(['c'])).toBe(6)
     expect(() => doc.setIn(['a', 'e'])).toThrow(/Cannot create/)
-    expect(() => doc.setIn(['e', 'e'])).toThrow(/Cannot create/)
+    expect(() => doc.setIn(['e', 'e'], 1)).toThrow(/Cannot create/)
+    doc.contents = YAML.createNode('s')
+    expect(() => doc.setIn(['a'], 1)).toThrow(/Document contents/)
   })
 })
 

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -124,6 +124,50 @@ describe('Seq', () => {
   })
 })
 
+describe('Document', () => {
+  let doc
+  beforeEach(() => {
+    doc = new YAML.Document()
+    doc.contents = YAML.createNode({ a: 1, b: [2, 3] })
+    expect(doc.contents.items).toMatchObject([
+      { key: { value: 'a' }, value: { value: 1 } },
+      {
+        key: { value: 'b' },
+        value: { items: [{ value: 2 }, { value: 3 }] }
+      }
+    ])
+  })
+
+  test('getIn collection', () => {
+    expect(doc.getIn(['a'])).toBe(1)
+    expect(doc.getIn(['a'], true)).toMatchObject({ value: 1 })
+    expect(doc.getIn(['b', 1])).toBe(3)
+    expect(doc.getIn(['b', 1], true)).toMatchObject({ value: 3 })
+    expect(doc.getIn(['b', 'e'])).toBeUndefined()
+    expect(doc.getIn(['c', 'e'])).toBeUndefined()
+    expect(() => doc.getIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
+  })
+
+  test('getIn scalar', () => {
+    doc.contents = YAML.createNode('s')
+    expect(doc.getIn([])).toBe('s')
+    expect(doc.getIn(null, true)).toMatchObject({ value: 's' })
+    expect(() => doc.getIn([0])).toThrow(/Document contents/)
+  })
+
+  test('setIn', () => {
+    doc.setIn(['a'], 2)
+    expect(doc.getIn(['a'])).toBe(2)
+    expect(doc.getIn(['a'], true)).toBe(2)
+    doc.setIn(['b', 1], 5)
+    expect(doc.getIn(['b', 1])).toBe(5)
+    doc.setIn(['c'], 6)
+    expect(doc.getIn(['c'])).toBe(6)
+    expect(() => doc.setIn(['a', 'e'])).toThrow(/Cannot create/)
+    expect(() => doc.setIn(['e', 'e'])).toThrow(/Cannot create/)
+  })
+})
+
 describe('Set', () => {
   let doc
   beforeAll(() => {

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -1,4 +1,5 @@
 import YAML from '../src/index'
+import Pair from '../src/schema/Pair'
 
 describe('Map', () => {
   let map
@@ -16,6 +17,14 @@ describe('Map', () => {
         }
       }
     ])
+  })
+
+  test('add', () => {
+    map.add(new Pair('c', 'x'))
+    expect(map.get('c')).toBe('x')
+    expect(() => map.add('a')).toThrow(/Expected a pair/)
+    expect(() => map.add(new Pair('c', 'y'))).toThrow(/already set/)
+    expect(map.items).toHaveLength(3)
   })
 
   test('delete', () => {
@@ -86,6 +95,13 @@ describe('Seq', () => {
       { value: 1 },
       { items: [{ value: 2 }, { value: 3 }] }
     ])
+  })
+
+  test('add', () => {
+    seq.add('x')
+    expect(seq.get(2)).toBe('x')
+    seq.add(1)
+    expect(seq.items).toHaveLength(4)
   })
 
   test('delete', () => {
@@ -332,6 +348,17 @@ describe('Set', () => {
     ])
   })
 
+  test('add', () => {
+    set.add('x')
+    expect(set.get('x')).toBe('x')
+    set.add('x')
+    const y0 = new Pair('y')
+    set.add(y0)
+    set.add(new Pair('y'))
+    expect(set.get('y', true)).toBe(y0)
+    expect(set.items).toHaveLength(5)
+  })
+
   test('get', () => {
     expect(set.get(1)).toBe(1)
     expect(set.get(1, true)).toMatchObject({ key: { value: 1 }, value: null })
@@ -379,6 +406,14 @@ describe('OMap', () => {
         }
       }
     ])
+  })
+
+  test('add', () => {
+    omap.add(new Pair('c', 'x'))
+    expect(omap.get('c')).toBe('x')
+    expect(() => omap.add('a')).toThrow(/Expected a pair/)
+    expect(() => omap.add(new Pair('c', 'y'))).toThrow(/already set/)
+    expect(omap.items).toHaveLength(3)
   })
 
   test('delete', () => {

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -20,9 +20,9 @@ describe('Map', () => {
   })
 
   test('add', () => {
-    map.add(new Pair('c', 'x'))
+    map.add({ key: 'c', value: 'x' })
     expect(map.get('c')).toBe('x')
-    expect(() => map.add('a')).toThrow(/Expected a pair/)
+    expect(() => map.add('a')).toThrow(/already set/)
     expect(() => map.add(new Pair('c', 'y'))).toThrow(/already set/)
     expect(map.items).toHaveLength(3)
   })
@@ -246,9 +246,9 @@ describe('OMap', () => {
   })
 
   test('add', () => {
-    omap.add(new Pair('c', 'x'))
+    omap.add({ key: 'c', value: 'x' })
     expect(omap.get('c')).toBe('x')
-    expect(() => omap.add('a')).toThrow(/Expected a pair/)
+    expect(() => omap.add('a')).toThrow(/already set/)
     expect(() => omap.add(new Pair('c', 'y'))).toThrow(/already set/)
     expect(omap.items).toHaveLength(3)
   })
@@ -369,9 +369,9 @@ describe('Document', () => {
   })
 
   test('add', () => {
-    doc.add(new Pair('c', 'x'))
+    doc.add({ key: 'c', value: 'x' })
     expect(doc.get('c')).toBe('x')
-    expect(() => doc.add('a')).toThrow(/Expected a pair/)
+    expect(() => doc.add('a')).toThrow(/already set/)
     expect(() => doc.add(new Pair('c', 'y'))).toThrow(/already set/)
     expect(doc.contents.items).toHaveLength(3)
   })

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -32,14 +32,19 @@ describe('Map', () => {
     expect(map.get(YAML.createNode('c'))).toBeUndefined()
   })
 
-  test('getIn', () => {
-    expect(map.getIn(['a'])).toBe(1)
-    expect(map.getIn(['a'], true)).toMatchObject({ value: 1 })
-    expect(map.getIn(['b', 'c'])).toBe(3)
-    expect(map.getIn(['b', 'c'], true)).toMatchObject({ value: 3 })
-    expect(map.getIn(['b', 'e'])).toBeUndefined()
-    expect(map.getIn(['c', 'e'])).toBeUndefined()
-    expect(() => map.getIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
+  test('has with value', () => {
+    expect(map.has('a')).toBe(true)
+    expect(map.has('b')).toBe(true)
+    expect(map.has('c')).toBe(false)
+    expect(map.has('')).toBe(false)
+    expect(map.has()).toBe(false)
+  })
+
+  test('has with node', () => {
+    expect(map.has(YAML.createNode('a'))).toBe(true)
+    expect(map.has(YAML.createNode('b'))).toBe(true)
+    expect(map.has(YAML.createNode('c'))).toBe(false)
+    expect(map.has(YAML.createNode())).toBe(false)
   })
 
   test('set', () => {
@@ -50,18 +55,6 @@ describe('Map', () => {
     expect(map.get('b')).toBe(5)
     map.set('c', 6)
     expect(map.get('c')).toBe(6)
-  })
-
-  test('setIn', () => {
-    map.setIn(['a'], 2)
-    expect(map.get('a')).toBe(2)
-    expect(map.get('a', true)).toBe(2)
-    map.setIn(['b', 'c'], 5)
-    expect(map.getIn(['b', 'c'])).toBe(5)
-    map.setIn(['c'], 6)
-    expect(map.get('c')).toBe(6)
-    expect(() => map.setIn(['a', 'e'])).toThrow(/Cannot create/)
-    expect(() => map.setIn(['e', 'e'])).toThrow(/Cannot create/)
   })
 })
 
@@ -91,14 +84,21 @@ describe('Seq', () => {
     expect(seq.get(YAML.createNode(2))).toBeUndefined()
   })
 
-  test('getIn', () => {
-    expect(seq.getIn([0])).toBe(1)
-    expect(seq.getIn([0], true)).toMatchObject({ value: 1 })
-    expect(seq.getIn([1, 1])).toBe(3)
-    expect(seq.getIn([1, 1], true)).toMatchObject({ value: 3 })
-    expect(seq.getIn([1, 2])).toBeUndefined()
-    expect(seq.getIn([2, 2])).toBeUndefined()
-    expect(() => seq.getIn([0, 1])).toThrow(/Expected a YAML collection/)
+  test('has with value', () => {
+    expect(seq.has(0)).toBe(true)
+    expect(seq.has(1)).toBe(true)
+    expect(seq.has(2)).toBe(false)
+    expect(seq.has('0')).toBe(true)
+    expect(seq.has('')).toBe(false)
+    expect(seq.has()).toBe(false)
+  })
+
+  test('has with node', () => {
+    expect(seq.has(YAML.createNode(0))).toBe(true)
+    expect(seq.has(YAML.createNode('0'))).toBe(true)
+    expect(seq.has(YAML.createNode(2))).toBe(false)
+    expect(seq.has(YAML.createNode(''))).toBe(false)
+    expect(seq.has(YAML.createNode())).toBe(false)
   })
 
   test('set', () => {
@@ -110,8 +110,48 @@ describe('Seq', () => {
     seq.set(2, 6)
     expect(seq.get(2)).toBe(6)
   })
+})
 
-  test('setIn', () => {
+describe('Collection', () => {
+  let map, seq
+  beforeEach(() => {
+    map = YAML.createNode({ a: 1, b: { c: 3, d: 4 } })
+    seq = YAML.createNode([1, [2, 3]])
+  })
+
+  test('getIn map', () => {
+    expect(map.getIn(['a'])).toBe(1)
+    expect(map.getIn(['a'], true)).toMatchObject({ value: 1 })
+    expect(map.getIn(['b', 'c'])).toBe(3)
+    expect(map.getIn(['b', 'c'], true)).toMatchObject({ value: 3 })
+    expect(map.getIn(['b', 'e'])).toBeUndefined()
+    expect(map.getIn(['c', 'e'])).toBeUndefined()
+    expect(() => map.getIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
+  })
+
+  test('getIn seq', () => {
+    expect(seq.getIn([0])).toBe(1)
+    expect(seq.getIn([0], true)).toMatchObject({ value: 1 })
+    expect(seq.getIn([1, 1])).toBe(3)
+    expect(seq.getIn([1, 1], true)).toMatchObject({ value: 3 })
+    expect(seq.getIn([1, 2])).toBeUndefined()
+    expect(seq.getIn([2, 2])).toBeUndefined()
+    expect(() => seq.getIn([0, 1])).toThrow(/Expected a YAML collection/)
+  })
+
+  test('setIn map', () => {
+    map.setIn(['a'], 2)
+    expect(map.get('a')).toBe(2)
+    expect(map.get('a', true)).toBe(2)
+    map.setIn(['b', 'c'], 5)
+    expect(map.getIn(['b', 'c'])).toBe(5)
+    map.setIn(['c'], 6)
+    expect(map.get('c')).toBe(6)
+    expect(() => map.setIn(['a', 'e'])).toThrow(/Cannot create/)
+    expect(() => map.setIn(['e', 'e'])).toThrow(/Cannot create/)
+  })
+
+  test('setIn seq', () => {
     seq.setIn([0], 2)
     expect(seq.get(0)).toBe(2)
     expect(seq.get(0, true)).toBe(2)
@@ -238,6 +278,14 @@ describe('OMap', () => {
     expect(omap.get('a', true)).toMatchObject({ value: 1 })
     expect(omap.get('b').toJSON()).toMatchObject({ c: 3, d: 4 })
     expect(omap.get('c')).toBeUndefined()
+  })
+
+  test('has', () => {
+    expect(omap.has('a')).toBe(true)
+    expect(omap.has('b')).toBe(true)
+    expect(omap.has('c')).toBe(false)
+    expect(omap.has('')).toBe(false)
+    expect(omap.has()).toBe(false)
   })
 
   test('set', () => {

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -146,7 +146,7 @@ describe('Collection', () => {
     expect(map.getIn(['b', 1], true)).toMatchObject({ value: 3 })
     expect(map.getIn(['b', 2])).toBeUndefined()
     expect(map.getIn(['c', 'e'])).toBeUndefined()
-    expect(() => map.getIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
+    expect(map.getIn(['a', 'e'])).toBeUndefined()
   })
 
   test('hasIn', () => {
@@ -155,7 +155,7 @@ describe('Collection', () => {
     expect(map.hasIn(['b', '1'])).toBe(true)
     expect(map.hasIn(['b', 2])).toBe(false)
     expect(map.hasIn(['c', 'e'])).toBe(false)
-    expect(() => map.hasIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
+    expect(map.hasIn(['a', 'e'])).toBe(false)
   })
 
   test('setIn', () => {
@@ -194,14 +194,14 @@ describe('Document', () => {
     expect(doc.getIn(['b', 1], true)).toMatchObject({ value: 3 })
     expect(doc.getIn(['b', 'e'])).toBeUndefined()
     expect(doc.getIn(['c', 'e'])).toBeUndefined()
-    expect(() => doc.getIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
+    expect(doc.getIn(['a', 'e'])).toBeUndefined()
   })
 
   test('getIn scalar', () => {
     doc.contents = YAML.createNode('s')
     expect(doc.getIn([])).toBe('s')
     expect(doc.getIn(null, true)).toMatchObject({ value: 's' })
-    expect(() => doc.getIn([0])).toThrow(/Document contents/)
+    expect(doc.getIn([0])).toBeUndefined()
   })
 
   test('hasIn', () => {
@@ -209,7 +209,7 @@ describe('Document', () => {
     expect(doc.hasIn(['b', 1])).toBe(true)
     expect(doc.hasIn(['b', 'e'])).toBe(false)
     expect(doc.hasIn(['c', 'e'])).toBe(false)
-    expect(() => doc.hasIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
+    expect(doc.hasIn(['a', 'e'])).toBe(false)
   })
 
   test('setIn', () => {

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -18,6 +18,13 @@ describe('Map', () => {
     ])
   })
 
+  test('delete', () => {
+    map.delete('a')
+    expect(map.get('a')).toBeUndefined()
+    map.delete('c')
+    expect(map.get('b')).toMatchObject({ items: [{}, {}] })
+  })
+
   test('get with value', () => {
     expect(map.get('a')).toBe(1)
     expect(map.get('a', true)).toMatchObject({ value: 1 })
@@ -76,6 +83,13 @@ describe('Seq', () => {
       { value: 1 },
       { items: [{ value: 2 }, { value: 3 }] }
     ])
+  })
+
+  test('delete', () => {
+    seq.delete(0)
+    seq.delete(2)
+    seq.delete('a')
+    expect(seq.get(0)).toMatchObject({ items: [{ value: 2 }, { value: 3 }] })
   })
 
   test('get with value', () => {
@@ -315,6 +329,13 @@ describe('OMap', () => {
         }
       }
     ])
+  })
+
+  test('delete', () => {
+    omap.delete('a')
+    expect(omap.get('a')).toBeUndefined()
+    omap.delete('c')
+    expect(omap.get('b')).toMatchObject({ items: [{}, {}] })
   })
 
   test('get', () => {

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -19,9 +19,9 @@ describe('Map', () => {
   })
 
   test('delete', () => {
-    map.delete('a')
+    expect(map.delete('a')).toBe(true)
     expect(map.get('a')).toBeUndefined()
-    map.delete('c')
+    expect(map.delete('c')).toBe(false)
     expect(map.get('b')).toMatchObject({ items: [{}, {}] })
     expect(map.items).toHaveLength(1)
   })
@@ -89,9 +89,9 @@ describe('Seq', () => {
   })
 
   test('delete', () => {
-    seq.delete(0)
-    seq.delete(2)
-    seq.delete('a')
+    expect(seq.delete(0)).toBe(true)
+    expect(seq.delete(2)).toBe(false)
+    expect(seq.delete('a')).toBe(false)
     expect(seq.get(0)).toMatchObject({ items: [{ value: 2 }, { value: 3 }] })
     expect(seq.items).toHaveLength(1)
   })
@@ -348,9 +348,9 @@ describe('OMap', () => {
   })
 
   test('delete', () => {
-    omap.delete('a')
+    expect(omap.delete('a')).toBe(true)
     expect(omap.get('a')).toBeUndefined()
-    omap.delete('c')
+    expect(omap.delete('c')).toBe(false)
     expect(omap.get('b')).toMatchObject({ items: [{}, {}] })
     expect(omap.items).toHaveLength(1)
   })

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -1,0 +1,208 @@
+import YAML from '../src/index'
+
+describe('Map', () => {
+  let map
+  beforeEach(() => {
+    map = YAML.createNode({ a: 1, b: { c: 3, d: 4 } })
+    expect(map.items).toMatchObject([
+      { key: { value: 'a' }, value: { value: 1 } },
+      {
+        key: { value: 'b' },
+        value: {
+          items: [
+            { key: { value: 'c' }, value: { value: 3 } },
+            { key: { value: 'd' }, value: { value: 4 } }
+          ]
+        }
+      }
+    ])
+  })
+
+  test('get with value', () => {
+    expect(map.get('a')).toBe(1)
+    expect(map.get('a', true)).toMatchObject({ value: 1 })
+    expect(map.get('b').toJSON()).toMatchObject({ c: 3, d: 4 })
+    expect(map.get('c')).toBeUndefined()
+  })
+
+  test('get with node', () => {
+    expect(map.get(YAML.createNode('a'))).toBe(1)
+    expect(map.get(YAML.createNode('a'), true)).toMatchObject({ value: 1 })
+    expect(map.get(YAML.createNode('b')).toJSON()).toMatchObject({ c: 3, d: 4 })
+    expect(map.get(YAML.createNode('c'))).toBeUndefined()
+  })
+
+  test('getIn', () => {
+    expect(map.getIn(['a'])).toBe(1)
+    expect(map.getIn(['a'], true)).toMatchObject({ value: 1 })
+    expect(map.getIn(['b', 'c'])).toBe(3)
+    expect(map.getIn(['b', 'c'], true)).toMatchObject({ value: 3 })
+    expect(map.getIn(['b', 'e'])).toBeUndefined()
+    expect(map.getIn(['c', 'e'])).toBeUndefined()
+    expect(() => map.getIn(['a', 'e'])).toThrow(/Expected a YAML collection/)
+  })
+
+  test('set', () => {
+    map.set('a', 2)
+    expect(map.get('a')).toBe(2)
+    expect(map.get('a', true)).toBe(2)
+    map.set('b', 5)
+    expect(map.get('b')).toBe(5)
+    map.set('c', 6)
+    expect(map.get('c')).toBe(6)
+  })
+
+  test('setIn', () => {
+    map.setIn(['a'], 2)
+    expect(map.get('a')).toBe(2)
+    expect(map.get('a', true)).toBe(2)
+    map.setIn(['b', 'c'], 5)
+    expect(map.getIn(['b', 'c'])).toBe(5)
+    map.setIn(['c'], 6)
+    expect(map.get('c')).toBe(6)
+    expect(() => map.setIn(['a', 'e'])).toThrow(/Cannot create/)
+    expect(() => map.setIn(['e', 'e'])).toThrow(/Cannot create/)
+  })
+})
+
+describe('Seq', () => {
+  let seq
+  beforeEach(() => {
+    seq = YAML.createNode([1, [2, 3]])
+    expect(seq.items).toMatchObject([
+      { value: 1 },
+      { items: [{ value: 2 }, { value: 3 }] }
+    ])
+  })
+
+  test('get with value', () => {
+    expect(seq.get(0)).toBe(1)
+    expect(seq.get('0')).toBe(1)
+    expect(seq.get(0, true)).toMatchObject({ value: 1 })
+    expect(seq.get(1).toJSON()).toMatchObject([2, 3])
+    expect(seq.get(2)).toBeUndefined()
+  })
+
+  test('get with node', () => {
+    expect(seq.get(YAML.createNode(0))).toBe(1)
+    expect(seq.get(YAML.createNode('0'))).toBe(1)
+    expect(seq.get(YAML.createNode(0), true)).toMatchObject({ value: 1 })
+    expect(seq.get(YAML.createNode(1)).toJSON()).toMatchObject([2, 3])
+    expect(seq.get(YAML.createNode(2))).toBeUndefined()
+  })
+
+  test('getIn', () => {
+    expect(seq.getIn([0])).toBe(1)
+    expect(seq.getIn([0], true)).toMatchObject({ value: 1 })
+    expect(seq.getIn([1, 1])).toBe(3)
+    expect(seq.getIn([1, 1], true)).toMatchObject({ value: 3 })
+    expect(seq.getIn([1, 2])).toBeUndefined()
+    expect(seq.getIn([2, 2])).toBeUndefined()
+    expect(() => seq.getIn([0, 1])).toThrow(/Expected a YAML collection/)
+  })
+
+  test('set', () => {
+    seq.set(0, 2)
+    expect(seq.get(0)).toBe(2)
+    expect(seq.get(0, true)).toBe(2)
+    seq.set(1, 5)
+    expect(seq.get(1)).toBe(5)
+    seq.set(2, 6)
+    expect(seq.get(2)).toBe(6)
+  })
+
+  test('setIn', () => {
+    seq.setIn([0], 2)
+    expect(seq.get(0)).toBe(2)
+    expect(seq.get(0, true)).toBe(2)
+    seq.setIn([1, 1], 5)
+    expect(seq.getIn([1, 1])).toBe(5)
+    seq.setIn([2], 6)
+    expect(seq.get(2)).toBe(6)
+    expect(() => seq.setIn([0, 1])).toThrow(/Cannot create/)
+    expect(() => seq.setIn([3, 3])).toThrow(/Cannot create/)
+  })
+})
+
+describe('Set', () => {
+  let doc
+  beforeAll(() => {
+    doc = new YAML.Document({ version: '1.1' })
+    doc.setSchema()
+  })
+
+  let set
+  beforeEach(() => {
+    set = doc.schema.createNode([1, 2, 3], true, '!!set')
+    expect(set.items).toMatchObject([
+      { key: { value: 1 }, value: null },
+      { key: { value: 2 }, value: null },
+      { key: { value: 3 }, value: null }
+    ])
+  })
+
+  test('get', () => {
+    expect(set.get(1)).toBe(1)
+    expect(set.get(1, true)).toMatchObject({ key: { value: 1 }, value: null })
+    expect(set.get(0)).toBeUndefined()
+    expect(set.get('1')).toBeUndefined()
+  })
+
+  test('set', () => {
+    set.set(1, true)
+    expect(set.get(1)).toBe(1)
+    set.set(1, false)
+    expect(set.get(1)).toBeUndefined()
+    set.set(4, false)
+    expect(set.get(4)).toBeUndefined()
+    set.set(4, true)
+    expect(set.get(4)).toBe(4)
+    expect(set.get(4, true)).toMatchObject({ key: 4, value: null })
+  })
+})
+
+describe('OMap', () => {
+  let doc
+  beforeAll(() => {
+    doc = new YAML.Document({ version: '1.1' })
+    doc.setSchema()
+  })
+
+  let omap
+  beforeEach(() => {
+    omap = doc.schema.createNode(
+      [{ a: 1 }, { b: { c: 3, d: 4 } }],
+      true,
+      '!!omap'
+    )
+    expect(omap.items).toMatchObject([
+      { key: { value: 'a' }, value: { value: 1 } },
+      {
+        key: { value: 'b' },
+        value: {
+          items: [
+            { key: { value: 'c' }, value: { value: 3 } },
+            { key: { value: 'd' }, value: { value: 4 } }
+          ]
+        }
+      }
+    ])
+  })
+
+  test('get', () => {
+    expect(omap.get('a')).toBe(1)
+    expect(omap.get('a', true)).toMatchObject({ value: 1 })
+    expect(omap.get('b').toJSON()).toMatchObject({ c: 3, d: 4 })
+    expect(omap.get('c')).toBeUndefined()
+  })
+
+  test('set', () => {
+    omap.set('a', 2)
+    expect(omap.get('a')).toBe(2)
+    expect(omap.get('a', true)).toBe(2)
+    omap.set('b', 5)
+    expect(omap.get('b')).toBe(5)
+    omap.set('c', 6)
+    expect(omap.get('c')).toBe(6)
+  })
+})

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -294,6 +294,17 @@ describe('Collection', () => {
     map = YAML.createNode({ a: 1, b: [2, 3] })
   })
 
+  test('addIn', () => {
+    map.addIn(['b'], 4)
+    expect(map.getIn(['b', 2])).toBe(4)
+    map.addIn([], new Pair('c', 5))
+    expect(map.get('c')).toBe(5)
+    expect(() => map.addIn(['a'])).toThrow(/Expected YAML collection/)
+    expect(() => map.addIn(['b', 3])).toThrow(/Expected YAML collection/)
+    expect(map.items).toHaveLength(3)
+    expect(map.get('b').items).toHaveLength(3)
+  })
+
   test('deleteIn', () => {
     expect(map.deleteIn(['a'])).toBe(true)
     expect(map.get('a')).toBeUndefined()
@@ -355,6 +366,25 @@ describe('Document', () => {
         value: { items: [{ value: 2 }, { value: 3 }] }
       }
     ])
+  })
+
+  test('add', () => {
+    doc.add(new Pair('c', 'x'))
+    expect(doc.get('c')).toBe('x')
+    expect(() => doc.add('a')).toThrow(/Expected a pair/)
+    expect(() => doc.add(new Pair('c', 'y'))).toThrow(/already set/)
+    expect(doc.contents.items).toHaveLength(3)
+  })
+
+  test('addIn', () => {
+    doc.addIn(['b'], 4)
+    expect(doc.getIn(['b', 2])).toBe(4)
+    doc.addIn([], new Pair('c', 5))
+    expect(doc.get('c')).toBe(5)
+    expect(() => doc.addIn(['a'])).toThrow(/Expected YAML collection/)
+    expect(() => doc.addIn(['b', 3])).toThrow(/Expected YAML collection/)
+    expect(doc.contents.items).toHaveLength(3)
+    expect(doc.get('b').items).toHaveLength(3)
   })
 
   test('delete', () => {

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -47,13 +47,23 @@ describe('Map', () => {
     expect(map.has(YAML.createNode())).toBe(false)
   })
 
-  test('set', () => {
+  test('set with value', () => {
     map.set('a', 2)
     expect(map.get('a')).toBe(2)
     expect(map.get('a', true)).toBe(2)
     map.set('b', 5)
     expect(map.get('b')).toBe(5)
     map.set('c', 6)
+    expect(map.get('c')).toBe(6)
+  })
+
+  test('set with node', () => {
+    map.set(YAML.createNode('a'), 2)
+    expect(map.get('a')).toBe(2)
+    expect(map.get('a', true)).toBe(2)
+    map.set(YAML.createNode('b'), 5)
+    expect(map.get('b')).toBe(5)
+    map.set(YAML.createNode('c'), 6)
     expect(map.get('c')).toBe(6)
   })
 })
@@ -101,13 +111,23 @@ describe('Seq', () => {
     expect(seq.has(YAML.createNode())).toBe(false)
   })
 
-  test('set', () => {
+  test('set with value', () => {
     seq.set(0, 2)
     expect(seq.get(0)).toBe(2)
     expect(seq.get(0, true)).toBe(2)
-    seq.set(1, 5)
+    seq.set('1', 5)
     expect(seq.get(1)).toBe(5)
     seq.set(2, 6)
+    expect(seq.get(2)).toBe(6)
+  })
+
+  test('set with node', () => {
+    seq.set(YAML.createNode(0), 2)
+    expect(seq.get(0)).toBe(2)
+    expect(seq.get(0, true)).toBe(2)
+    seq.set(YAML.createNode('1'), 5)
+    expect(seq.get(1)).toBe(5)
+    seq.set(YAML.createNode(2), 6)
     expect(seq.get(2)).toBe(6)
   })
 })

--- a/__tests__/collection-access.js
+++ b/__tests__/collection-access.js
@@ -23,6 +23,7 @@ describe('Map', () => {
     expect(map.get('a')).toBeUndefined()
     map.delete('c')
     expect(map.get('b')).toMatchObject({ items: [{}, {}] })
+    expect(map.items).toHaveLength(1)
   })
 
   test('get with value', () => {
@@ -62,6 +63,7 @@ describe('Map', () => {
     expect(map.get('b')).toBe(5)
     map.set('c', 6)
     expect(map.get('c')).toBe(6)
+    expect(map.items).toHaveLength(3)
   })
 
   test('set with node', () => {
@@ -72,6 +74,7 @@ describe('Map', () => {
     expect(map.get('b')).toBe(5)
     map.set(YAML.createNode('c'), 6)
     expect(map.get('c')).toBe(6)
+    expect(map.items).toHaveLength(3)
   })
 })
 
@@ -90,6 +93,7 @@ describe('Seq', () => {
     seq.delete(2)
     seq.delete('a')
     expect(seq.get(0)).toMatchObject({ items: [{ value: 2 }, { value: 3 }] })
+    expect(seq.items).toHaveLength(1)
   })
 
   test('get with value', () => {
@@ -133,6 +137,7 @@ describe('Seq', () => {
     expect(seq.get(1)).toBe(5)
     seq.set(2, 6)
     expect(seq.get(2)).toBe(6)
+    expect(seq.items).toHaveLength(3)
   })
 
   test('set with node', () => {
@@ -143,6 +148,7 @@ describe('Seq', () => {
     expect(seq.get(1)).toBe(5)
     seq.set(YAML.createNode(2), 6)
     expect(seq.get(2)).toBe(6)
+    expect(seq.items).toHaveLength(3)
   })
 })
 
@@ -184,6 +190,8 @@ describe('Collection', () => {
     expect(map.getIn(['b', 2])).toBe(6)
     expect(() => map.setIn(['a', 'e'])).toThrow(/Cannot create/)
     expect(() => map.setIn(['e', 'e'])).toThrow(/Cannot create/)
+    expect(map.items).toHaveLength(3)
+    expect(map.get('b').items).toHaveLength(3)
   })
 })
 
@@ -205,6 +213,7 @@ describe('Document', () => {
     expect(doc.get('a')).toBe(1)
     expect(doc.get('a', true)).toMatchObject({ value: 1 })
     expect(doc.get('c')).toBeUndefined()
+
     doc.contents = YAML.createNode('s')
     expect(doc.get('a')).toBeUndefined()
   })
@@ -229,6 +238,7 @@ describe('Document', () => {
   test('has', () => {
     expect(doc.has('a')).toBe(true)
     expect(doc.has('c')).toBe(false)
+
     doc.contents = YAML.createNode('s')
     expect(doc.has('a')).toBe(false)
   })
@@ -247,6 +257,8 @@ describe('Document', () => {
     expect(doc.get('a', true)).toBe(2)
     doc.set('c', 6)
     expect(doc.get('c')).toBe(6)
+    expect(doc.contents.items).toHaveLength(3)
+
     doc.contents = YAML.createNode('s')
     expect(() => doc.set('a', 1)).toThrow(/Document contents/)
   })
@@ -261,6 +273,9 @@ describe('Document', () => {
     expect(doc.getIn(['c'])).toBe(6)
     expect(() => doc.setIn(['a', 'e'])).toThrow(/Cannot create/)
     expect(() => doc.setIn(['e', 'e'], 1)).toThrow(/Cannot create/)
+    expect(doc.contents.items).toHaveLength(3)
+    expect(doc.get('b').items).toHaveLength(2)
+
     doc.contents = YAML.createNode('s')
     expect(() => doc.setIn(['a'], 1)).toThrow(/Document contents/)
   })
@@ -300,6 +315,7 @@ describe('Set', () => {
     set.set(4, true)
     expect(set.get(4)).toBe(4)
     expect(set.get(4, true)).toMatchObject({ key: 4, value: null })
+    expect(set.items).toHaveLength(3)
   })
 })
 
@@ -336,6 +352,7 @@ describe('OMap', () => {
     expect(omap.get('a')).toBeUndefined()
     omap.delete('c')
     expect(omap.get('b')).toMatchObject({ items: [{}, {}] })
+    expect(omap.items).toHaveLength(1)
   })
 
   test('get', () => {
@@ -361,5 +378,6 @@ describe('OMap', () => {
     expect(omap.get('b')).toBe(5)
     omap.set('c', 6)
     expect(omap.get('c')).toBe(6)
+    expect(omap.items).toHaveLength(3)
   })
 })

--- a/src/Document.js
+++ b/src/Document.js
@@ -63,6 +63,21 @@ export default class Document {
     this.warnings = []
   }
 
+  delete(key) {
+    if (this.contents instanceof Collection) return this.contents.delete(key)
+    else throw new Error('Expected a YAML collection as document contents')
+  }
+
+  deleteIn(path) {
+    if (isEmptyPath(path)) {
+      if (this.contents == null) return false
+      this.contents = null
+      return true
+    }
+    if (this.contents instanceof Collection) return this.contents.deleteIn(path)
+    else throw new Error('Expected a YAML collection as document contents')
+  }
+
   getDefaults() {
     return (
       Document.defaults[this.version] ||
@@ -100,16 +115,14 @@ export default class Document {
 
   set(key, value) {
     if (this.contents instanceof Collection) this.contents.set(key, value)
-    else
-      throw new Error(`Document contents must be a YAML collection for set()`)
+    else throw new Error('Expected a YAML collection as document contents')
   }
 
   setIn(path, value) {
     if (isEmptyPath(path)) this.contents = value
     else if (this.contents instanceof Collection)
       this.contents.setIn(path, value)
-    else
-      throw new Error(`Document contents must be a YAML collection for setIn()`)
+    else throw new Error('Expected a YAML collection as document contents')
   }
 
   setSchema() {

--- a/src/Document.js
+++ b/src/Document.js
@@ -71,6 +71,12 @@ export default class Document {
     )
   }
 
+  get(key, keepScalar) {
+    return this.contents instanceof Collection
+      ? this.contents.get(key, keepScalar)
+      : undefined
+  }
+
   getIn(path, keepScalar) {
     if (isEmptyPath(path))
       return !keepScalar && this.contents instanceof Scalar
@@ -81,6 +87,10 @@ export default class Document {
       : undefined
   }
 
+  has(key) {
+    return this.contents instanceof Collection ? this.contents.has(key) : false
+  }
+
   hasIn(path) {
     if (isEmptyPath(path)) return this.contents !== undefined
     return this.contents instanceof Collection
@@ -88,14 +98,18 @@ export default class Document {
       : false
   }
 
+  set(key, value) {
+    if (this.contents instanceof Collection) this.contents.set(key, value)
+    else
+      throw new Error(`Document contents must be a YAML collection for set()`)
+  }
+
   setIn(path, value) {
     if (isEmptyPath(path)) this.contents = value
     else if (this.contents instanceof Collection)
       this.contents.setIn(path, value)
     else
-      throw new Error(
-        `Document contents must be a YAML collection for setIn([${path}], ...)`
-      )
+      throw new Error(`Document contents must be a YAML collection for setIn()`)
   }
 
   setSchema() {

--- a/src/Document.js
+++ b/src/Document.js
@@ -76,19 +76,16 @@ export default class Document {
       return !keepScalar && this.contents instanceof Scalar
         ? this.contents.value
         : this.contents
-    if (this.contents instanceof Collection)
-      return this.contents.getIn(path, keepScalar)
-    throw new Error(
-      `Document contents must be a YAML collection for getIn([${path}])`
-    )
+    return this.contents instanceof Collection
+      ? this.contents.getIn(path, keepScalar)
+      : undefined
   }
 
   hasIn(path) {
     if (isEmptyPath(path)) return this.contents !== undefined
-    if (this.contents instanceof Collection) return this.contents.hasIn(path)
-    throw new Error(
-      `Document contents must be a YAML collection for hasIn([${path}])`
-    )
+    return this.contents instanceof Collection
+      ? this.contents.hasIn(path)
+      : false
   }
 
   setIn(path, value) {

--- a/src/Document.js
+++ b/src/Document.js
@@ -83,6 +83,14 @@ export default class Document {
     )
   }
 
+  hasIn(path) {
+    if (isEmptyPath(path)) return this.contents !== undefined
+    if (this.contents instanceof Collection) return this.contents.hasIn(path)
+    throw new Error(
+      `Document contents must be a YAML collection for hasIn([${path}])`
+    )
+  }
+
   setIn(path, value) {
     if (isEmptyPath(path)) this.contents = value
     else if (this.contents instanceof Collection)

--- a/src/Document.js
+++ b/src/Document.js
@@ -63,6 +63,16 @@ export default class Document {
     throw new Error('Expected a YAML collection as document contents')
   }
 
+  add(value) {
+    this.assertCollectionContents()
+    return this.contents.add(value)
+  }
+
+  addIn(path, value) {
+    this.assertCollectionContents()
+    this.contents.addIn(path, value)
+  }
+
   delete(key) {
     this.assertCollectionContents()
     return this.contents.delete(key)

--- a/src/schema/Collection.js
+++ b/src/schema/Collection.js
@@ -10,13 +10,12 @@ export default class Collection extends Node {
 
   getIn([key, ...rest], keepScalar) {
     const node = this.get(key, true)
-    if (node === undefined) return undefined
     if (rest.length === 0)
       return !keepScalar && node instanceof Scalar ? node.value : node
-    if (node instanceof Collection) return node.getIn(rest, keepScalar)
-    throw new Error(
-      `Expected a YAML collection at ${key}, but found ${node}. Remaining path: ${rest}`
-    )
+    else
+      return node instanceof Collection
+        ? node.getIn(rest, keepScalar)
+        : undefined
   }
 
   hasAllNullValues() {
@@ -37,11 +36,7 @@ export default class Collection extends Node {
   hasIn([key, ...rest]) {
     if (rest.length === 0) return this.has(key)
     const node = this.get(key, true)
-    if (node === undefined) return false
-    if (node instanceof Collection) return node.hasIn(rest)
-    throw new Error(
-      `Expected a YAML collection at ${key}, but found ${node}. Remaining path: ${rest}`
-    )
+    return node instanceof Collection ? node.hasIn(rest) : false
   }
 
   setIn([key, ...rest], value) {

--- a/src/schema/Collection.js
+++ b/src/schema/Collection.js
@@ -3,6 +3,11 @@ import Node from './Node'
 import Pair from './Pair'
 import Scalar from './Scalar'
 
+// null, undefined, or an empty non-string iterable (e.g. [])
+export const isEmptyPath = path =>
+  path == null ||
+  (typeof path === 'object' && path[Symbol.iterator]().next().done)
+
 export default class Collection extends Node {
   static maxFlowStringSingleLineLength = 60
 
@@ -57,7 +62,7 @@ export default class Collection extends Node {
       if (node instanceof Collection) node.setIn(rest, value)
       else
         throw new Error(
-          `Cannot create intermediate YAML collection at ${key}. Remaining path: ${rest}`
+          `Expected YAML collection at ${key}. Remaining path: ${rest}`
         )
     }
   }

--- a/src/schema/Collection.js
+++ b/src/schema/Collection.js
@@ -8,6 +8,16 @@ export default class Collection extends Node {
 
   items = []
 
+  deleteIn([key, ...rest]) {
+    if (rest.length === 0) return this.delete(key)
+    const node = this.get(key, true)
+    if (node instanceof Collection) return node.deleteIn(rest)
+    else
+      throw new Error(
+        `Expected YAML collection at ${key}. Remaining path: ${rest}`
+      )
+  }
+
   getIn([key, ...rest], keepScalar) {
     const node = this.get(key, true)
     if (rest.length === 0)

--- a/src/schema/Collection.js
+++ b/src/schema/Collection.js
@@ -13,6 +13,19 @@ export default class Collection extends Node {
 
   items = []
 
+  addIn(path, value) {
+    if (isEmptyPath(path)) this.add(value)
+    else {
+      const [key, ...rest] = path
+      const node = this.get(key, true)
+      if (node instanceof Collection) node.addIn(rest, value)
+      else
+        throw new Error(
+          `Expected YAML collection at ${key}. Remaining path: ${rest}`
+        )
+    }
+  }
+
   deleteIn([key, ...rest]) {
     if (rest.length === 0) return this.delete(key)
     const node = this.get(key, true)

--- a/src/schema/Collection.js
+++ b/src/schema/Collection.js
@@ -34,6 +34,16 @@ export default class Collection extends Node {
     })
   }
 
+  hasIn([key, ...rest]) {
+    if (rest.length === 0) return this.has(key)
+    const node = this.get(key, true)
+    if (node === undefined) return false
+    if (node instanceof Collection) return node.hasIn(rest)
+    throw new Error(
+      `Expected a YAML collection at ${key}, but found ${node}. Remaining path: ${rest}`
+    )
+  }
+
   setIn([key, ...rest], value) {
     if (rest.length === 0) {
       this.set(key, value)

--- a/src/schema/Collection.js
+++ b/src/schema/Collection.js
@@ -8,6 +8,17 @@ export default class Collection extends Node {
 
   items = []
 
+  getIn([key, ...rest], keepScalar) {
+    const node = this.get(key, true)
+    if (node === undefined) return undefined
+    if (rest.length === 0)
+      return !keepScalar && node instanceof Scalar ? node.value : node
+    if (node instanceof Collection) return node.getIn(rest, keepScalar)
+    throw new Error(
+      `Expected a YAML collection at ${key}, but found ${node}. Remaining path: ${rest}`
+    )
+  }
+
   hasAllNullValues() {
     return this.items.every(node => {
       if (!(node instanceof Pair)) return false
@@ -21,6 +32,19 @@ export default class Collection extends Node {
           !n.tag)
       )
     })
+  }
+
+  setIn([key, ...rest], value) {
+    if (rest.length === 0) {
+      this.set(key, value)
+    } else {
+      const node = this.get(key, true)
+      if (node instanceof Collection) node.setIn(rest, value)
+      else
+        throw new Error(
+          `Cannot create intermediate YAML collection at ${key}. Remaining path: ${rest}`
+        )
+    }
   }
 
   // overridden in implementations

--- a/src/schema/Map.js
+++ b/src/schema/Map.js
@@ -18,6 +18,14 @@ export function findPair(items, key) {
 }
 
 export default class YAMLMap extends Collection {
+  add(pair) {
+    if (pair instanceof Pair) {
+      const prev = findPair(this.items, pair.key)
+      if (prev) throw new Error(`Key ${pair.key} already set`)
+      this.items.push(pair)
+    } else throw new Error('Expected a pair as argument for Map add()')
+  }
+
   delete(key) {
     const it = findPair(this.items, key)
     if (!it) return false

--- a/src/schema/Map.js
+++ b/src/schema/Map.js
@@ -4,8 +4,32 @@ import toJSON from '../toJSON'
 import Collection from './Collection'
 import Merge from './Merge'
 import Pair from './Pair'
+import Scalar from './Scalar'
+
+export function findPair(items, key) {
+  const k = key instanceof Scalar ? key.value : key
+  for (const it of items) {
+    if (it instanceof Pair) {
+      if (it.key === key || it.key === k) return it
+      if (it.key && it.key.value === k) return it
+    }
+  }
+  return undefined
+}
 
 export default class YAMLMap extends Collection {
+  get(key, keepScalar) {
+    const it = findPair(this.items, key)
+    const node = it && it.value
+    return !keepScalar && node instanceof Scalar ? node.value : node
+  }
+
+  set(key, value) {
+    const prev = findPair(this.items, key)
+    if (prev) prev.value = value
+    else this.items.push(new Pair(key, value))
+  }
+
   toJSON(_, opt) {
     if (opt && opt.mapAsMap) return this.toJSMap(opt)
     return this.items.reduce((map, item) => {

--- a/src/schema/Map.js
+++ b/src/schema/Map.js
@@ -20,7 +20,9 @@ export function findPair(items, key) {
 export default class YAMLMap extends Collection {
   delete(key) {
     const it = findPair(this.items, key)
-    if (it) this.items.splice(this.items.indexOf(it), 1)
+    if (!it) return false
+    const del = this.items.splice(this.items.indexOf(it), 1)
+    return del.length > 0
   }
 
   get(key, keepScalar) {

--- a/src/schema/Map.js
+++ b/src/schema/Map.js
@@ -18,6 +18,11 @@ export function findPair(items, key) {
 }
 
 export default class YAMLMap extends Collection {
+  delete(key) {
+    const it = findPair(this.items, key)
+    if (it) this.items.splice(this.items.indexOf(it), 1)
+  }
+
   get(key, keepScalar) {
     const it = findPair(this.items, key)
     const node = it && it.value

--- a/src/schema/Map.js
+++ b/src/schema/Map.js
@@ -19,11 +19,12 @@ export function findPair(items, key) {
 
 export default class YAMLMap extends Collection {
   add(pair) {
-    if (pair instanceof Pair) {
-      const prev = findPair(this.items, pair.key)
-      if (prev) throw new Error(`Key ${pair.key} already set`)
-      this.items.push(pair)
-    } else throw new Error('Expected a pair as argument for Map add()')
+    if (!pair) pair = new Pair(pair)
+    else if (!(pair instanceof Pair))
+      pair = new Pair(pair.key || pair, pair.value)
+    const prev = findPair(this.items, pair.key)
+    if (prev) throw new Error(`Key ${pair.key} already set`)
+    this.items.push(pair)
   }
 
   delete(key) {

--- a/src/schema/Map.js
+++ b/src/schema/Map.js
@@ -24,6 +24,10 @@ export default class YAMLMap extends Collection {
     return !keepScalar && node instanceof Scalar ? node.value : node
   }
 
+  has(key) {
+    return !!findPair(this.items, key)
+  }
+
   set(key, value) {
     const prev = findPair(this.items, key)
     if (prev) prev.value = value

--- a/src/schema/Seq.js
+++ b/src/schema/Seq.js
@@ -2,8 +2,23 @@
 
 import toJSON from '../toJSON'
 import Collection from './Collection'
+import Scalar from './Scalar'
 
 export default class YAMLSeq extends Collection {
+  get(key, keepScalar) {
+    const k = key instanceof Scalar ? key.value : key
+    if (!isFinite(k)) return undefined
+    const it = this.items[k]
+    return !keepScalar && it instanceof Scalar ? it.value : it
+  }
+
+  set(key, value) {
+    const k = typeof key === 'number' ? key : Number(key)
+    if (k < 0 || !Number.isInteger(k))
+      throw new Error(`Expected a valid index for YAML sequence, not ${key}.`)
+    this.items[k] = value
+  }
+
   toJSON(_, opt) {
     return this.items.map((v, i) => toJSON(v, String(i), opt))
   }

--- a/src/schema/Seq.js
+++ b/src/schema/Seq.js
@@ -11,6 +11,10 @@ function asItemIndex(key) {
 }
 
 export default class YAMLSeq extends Collection {
+  add(value) {
+    this.items.push(value)
+  }
+
   delete(key) {
     const idx = asItemIndex(key)
     if (typeof idx !== 'number') return false

--- a/src/schema/Seq.js
+++ b/src/schema/Seq.js
@@ -13,7 +13,9 @@ function asItemIndex(key) {
 export default class YAMLSeq extends Collection {
   delete(key) {
     const idx = asItemIndex(key)
-    if (typeof idx === 'number') this.items.splice(idx, 1)
+    if (typeof idx !== 'number') return false
+    const del = this.items.splice(idx, 1)
+    return del.length > 0
   }
 
   get(key, keepScalar) {

--- a/src/schema/Seq.js
+++ b/src/schema/Seq.js
@@ -19,9 +19,10 @@ export default class YAMLSeq extends Collection {
   }
 
   set(key, value) {
-    const k = typeof key === 'number' ? key : Number(key)
+    let k = key instanceof Scalar ? key.value : key
+    if (k && typeof k === 'string') k = Number(k)
     if (k < 0 || !Number.isInteger(k))
-      throw new Error(`Expected a valid index for YAML sequence, not ${key}.`)
+      throw new Error(`Expected a valid index for YAML sequence, not ${k}.`)
     this.items[k] = value
   }
 

--- a/src/schema/Seq.js
+++ b/src/schema/Seq.js
@@ -12,6 +12,12 @@ export default class YAMLSeq extends Collection {
     return !keepScalar && it instanceof Scalar ? it.value : it
   }
 
+  has(key) {
+    let k = key instanceof Scalar ? key.value : key
+    if (k && typeof k === 'string') k = Number(k)
+    return Number.isInteger(k) && k >= 0 && k < this.items.length
+  }
+
   set(key, value) {
     const k = typeof key === 'number' ? key : Number(key)
     if (k < 0 || !Number.isInteger(k))

--- a/src/schema/_omap.js
+++ b/src/schema/_omap.js
@@ -14,6 +14,7 @@ export class YAMLOMap extends YAMLSeq {
     this.tag = YAMLOMap.tag
   }
 
+  delete = YAMLMap.prototype.delete.bind(this)
   get = YAMLMap.prototype.get.bind(this)
   has = YAMLMap.prototype.has.bind(this)
   set = YAMLMap.prototype.set.bind(this)

--- a/src/schema/_omap.js
+++ b/src/schema/_omap.js
@@ -14,6 +14,7 @@ export class YAMLOMap extends YAMLSeq {
     this.tag = YAMLOMap.tag
   }
 
+  add = YAMLMap.prototype.add.bind(this)
   delete = YAMLMap.prototype.delete.bind(this)
   get = YAMLMap.prototype.get.bind(this)
   has = YAMLMap.prototype.has.bind(this)

--- a/src/schema/_omap.js
+++ b/src/schema/_omap.js
@@ -15,6 +15,7 @@ export class YAMLOMap extends YAMLSeq {
   }
 
   get = YAMLMap.prototype.get.bind(this)
+  has = YAMLMap.prototype.has.bind(this)
   set = YAMLMap.prototype.set.bind(this)
 
   toJSON(_, opt) {

--- a/src/schema/_omap.js
+++ b/src/schema/_omap.js
@@ -1,5 +1,6 @@
 import { YAMLSemanticError } from '../errors'
 import toJSON from '../toJSON'
+import YAMLMap from './Map'
 import Pair from './Pair'
 import Scalar from './Scalar'
 import YAMLSeq from './Seq'
@@ -12,6 +13,9 @@ export class YAMLOMap extends YAMLSeq {
     super()
     this.tag = YAMLOMap.tag
   }
+
+  get = YAMLMap.prototype.get.bind(this)
+  set = YAMLMap.prototype.set.bind(this)
 
   toJSON(_, opt) {
     const map = new Map()

--- a/src/schema/_set.js
+++ b/src/schema/_set.js
@@ -7,6 +7,12 @@ import parseMap from './parseMap'
 import Scalar from './Scalar'
 
 export class YAMLSet extends YAMLMap {
+  add(key) {
+    const pair = key instanceof Pair ? key : new Pair(key)
+    const prev = findPair(this.items, pair.key)
+    if (!prev) this.items.push(pair)
+  }
+
   get(key, keepPair) {
     const pair = findPair(this.items, key)
     return !keepPair && pair instanceof Pair


### PR DESCRIPTION
Following [this comment](../pull/68#issuecomment-451897190) on PR #68, this adds the following accessor functions to all collections:

- `add(value: any)` – adds a value to the collection. For `!!map` and `!!omap` the `value` must be a Pair instance or a `{ key, value }` object, which may not have a key that already exists in the map.
- `delete(key: any): boolean` – removes a value from the collection. Returns `true` if the item was found and removed.
- `get(key: any, keepScalar: boolean?): any | undefined` – returns item at `key`, or `undefined` if not found. If `keepScalar` is not set, unwraps scalar values from their surrounding node; collections are always returned intact.
- `has(key: any): boolean` – checks if the collection includes a value with the key `key`
- `set(key: any, value: any)` – sets a value in this collection. For `!!set`, value needs to be a boolean to add/remove the item from the set.

For all of these, the keys may be nodes or their wrapped scalar values (i.e. `42` will match `Scalar { value: 42 }`) . Keys for `!!seq` should be positive integers, or their string representations. `add()` and `set()` do not automatically call `createNode()` to wrap the value.

Each of the methods also has a variant that requires an iterable as the first parameter, and allows fetching or modifying deeper collections: `addIn(path, value)`, `deleteIn(path)`, `getIn(path, keepScalar)`, `hasIn(path)`, `setIn(path, value)`. `getIn` and `hasIn` will return `undefined` or `false` (respectively) if any of the intermediate collections is not found or if the key path attempts to extend within a scalar value, but the others will throw an error in such cases. Note that for `addIn` the path argument points to the collection rather than the item.

The document also gets the same methods, based on the top-level collection (if any). For the `*in` methods using an empty `path` value (i.e. `null`, `undefined`, or `[]`) will refer to the document's top-level `contents`.

Examples:
```js
const map = YAML.createNode({ a: 1, b: [2, 3] })
map.add({ key: 'c', value: 4 }) // -> map.get('c') === 4 && map.has('c') === true
map.addIn(['b'], 5) // -> map.getIn(['b', 2]) === 5
map.delete('c') // true
map.deleteIn(['c', 'f']) // false
map.get('a') // 1
map.get(YAML.createNode('a'), true) // Scalar { value: 1 }
map.getIn(['b', 1]) // 3
map.has('c') // false
map.hasIn(['b', '0']) // true
map.set('c', null) // -> map.get('c') === null && map.has('c') === true
map.setIn(['c', 'x']) // throws Error: Expected YAML collection at c. Remaining path: x

const doc = YAML.parseDocument('a: 1\nb: [2, 3]\n')
doc.get('a') // 1
doc.getIn([]) // YAMLMap { items: [Pair, Pair], ... }
doc.hasIn(['b', 0]) // true
doc.setIn(['a'], 4) // -> doc.getIn(['a']) === 4
```

@MikeRalphson will this help with your usage with JSON pointers?

**Edit 1:** Added get/has/set to Document & dropped getIn/hasIn throwing for invalid key paths.
**Edit 2:** Added add/addIn/delete/deleteIn.