### PR TITLE
set reqStringParse for all (and only) strings

### DIFF
--- a/src/schema/_string.js
+++ b/src/schema/_string.js
@@ -279,6 +279,9 @@ export function stringify(item, ctx, onComment, onChompKeep) {
   if (typeof value !== 'string') {
     value = String(value)
     item = Object.assign({}, item, { value })
+    ctx = Object.assign({}, ctx, { reqStringParse: false })
+  } else {
+    ctx = Object.assign({}, ctx, { reqStringParse: true })
   }
   const _stringify = _type => {
     switch (_type) {

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -137,7 +137,7 @@ describe('eemeli/yaml#80', () => {
     test: /^\/(.*)\/([gimuy]+)$/,
     stringify(item, ctx, onComment, onChompKeep) {
       return stringifyStr(
-        { value: item.value.toString() },
+        item,
         ctx,
         onComment,
         onChompKeep


### PR DESCRIPTION
This is another approach for the issue being discussed in #80.

Set reqStringParse for strings, but never for non-strings.