### PR TITLE
Handle circular references

### DIFF
--- a/src/Anchors.js
+++ b/src/Anchors.js
@@ -11,6 +11,10 @@ export default class Anchors {
 
   map = {}
 
+  constructor(prefix) {
+    this.prefix = prefix
+  }
+
   createAlias(node, name) {
     this.setAnchor(node, name)
     return new Alias(node)
@@ -39,6 +43,7 @@ export default class Anchors {
   }
 
   newName(prefix) {
+    if (!prefix) prefix = this.prefix
     const names = Object.keys(this.map)
     for (let i = 1; true; ++i) {
       const name = `${prefix}${i}`
@@ -79,7 +84,7 @@ export default class Anchors {
     } else {
       if (!name) {
         if (!node) return null
-        name = this.newName('a')
+        name = this.newName()
       }
       map[name] = node
     }

--- a/src/Document.js
+++ b/src/Document.js
@@ -413,11 +413,6 @@ export default class Document {
       // Lazy resolution for circular references
       res = new Alias(src)
       anchors._cstAliases.push(res)
-      if (!src.resolved) {
-        const msg =
-          'Alias node contains a circular reference, which cannot be resolved as JSON'
-        this.warnings.push(new YAMLWarning(node, msg))
-      }
     } else {
       const tagName = this.resolveTagName(node)
       if (tagName) {

--- a/src/Document.js
+++ b/src/Document.js
@@ -505,9 +505,12 @@ export default class Document {
       this.options.keepBlobsInJSON &&
       (typeof arg !== 'string' || !(this.contents instanceof Scalar))
     const ctx = { keep, mapAsMap: keep && !!this.options.mapAsMap }
-    const anchorNodes = Object.values(this.anchors.map)
-    if (anchorNodes.length > 0)
-      ctx.anchors = anchorNodes.map(node => ({ alias: [], node }))
+    const anchorNames = Object.keys(this.anchors.map)
+    if (anchorNames.length > 0)
+      ctx.anchors = anchorNames.map(name => ({
+        alias: [],
+        node: this.anchors.map[name]
+      }))
     return toJSON(this.contents, arg, ctx)
   }
 

--- a/src/Document.js
+++ b/src/Document.js
@@ -47,7 +47,7 @@ export default class Document {
   }
 
   constructor(options) {
-    this.anchors = new Anchors()
+    this.anchors = new Anchors(options.anchorPrefix)
     this.commentBefore = null
     this.comment = null
     this.contents = null

--- a/src/Document.js
+++ b/src/Document.js
@@ -501,13 +501,14 @@ export default class Document {
   }
 
   toJSON(arg) {
-    const cr = this.warnings.find(w => /circular reference/.test(w.message))
-    if (cr) throw new YAMLSemanticError(cr.source, cr.message)
     const keep =
       this.options.keepBlobsInJSON &&
       (typeof arg !== 'string' || !(this.contents instanceof Scalar))
-    const mapAsMap = keep && !!this.options.mapAsMap
-    return toJSON(this.contents, arg, { keep, mapAsMap })
+    const ctx = { keep, mapAsMap: keep && !!this.options.mapAsMap }
+    const anchorNodes = Object.values(this.anchors.map)
+    if (anchorNodes.length > 0)
+      ctx.anchors = anchorNodes.map(node => ({ alias: [], node }))
+    return toJSON(this.contents, arg, ctx)
   }
 
   toString() {

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { YAMLSemanticError } from './errors'
 import Schema from './schema'
 
 const defaultOptions = {
+  anchorPrefix: 'a',
   keepNodeTypes: true,
   keepBlobsInJSON: true,
   mapAsMap: false,

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import Schema from './schema'
 
 const defaultOptions = {
   anchorPrefix: 'a',
+  keepCstNodes: false,
   keepNodeTypes: true,
   keepBlobsInJSON: true,
   mapAsMap: false,

--- a/src/schema/Alias.js
+++ b/src/schema/Alias.js
@@ -24,7 +24,9 @@ export default class Alias extends Node {
     throw new Error('Alias nodes cannot have tags')
   }
 
-  toJSON(arg, opt) {
-    return toJSON(this.source, arg, opt)
+  toJSON(arg, ctx) {
+    const anchor =
+      ctx && ctx.anchors && ctx.anchors.find(a => a.node === this.source)
+    return (anchor && anchor.res) || toJSON(this.source, arg, ctx)
   }
 }

--- a/src/schema/Pair.js
+++ b/src/schema/Pair.js
@@ -35,10 +35,10 @@ export default class Pair extends Node {
     return String(key)
   }
 
-  toJSON(_, opt) {
+  toJSON(_, ctx) {
     const pair = {}
     const sk = this.stringKey
-    pair[sk] = toJSON(this.value, sk, opt)
+    pair[sk] = toJSON(this.value, sk, ctx)
     return pair
   }
 

--- a/src/schema/Scalar.js
+++ b/src/schema/Scalar.js
@@ -9,8 +9,8 @@ export default class Scalar extends Node {
     this.value = value
   }
 
-  toJSON(arg, opt) {
-    return opt && opt.keep ? this.value : toJSON(this.value, arg, opt)
+  toJSON(arg, ctx) {
+    return ctx && ctx.keep ? this.value : toJSON(this.value, arg, ctx)
   }
 
   toString() {

--- a/src/schema/Seq.js
+++ b/src/schema/Seq.js
@@ -41,8 +41,12 @@ export default class YAMLSeq extends Collection {
     this.items[idx] = value
   }
 
-  toJSON(_, opt) {
-    return this.items.map((v, i) => toJSON(v, String(i), opt))
+  toJSON(_, ctx) {
+    const seq = []
+    if (ctx && ctx.onCreate) ctx.onCreate(seq)
+    let i = 0
+    for (const item of this.items) seq.push(toJSON(item, String(i++), ctx))
+    return seq
   }
 
   toString(ctx, onComment, onChompKeep) {

--- a/src/schema/_omap.js
+++ b/src/schema/_omap.js
@@ -20,15 +20,16 @@ export class YAMLOMap extends YAMLSeq {
   has = YAMLMap.prototype.has.bind(this)
   set = YAMLMap.prototype.set.bind(this)
 
-  toJSON(_, opt) {
+  toJSON(_, ctx) {
     const map = new Map()
+    if (ctx && ctx.onCreate) ctx.onCreate(map)
     for (const pair of this.items) {
       let key, value
       if (pair instanceof Pair) {
-        key = toJSON(pair.key, '', opt)
-        value = toJSON(pair.value, key, opt)
+        key = toJSON(pair.key, '', ctx)
+        value = toJSON(pair.value, key, ctx)
       } else {
-        key = toJSON(pair, '', opt)
+        key = toJSON(pair, '', ctx)
       }
       if (map.has(key))
         throw new Error('Ordered maps must not include duplicate keys')

--- a/src/schema/_omap.js
+++ b/src/schema/_omap.js
@@ -54,8 +54,8 @@ function parseOMap(doc, cst) {
   return Object.assign(new YAMLOMap(), pairs)
 }
 
-function createOMap(schema, iterable, wrapScalars) {
-  const pairs = createPairs(schema, iterable, wrapScalars)
+function createOMap(schema, iterable, ctx) {
+  const pairs = createPairs(schema, iterable, ctx)
   const omap = new YAMLOMap()
   omap.items = pairs.items
   return omap

--- a/src/schema/_pairs.js
+++ b/src/schema/_pairs.js
@@ -30,7 +30,7 @@ export function parsePairs(doc, cst) {
   return seq
 }
 
-export function createPairs(schema, iterable, wrapScalars) {
+export function createPairs(schema, iterable, ctx) {
   const pairs = new YAMLSeq()
   pairs.tag = 'tag:yaml.org,2002:pairs'
   for (const it of iterable) {
@@ -49,8 +49,8 @@ export function createPairs(schema, iterable, wrapScalars) {
     } else {
       key = it
     }
-    const k = schema.createNode(key, wrapScalars)
-    const v = schema.createNode(value, wrapScalars)
+    const k = schema.createNode(key, ctx.wrapScalars, null, ctx)
+    const v = schema.createNode(value, ctx.wrapScalars, null, ctx)
     pairs.items.push(new Pair(k, v))
   }
   return pairs

--- a/src/schema/_set.js
+++ b/src/schema/_set.js
@@ -77,10 +77,10 @@ function parseSet(doc, cst) {
   return Object.assign(new YAMLSet(), map)
 }
 
-function createSet(schema, iterable, wrapScalars) {
+function createSet(schema, iterable, ctx) {
   const set = new YAMLSet()
   for (const value of iterable) {
-    const v = schema.createNode(value, wrapScalars)
+    const v = schema.createNode(value, ctx.wrapScalars, null, ctx)
     set.items.push(new Pair(v))
   }
   return set

--- a/src/schema/_set.js
+++ b/src/schema/_set.js
@@ -42,21 +42,22 @@ export class YAMLSet extends YAMLMap {
     }
   }
 
-  toJSON(_, opt) {
+  toJSON(_, ctx) {
     const set = new Set()
+    if (ctx && ctx.onCreate) ctx.onCreate(set)
     for (const item of this.items) {
       if (item instanceof Merge) {
         const { items } = item.value
         for (let i = items.length - 1; i >= 0; --i) {
           const { source } = items[i]
           if (source instanceof YAMLMap) {
-            for (const [key] of source.toJSMap(opt)) set.add(key)
+            for (const [key] of source.toJSMap(ctx)) set.add(key)
           } else {
             throw new Error('Merge sources must be maps')
           }
         }
       } else {
-        set.add(toJSON(item.key, '', opt))
+        set.add(toJSON(item.key, '', ctx))
       }
     }
     return set

--- a/src/schema/failsafe.js
+++ b/src/schema/failsafe.js
@@ -5,29 +5,29 @@ import { str } from './_string'
 import parseMap from './parseMap'
 import parseSeq from './parseSeq'
 
-function createMap(schema, obj, wrapScalars) {
+function createMap(schema, obj, ctx) {
   const map = new YAMLMap()
   if (obj instanceof Map) {
     for (const [key, value] of obj) {
-      const k = schema.createNode(key, wrapScalars)
-      const v = schema.createNode(value, wrapScalars)
+      const k = schema.createNode(key, ctx.wrapScalars, null, ctx)
+      const v = schema.createNode(value, ctx.wrapScalars, null, ctx)
       map.items.push(new Pair(k, v))
     }
   } else if (obj && typeof obj === 'object') {
     map.items = Object.keys(obj).map(key => {
-      const k = schema.createNode(key, wrapScalars)
-      const v = schema.createNode(obj[key], wrapScalars)
+      const k = schema.createNode(key, ctx.wrapScalars, null, ctx)
+      const v = schema.createNode(obj[key], ctx.wrapScalars, null, ctx)
       return new Pair(k, v)
     })
   }
   return map
 }
 
-function createSeq(schema, obj, wrapScalars) {
+function createSeq(schema, obj, ctx) {
   const seq = new YAMLSeq()
   if (obj && obj[Symbol.iterator]) {
     for (const it of obj) {
-      const v = schema.createNode(it, wrapScalars)
+      const v = schema.createNode(it, ctx.wrapScalars, null, ctx)
       seq.items.push(v)
     }
   }

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -236,7 +236,7 @@ export default class Schema {
         alias.source = alias.source.node
         let name = anchors.getName(alias.source)
         if (!name) {
-          name = anchors.newName('ref')
+          name = anchors.newName()
           anchors.map[name] = alias.source
         }
       }

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -69,9 +69,14 @@ export default class Schema {
         tagObj = value instanceof Map ? map : value[Symbol.iterator] ? seq : map
       }
     }
-    if (ctx && ctx.onTagObj) ctx.onTagObj(tagObj)
+    if (!ctx) ctx = { wrapScalars }
+    else ctx.wrapScalars = wrapScalars
+    if (ctx.onTagObj) {
+      ctx.onTagObj(tagObj)
+      delete ctx.onTagObj
+    }
     return tagObj.createNode
-      ? tagObj.createNode(this, value, wrapScalars)
+      ? tagObj.createNode(this, value, ctx)
       : new Scalar(value)
   }
 

--- a/src/toJSON.js
+++ b/src/toJSON.js
@@ -1,7 +1,16 @@
-export default function toJSON(value, arg, opt) {
-  return Array.isArray(value)
-    ? value.map((v, i) => toJSON(v, String(i), opt))
-    : value && typeof value.toJSON === 'function'
-    ? value.toJSON(arg, opt)
-    : value
+export default function toJSON(value, arg, ctx) {
+  if (Array.isArray(value))
+    return value.map((v, i) => toJSON(v, String(i), ctx))
+  if (value && typeof value.toJSON === 'function') {
+    const anchor = ctx && ctx.anchors && ctx.anchors.find(a => a.node === value)
+    if (anchor)
+      ctx.onCreate = res => {
+        anchor.res = res
+        delete ctx.onCreate
+      }
+    const res = value.toJSON(arg, ctx)
+    if (anchor && ctx.onCreate) ctx.onCreate(res)
+    return res
+  }
+  return value
 }

--- a/tests/doc/anchors.js
+++ b/tests/doc/anchors.js
@@ -29,10 +29,8 @@ test('re-defined anchor', () => {
 test('circular reference', () => {
   const src = '&a [ 1, *a ]\n'
   const doc = YAML.parseDocument(src)
-  const message =
-    'Alias node contains a circular reference, which cannot be resolved as JSON'
   expect(doc.errors).toHaveLength(0)
-  expect(doc.warnings).toMatchObject([{ message }])
+  expect(doc.warnings).toHaveLength(0)
   const { items } = doc.contents
   expect(items).toHaveLength(2)
   expect(items[1].source).toBe(doc.contents)
@@ -173,9 +171,7 @@ describe('merge <<', () => {
       const src = '&A { <<: *A, B: b }\n'
       const doc = YAML.parseDocument(src, { merge: true })
       expect(doc.errors).toHaveLength(0)
-      const message =
-        'Alias node contains a circular reference, which cannot be resolved as JSON'
-      expect(doc.warnings).toMatchObject([{ message }])
+      expect(doc.warnings).toHaveLength(0)
       expect(() => doc.toJSON()).toThrow('Maximum call stack size exceeded')
       expect(String(doc)).toBe(src)
     })

--- a/tests/doc/anchors.js
+++ b/tests/doc/anchors.js
@@ -36,7 +36,8 @@ test('circular reference', () => {
   const { items } = doc.contents
   expect(items).toHaveLength(2)
   expect(items[1].source).toBe(doc.contents)
-  expect(() => doc.toJSON()).toThrow(message)
+  const res = doc.toJSON()
+  expect(res[1]).toBe(res)
   expect(String(doc)).toBe(src)
 })
 
@@ -175,7 +176,7 @@ describe('merge <<', () => {
       const message =
         'Alias node contains a circular reference, which cannot be resolved as JSON'
       expect(doc.warnings).toMatchObject([{ message }])
-      expect(() => doc.toJSON()).toThrow(message)
+      expect(() => doc.toJSON()).toThrow('Maximum call stack size exceeded')
       expect(String(doc)).toBe(src)
     })
   })

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -79,33 +79,33 @@ describe('circular references', () => {
   test('parent at root', () => {
     const map = { foo: 'bar' }
     map.map = map
-    expect(YAML.stringify(map)).toBe(`&ref1
+    expect(YAML.stringify(map)).toBe(`&a1
 foo: bar
-map: *ref1\n`)
+map: *a1\n`)
   })
 
   test('ancestor at root', () => {
     const baz = {}
     const map = { foo: { bar: { baz } } }
     baz.map = map
-    expect(YAML.stringify(map)).toBe(`&ref1
+    expect(YAML.stringify(map)).toBe(`&a1
 foo:
   bar:
     baz:
-      map: *ref1\n`)
+      map: *a1\n`)
   })
 
   test('sibling sequences', () => {
     const one = ['one']
     const two = ['two']
     const seq = [one, two, one, one, two]
-    expect(YAML.stringify(seq)).toBe(`- &ref1
+    expect(YAML.stringify(seq)).toBe(`- &a1
   - one
-- &ref2
+- &a2
   - two
-- *ref1
-- *ref1
-- *ref2\n`)
+- *a1
+- *a1
+- *a2\n`)
   })
 
   test('further relatives', () => {
@@ -114,25 +114,26 @@ foo:
     expect(YAML.stringify(seq)).toBe(`- foo:
     bar:
       baz:
-        &ref1
+        &a1
         a: 1
 - fe:
     fi:
       fo:
-        baz: *ref1\n`)
+        baz: *a1\n`)
   })
 
   test('only match objects', () => {
     const date = new Date('2001-12-15T02:59:43.1Z')
     const seq = ['a', 'a', 1, 1, true, true, date, date]
-    expect(YAML.stringify(seq, { version: '1.1' })).toBe(`- a
+    expect(YAML.stringify(seq, { anchorPrefix: 'foo', version: '1.1' }))
+      .toBe(`- a
 - a
 - 1
 - 1
 - true
 - true
-- &ref1 2001-12-15T02:59:43.100Z
-- *ref1\n`)
+- &foo1 2001-12-15T02:59:43.100Z
+- *foo1\n`)
   })
 })
 

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -75,6 +75,67 @@ blah blah\n`)
   })
 })
 
+describe('circular references', () => {
+  test('parent at root', () => {
+    const map = { foo: 'bar' }
+    map.map = map
+    expect(YAML.stringify(map)).toBe(`&ref1
+foo: bar
+map: *ref1\n`)
+  })
+
+  test('ancestor at root', () => {
+    const baz = {}
+    const map = { foo: { bar: { baz } } }
+    baz.map = map
+    expect(YAML.stringify(map)).toBe(`&ref1
+foo:
+  bar:
+    baz:
+      map: *ref1\n`)
+  })
+
+  test('sibling sequences', () => {
+    const one = ['one']
+    const two = ['two']
+    const seq = [one, two, one, one, two]
+    expect(YAML.stringify(seq)).toBe(`- &ref1
+  - one
+- &ref2
+  - two
+- *ref1
+- *ref1
+- *ref2\n`)
+  })
+
+  test('further relatives', () => {
+    const baz = { a: 1 }
+    const seq = [{ foo: { bar: { baz } } }, { fe: { fi: { fo: { baz } } } }]
+    expect(YAML.stringify(seq)).toBe(`- foo:
+    bar:
+      baz:
+        &ref1
+        a: 1
+- fe:
+    fi:
+      fo:
+        baz: *ref1\n`)
+  })
+
+  test('only match objects', () => {
+    const date = new Date('2001-12-15T02:59:43.1Z')
+    const seq = ['a', 'a', 1, 1, true, true, date, date]
+    expect(YAML.stringify(seq, { version: '1.1' })).toBe(`- a
+- a
+- 1
+- 1
+- true
+- true
+- &ref1 2001-12-15T02:59:43.100Z
+- *ref1\n`)
+  })
+})
+
 test('array', () => {
   const array = [3, ['four', 5]]
   const str = YAML.stringify(array)


### PR DESCRIPTION
Fixes #81

Essentially, this now works:
```js
const a = ['b']
a.push(a)
const str = YAML.stringify(a)
// &a1
// - b
// - *a1
YAML.parse(str)
// [ 'b', [Circular] ]
```

For stringifying, this means that input that would earlier throw now doesn't, producing valid YAML instead. When parsing, alias nodes referring to anchors now resolve the original objects, rather than separate instances. I'm not sure yet whether this should mean a major version bump or not.

The public `YAML.createNode()` and the `doc.schema.createNode()` APIs have not changed, and do not support the autogeneration of alias nodes.