### PR TITLE
Refactor exports

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -6,8 +6,7 @@ const presets = [['@babel/env', envOptions]]
 
 const plugins = [
   '@babel/plugin-proposal-class-properties',
-  ['babel-plugin-trace', { strip: true }],
-  ['babel-plugin-add-module-exports', { addDefaultProperty: true }]
+  ['babel-plugin-trace', { strip: true }]
 ]
 if (isBrowser) plugins.push('@babel/plugin-transform-runtime')
 

--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -5,7 +5,7 @@ env:
 
 extends:
   - eslint:recommended
-  - prettier
+  - plugin:prettier/recommended
 
 rules:
   array-callback-return: error
@@ -19,6 +19,7 @@ rules:
   no-unused-labels: 0
   no-var: error
   prefer-const: [warn, destructuring: all]
+  prettier/prettier: error
 
 overrides:
   - files: src/**/*.js

--- a/README.md
+++ b/README.md
@@ -45,14 +45,12 @@ const YAML = require('yaml')
 - [`YAML.parseDocument(str, options): YAML.Document`](https://eemeli.org/yaml/#parsing-documents)
 
 ```js
-import Map from 'yaml/map'
-import Pair from 'yaml/pair'
-import Seq from 'yaml/seq'
+import { Pair, YAMLMap, YAMLSeq } from 'yaml/types'
 ```
 
-- [`new Map()`](https://eemeli.org/yaml/#creating-nodes)
 - [`new Pair(key, value)`](https://eemeli.org/yaml/#creating-nodes)
-- [`new Seq()`](https://eemeli.org/yaml/#creating-nodes)
+- [`new YAMLMap()`](https://eemeli.org/yaml/#creating-nodes)
+- [`new YAMLSeq()`](https://eemeli.org/yaml/#creating-nodes)
 
 ### CST Parser
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist').default

--- a/map.js
+++ b/map.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/schema/Map').default
+require('./dist/deprecation').warn(__filename)

--- a/map.js
+++ b/map.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/schema/Map')
+module.exports = require('./dist/schema/Map').default

--- a/package-lock.json
+++ b/package-lock.json
@@ -2543,6 +2543,15 @@
         "get-stdin": "^6.0.0"
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
+      "integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
@@ -2811,6 +2820,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
     "fast-glob": {
@@ -5754,6 +5769,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
       "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
       "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
     },
     "pretty-format": {
       "version": "24.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1590,15 +1590,6 @@
         }
       }
     },
-    "babel-plugin-add-module-exports": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-1.0.0.tgz",
-      "integrity": "sha512-m0sMxPL4FaN2K69GQgaRJa4Ny15qKSdoknIcpN+gz+NaJlAW9pge/povs13tPYsKDboflrEQC+/3kfIsONBTaw==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^2.0.4"
-      }
-    },
     "babel-plugin-istanbul": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
@@ -4964,7 +4955,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -5259,7 +5250,7 @@
     },
     "mute-stream": {
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
@@ -6769,7 +6760,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -18,20 +18,22 @@
     "*.js",
     "!.*.js"
   ],
-  "main": "./dist/index.js",
+  "main": "./index.js",
   "browser": {
-    "./dist/index.js": "./browser/dist/index.js",
+    "./index.js": "./browser/index.js",
     "./map.js": "./browser/map.js",
     "./pair.js": "./browser/pair.js",
     "./parse-cst.js": "./browser/parse-cst.js",
     "./scalar.js": "./browser/scalar.js",
     "./schema.js": "./browser/schema.js",
     "./seq.js": "./browser/seq.js",
+    "./types.js": "./browser/types.js",
     "./types/binary.js": "./browser/types/binary.js",
     "./types/omap.js": "./browser/types/omap.js",
     "./types/pairs.js": "./browser/types/pairs.js",
     "./types/set.js": "./browser/types/set.js",
-    "./types/timestamp.js": "./browser/types/timestamp.js"
+    "./types/timestamp.js": "./browser/types/timestamp.js",
+    "./util.js": "./browser/util.js"
   },
   "scripts": {
     "browser:build": "BABEL_ENV=browser babel src/ --out-dir browser/dist/",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@babel/preset-env": "^7.3.4",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.3.0",
-    "babel-plugin-add-module-exports": "^1.0.0",
     "babel-plugin-trace": "^1.1.0",
     "cpy-cli": "^2.0.0",
     "eslint": "^5.15.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "cpy-cli": "^2.0.0",
     "eslint": "^5.15.1",
     "eslint-config-prettier": "^4.1.0",
+    "eslint-plugin-prettier": "^3.0.1",
     "fast-check": "^1.12.0",
     "jest": "^24.3.0",
     "prettier": "^1.16.4"

--- a/pair.js
+++ b/pair.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/schema/Pair').default
+require('./dist/deprecation').warn(__filename)

--- a/pair.js
+++ b/pair.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/schema/Pair')
+module.exports = require('./dist/schema/Pair').default

--- a/parse-cst.js
+++ b/parse-cst.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cst/parse')
+module.exports = require('./dist/cst/parse').default

--- a/scalar.js
+++ b/scalar.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/schema/Scalar')
+module.exports = require('./dist/schema/Scalar').default

--- a/scalar.js
+++ b/scalar.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/schema/Scalar').default
+require('./dist/deprecation').warn(__filename)

--- a/schema.js
+++ b/schema.js
@@ -1,4 +1,4 @@
 module.exports = require('./dist/schema').default
-module.exports.nullOptions = require('./dist/tags/core').nullOptions
+module.exports.nullOptions = require('./dist/tags/options').nullOptions
 module.exports.stringify = require('./dist/stringify').default
 module.exports.strOptions = require('./dist/stringify').strOptions

--- a/schema.js
+++ b/schema.js
@@ -3,3 +3,5 @@ var opt = require('./dist/tags/options')
 module.exports.nullOptions = opt.nullOptions
 module.exports.strOptions = opt.strOptions
 module.exports.stringify = require('./dist/stringify').stringifyString
+
+require('./dist/deprecation').warn(__filename)

--- a/schema.js
+++ b/schema.js
@@ -2,4 +2,4 @@ module.exports = require('./dist/schema').default
 var opt = require('./dist/tags/options')
 module.exports.nullOptions = opt.nullOptions
 module.exports.strOptions = opt.strOptions
-module.exports.stringify = require('./dist/stringify').default
+module.exports.stringify = require('./dist/stringify').stringifyString

--- a/schema.js
+++ b/schema.js
@@ -1,4 +1,5 @@
 module.exports = require('./dist/schema').default
-module.exports.nullOptions = require('./dist/tags/options').nullOptions
+var opt = require('./dist/tags/options')
+module.exports.nullOptions = opt.nullOptions
+module.exports.strOptions = opt.strOptions
 module.exports.stringify = require('./dist/stringify').default
-module.exports.strOptions = require('./dist/stringify').strOptions

--- a/schema.js
+++ b/schema.js
@@ -1,4 +1,4 @@
-module.exports = require('./dist/schema')
-module.exports.nullOptions = require('./dist/schema/core').nullOptions
+module.exports = require('./dist/schema').default
+module.exports.nullOptions = require('./dist/tags/core').nullOptions
 module.exports.stringify = require('./dist/stringify').default
 module.exports.strOptions = require('./dist/stringify').strOptions

--- a/seq.js
+++ b/seq.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/schema/Seq')
+module.exports = require('./dist/schema/Seq').default

--- a/seq.js
+++ b/seq.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/schema/Seq').default
+require('./dist/deprecation').warn(__filename)

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -1,3 +1,4 @@
+/* global global, console */
 export function warn(filename) {
   if (global && global._YAML_SILENCE_DEPRECATION_WARNINGS) return
   const path = filename
@@ -8,6 +9,7 @@ export function warn(filename) {
   if (global && global.process && global.process.emitWarning) {
     global.process.emitWarning(msg, 'DeprecationWarning')
   } else {
+    // eslint-disable-next-line no-console
     console.warn(`DeprecationWarning: ${msg}`)
   }
 }

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -1,0 +1,13 @@
+export function warn(filename) {
+  if (global && global._YAML_SILENCE_DEPRECATION_WARNINGS) return
+  const path = filename
+    .replace(/.*yaml[/\\]/i, '')
+    .replace(/\.js$/, '')
+    .replace(/\\/g, '/')
+  const msg = `The endpoint 'yaml/${path}' will be removed in a future release.`
+  if (global && global.process && global.process.emitWarning) {
+    global.process.emitWarning(msg, 'DeprecationWarning')
+  } else {
+    console.warn(`DeprecationWarning: ${msg}`)
+  }
+}

--- a/src/schema/Map.js
+++ b/src/schema/Map.js
@@ -50,63 +50,16 @@ export default class YAMLMap extends Collection {
     else this.items.push(new Pair(key, value))
   }
 
-  toJSON(_, ctx) {
-    if (ctx && ctx.mapAsMap) return this.toJSMap(ctx)
-    const map = {}
+  /**
+   * @param {*} arg ignored
+   * @param {*} ctx Conversion context, originally set in Document#toJSON()
+   * @param {Class} Type If set, forces the returned collection type
+   * @returns {*} Instance of Type, Map, or Object
+   */
+  toJSON(_, ctx, Type) {
+    const map = Type ? new Type() : ctx && ctx.mapAsMap ? new Map() : {}
     if (ctx && ctx.onCreate) ctx.onCreate(map)
-    for (const item of this.items) {
-      if (item instanceof Merge) {
-        // If the value associated with a merge key is a single mapping node,
-        // each of its key/value pairs is inserted into the current mapping,
-        // unless the key already exists in it. If the value associated with the
-        // merge key is a sequence, then this sequence is expected to contain
-        // mapping nodes and each of these nodes is merged in turn according to
-        // its order in the sequence. Keys in mapping nodes earlier in the
-        // sequence override keys specified in later mapping nodes.
-        // -- http://yaml.org/type/merge.html
-        const keys = Object.keys(map)
-        const { items } = item.value
-        for (let i = items.length - 1; i >= 0; --i) {
-          const { source } = items[i]
-          if (source instanceof YAMLMap) {
-            const obj = source.toJSON('', ctx)
-            Object.keys(obj).forEach(key => {
-              if (!keys.includes(key)) map[key] = obj[key]
-            })
-          } else {
-            throw new Error('Merge sources must be maps')
-          }
-        }
-      } else {
-        const { stringKey, value } = item
-        map[stringKey] = toJSON(value, stringKey, ctx)
-      }
-    }
-    return map
-  }
-
-  toJSMap(ctx) {
-    const map = new Map()
-    if (ctx && ctx.onCreate) ctx.onCreate(map)
-    for (const item of this.items) {
-      if (item instanceof Merge) {
-        const { items } = item.value
-        for (let i = items.length - 1; i >= 0; --i) {
-          const { source } = items[i]
-          if (source instanceof YAMLMap) {
-            for (const [key, value] of source.toJSMap(ctx)) {
-              if (!map.has(key)) map.set(key, value)
-            }
-          } else {
-            throw new Error('Merge sources must be maps')
-          }
-        }
-      } else {
-        const key = toJSON(item.key, '', ctx)
-        const value = toJSON(item.value, key, ctx)
-        map.set(key, value)
-      }
-    }
+    for (const item of this.items) item.addToJSMap(ctx, map)
     return map
   }
 

--- a/src/schema/Map.js
+++ b/src/schema/Map.js
@@ -1,8 +1,4 @@
-// Published as 'yaml/map'
-
-import toJSON from '../toJSON'
 import Collection from './Collection'
-import Merge from './Merge'
 import Pair from './Pair'
 import Scalar from './Scalar'
 

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -27,13 +27,28 @@ export default class Schema {
     this.name = schema
     this.tags = schemas[schema.replace(/\W/g, '')] // 'yaml-1.1' -> 'yaml11'
     if (!this.tags) {
-      const keys = Object.keys(schemas).map(key => JSON.stringify(key))
-      throw new Error(`Unknown schema; use one of ${keys.join(', ')}`)
+      const keys = Object.keys(schemas)
+        .map(key => JSON.stringify(key))
+        .join(', ')
+      throw new Error(`Unknown schema "${schema}"; use one of ${keys}`)
     }
     if (Array.isArray(customTags)) {
       for (const tag of customTags) this.tags = this.tags.concat(tag)
     } else if (typeof customTags === 'function') {
       this.tags = customTags(this.tags.slice())
+    }
+    for (let i = 0; i < this.tags.length; ++i) {
+      const tag = this.tags[i]
+      if (typeof tag === 'string') {
+        const tagObj = tags[tag]
+        if (!tagObj) {
+          const keys = Object.keys(tags)
+            .map(key => JSON.stringify(key))
+            .join(', ')
+          throw new Error(`Unknown custom tag "${tag}"; use one of ${keys}`)
+        }
+        this.tags[i] = tagObj
+      }
     }
   }
 

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -239,12 +239,12 @@ export default class Schema {
     if (item instanceof Pair) return item.toString(ctx, onComment, onChompKeep)
     if (!tagObj) tagObj = this.getTagObject(item)
     const props = this.stringifyProps(item, tagObj, ctx)
-    const str = (tagObj.stringify || stringify)(
-      item,
-      ctx,
-      onComment,
-      onChompKeep
-    )
+    const str =
+      typeof tagObj.stringify === 'function'
+        ? tagObj.stringify(item, ctx, onComment, onChompKeep)
+        : item instanceof Collection
+        ? item.toString(ctx, onComment, onChompKeep)
+        : stringify(item, ctx, onComment, onChompKeep)
     return props
       ? item instanceof Collection && str[0] !== '{' && str[0] !== '['
         ? `${props}\n${ctx.indent}${str}`

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -96,6 +96,12 @@ export default class Schema {
     return obj.node
   }
 
+  createPair(key, value, ctx) {
+    const k = this.createNode(key, ctx.wrapScalars, null, ctx)
+    const v = this.createNode(value, ctx.wrapScalars, null, ctx)
+    return new Pair(k, v)
+  }
+
   // falls back to string on no match
   resolveScalar(str, tags) {
     if (!tags) tags = this.tags

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -1,6 +1,6 @@
 import { Type } from '../cst/Node'
 import { YAMLReferenceError, YAMLWarning } from '../errors'
-import stringify from '../stringify'
+import { stringifyString } from '../stringify'
 import core from '../tags/core'
 import failsafe from '../tags/failsafe'
 import map from '../tags/failsafe/map'
@@ -244,7 +244,7 @@ export default class Schema {
         ? tagObj.stringify(item, ctx, onComment, onChompKeep)
         : item instanceof Collection
         ? item.toString(ctx, onComment, onChompKeep)
-        : stringify(item, ctx, onComment, onChompKeep)
+        : stringifyString(item, ctx, onComment, onChompKeep)
     return props
       ? item instanceof Collection && str[0] !== '{' && str[0] !== '['
         ? `${props}\n${ctx.indent}${str}`

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -7,6 +7,15 @@ import foldFlowLines, {
 } from './foldFlowLines'
 import { strOptions } from './tags/options'
 
+export const stringifyNumber = ({ value }) =>
+  isFinite(value)
+    ? JSON.stringify(value)
+    : isNaN(value)
+    ? '.nan'
+    : value < 0
+    ? '-.inf'
+    : '.inf'
+
 function lineLengthOverLimit(str, limit) {
   const strLen = str.length
   if (strLen <= limit) return false

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -249,7 +249,7 @@ function plainString(item, ctx, onComment, onChompKeep) {
   return body
 }
 
-export default function stringify(item, ctx, onComment, onChompKeep) {
+export function stringifyString(item, ctx, onComment, onChompKeep) {
   const { defaultType } = strOptions
   const { implicitKey, inFlow } = ctx
   let { type, value } = item

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -5,18 +5,7 @@ import foldFlowLines, {
   FOLD_FLOW,
   FOLD_QUOTED
 } from './foldFlowLines'
-
-export const strOptions = {
-  defaultType: Type.PLAIN,
-  doubleQuoted: {
-    jsonEncoding: false,
-    minMultiLineLength: 40
-  },
-  fold: {
-    lineWidth: 80,
-    minContentWidth: 20
-  }
-}
+import { strOptions } from './tags/options'
 
 function lineLengthOverLimit(str, limit) {
   const strLen = str.length

--- a/src/tags/core.js
+++ b/src/tags/core.js
@@ -1,5 +1,6 @@
-import failsafe from './failsafe'
 import Scalar from '../schema/Scalar'
+import failsafe from './failsafe'
+import { boolOptions, nullOptions } from './options'
 
 export const stringifyNumber = ({ value }) =>
   isFinite(value)
@@ -9,8 +10,6 @@ export const stringifyNumber = ({ value }) =>
     : value < 0
     ? '-.inf'
     : '.inf'
-
-export const nullOptions = { nullStr: 'null' }
 
 export default failsafe.concat([
   {
@@ -30,7 +29,9 @@ export default failsafe.concat([
     tag: 'tag:yaml.org,2002:bool',
     test: /^(?:[Tt]rue|TRUE|[Ff]alse|FALSE)$/,
     resolve: str => str[0] === 't' || str[0] === 'T',
-    stringify: value => JSON.stringify(value)
+    options: boolOptions,
+    stringify: ({ value }) =>
+      value ? boolOptions.trueStr : boolOptions.falseStr
   },
   {
     identify: value => typeof value === 'number',

--- a/src/tags/core.js
+++ b/src/tags/core.js
@@ -1,15 +1,7 @@
 import Scalar from '../schema/Scalar'
+import { stringifyNumber } from '../stringify'
 import failsafe from './failsafe'
 import { boolOptions, nullOptions } from './options'
-
-export const stringifyNumber = ({ value }) =>
-  isFinite(value)
-    ? JSON.stringify(value)
-    : isNaN(value)
-    ? '.nan'
-    : value < 0
-    ? '-.inf'
-    : '.inf'
 
 export default failsafe.concat([
   {

--- a/src/tags/failsafe/map.js
+++ b/src/tags/failsafe/map.js
@@ -1,21 +1,14 @@
 import YAMLMap from '../../schema/Map'
-import Pair from '../../schema/Pair'
 import parseMap from '../../schema/parseMap'
 
-export function createMap(schema, obj, ctx) {
+function createMap(schema, obj, ctx) {
   const map = new YAMLMap()
   if (obj instanceof Map) {
-    for (const [key, value] of obj) {
-      const k = schema.createNode(key, ctx.wrapScalars, null, ctx)
-      const v = schema.createNode(value, ctx.wrapScalars, null, ctx)
-      map.items.push(new Pair(k, v))
-    }
+    for (const [key, value] of obj)
+      map.items.push(schema.createPair(key, value, ctx))
   } else if (obj && typeof obj === 'object') {
-    map.items = Object.keys(obj).map(key => {
-      const k = schema.createNode(key, ctx.wrapScalars, null, ctx)
-      const v = schema.createNode(obj[key], ctx.wrapScalars, null, ctx)
-      return new Pair(k, v)
-    })
+    for (const key of Object.keys(obj))
+      map.items.push(schema.createPair(key, obj[key], ctx))
   }
   return map
 }

--- a/src/tags/failsafe/map.js
+++ b/src/tags/failsafe/map.js
@@ -18,7 +18,5 @@ export default {
   default: true,
   nodeClass: YAMLMap,
   tag: 'tag:yaml.org,2002:map',
-  resolve: parseMap,
-  stringify: (value, ctx, onComment, onChompKeep) =>
-    value.toString(ctx, onComment, onChompKeep)
+  resolve: parseMap
 }

--- a/src/tags/failsafe/map.js
+++ b/src/tags/failsafe/map.js
@@ -2,7 +2,7 @@ import YAMLMap from '../../schema/Map'
 import Pair from '../../schema/Pair'
 import parseMap from '../../schema/parseMap'
 
-function createMap(schema, obj, ctx) {
+export function createMap(schema, obj, ctx) {
   const map = new YAMLMap()
   if (obj instanceof Map) {
     for (const [key, value] of obj) {

--- a/src/tags/failsafe/seq.js
+++ b/src/tags/failsafe/seq.js
@@ -17,7 +17,5 @@ export default {
   default: true,
   nodeClass: YAMLSeq,
   tag: 'tag:yaml.org,2002:seq',
-  resolve: parseSeq,
-  stringify: (value, ctx, onComment, onChompKeep) =>
-    value.toString(ctx, onComment, onChompKeep)
+  resolve: parseSeq
 }

--- a/src/tags/failsafe/seq.js
+++ b/src/tags/failsafe/seq.js
@@ -1,7 +1,7 @@
 import parseSeq from '../../schema/parseSeq'
 import YAMLSeq from '../../schema/Seq'
 
-export function createSeq(schema, obj, ctx) {
+function createSeq(schema, obj, ctx) {
   const seq = new YAMLSeq()
   if (obj && obj[Symbol.iterator]) {
     for (const it of obj) {

--- a/src/tags/failsafe/seq.js
+++ b/src/tags/failsafe/seq.js
@@ -1,7 +1,7 @@
 import parseSeq from '../../schema/parseSeq'
 import YAMLSeq from '../../schema/Seq'
 
-function createSeq(schema, obj, ctx) {
+export function createSeq(schema, obj, ctx) {
   const seq = new YAMLSeq()
   if (obj && obj[Symbol.iterator]) {
     for (const it of obj) {

--- a/src/tags/failsafe/string.js
+++ b/src/tags/failsafe/string.js
@@ -1,4 +1,4 @@
-import stringify from '../../stringify'
+import { stringifyString } from '../../stringify'
 import { strOptions } from '../options'
 
 export const resolveString = (doc, node) => {
@@ -20,7 +20,7 @@ export default {
   resolve: resolveString,
   stringify(item, ctx, onComment, onChompKeep) {
     ctx = Object.assign({ actualString: true }, ctx)
-    return stringify(item, ctx, onComment, onChompKeep)
+    return stringifyString(item, ctx, onComment, onChompKeep)
   },
   options: strOptions
 }

--- a/src/tags/failsafe/string.js
+++ b/src/tags/failsafe/string.js
@@ -1,4 +1,5 @@
-import stringify, { strOptions } from '../../stringify'
+import stringify from '../../stringify'
+import { strOptions } from '../options'
 
 export const resolveString = (doc, node) => {
   // on error, will return { str: string, errors: Error[] }

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -1,0 +1,25 @@
+import core from './core'
+import failsafe from './failsafe'
+import json from './json'
+import yaml11 from './yaml-1.1'
+
+import map from './failsafe/map'
+import seq from './failsafe/seq'
+import binary from './yaml-1.1/binary'
+import omap from './yaml-1.1/omap'
+import pairs from './yaml-1.1/pairs'
+import set from './yaml-1.1/set'
+import { floatTime, intTime, timestamp } from './yaml-1.1/timestamp'
+
+export const schemas = { core, failsafe, json, yaml11 }
+export const tags = {
+  binary,
+  floatTime,
+  intTime,
+  map,
+  omap,
+  pairs,
+  seq,
+  set,
+  timestamp
+}

--- a/src/tags/options.js
+++ b/src/tags/options.js
@@ -1,3 +1,17 @@
+import { Type } from '../cst/Node'
+
 export const boolOptions = { trueStr: 'true', falseStr: 'false' }
 
 export const nullOptions = { nullStr: 'null' }
+
+export const strOptions = {
+  defaultType: Type.PLAIN,
+  doubleQuoted: {
+    jsonEncoding: false,
+    minMultiLineLength: 40
+  },
+  fold: {
+    lineWidth: 80,
+    minContentWidth: 20
+  }
+}

--- a/src/tags/options.js
+++ b/src/tags/options.js
@@ -1,5 +1,10 @@
 import { Type } from '../cst/Node'
 
+export const binaryOptions = {
+  defaultType: Type.BLOCK_LITERAL,
+  lineWidth: 76
+}
+
 export const boolOptions = { trueStr: 'true', falseStr: 'false' }
 
 export const nullOptions = { nullStr: 'null' }

--- a/src/tags/options.js
+++ b/src/tags/options.js
@@ -1,0 +1,3 @@
+export const boolOptions = { trueStr: 'true', falseStr: 'false' }
+
+export const nullOptions = { nullStr: 'null' }

--- a/src/tags/yaml-1.1/binary.js
+++ b/src/tags/yaml-1.1/binary.js
@@ -1,13 +1,13 @@
 /* global atob, btoa, Buffer */
 
-// Published as 'yaml/types/binary'
-
 import { YAMLReferenceError } from '../../errors'
 import { Type } from '../../cst/Node'
 import stringify from '../../stringify'
 import { resolveString } from '../failsafe/string'
 
-export const binary = {
+const options = { defaultType: Type.BLOCK_LITERAL, lineWidth: 76 }
+
+export default {
   identify: value => value instanceof Uint8Array, // Buffer inherits from Uint8Array
   default: false,
   tag: 'tag:yaml.org,2002:binary',
@@ -38,7 +38,7 @@ export const binary = {
       return null
     }
   },
-  options: { defaultType: Type.BLOCK_LITERAL, lineWidth: 76 },
+  options,
   stringify: ({ comment, type, value }, ctx, onComment, onChompKeep) => {
     let src
     if (typeof Buffer === 'function') {
@@ -55,11 +55,11 @@ export const binary = {
         'This environment does not support writing binary tags; either Buffer or btoa is required'
       )
     }
-    if (!type) type = binary.options.defaultType
+    if (!type) type = options.defaultType
     if (type === Type.QUOTE_DOUBLE) {
       value = src
     } else {
-      const { lineWidth } = binary.options
+      const { lineWidth } = options
       const n = Math.ceil(src.length / lineWidth)
       const lines = new Array(n)
       for (let i = 0, o = 0; i < n; ++i, o += lineWidth) {
@@ -70,5 +70,3 @@ export const binary = {
     return stringify({ comment, type, value }, ctx, onComment, onChompKeep)
   }
 }
-
-export default [binary]

--- a/src/tags/yaml-1.1/binary.js
+++ b/src/tags/yaml-1.1/binary.js
@@ -4,8 +4,7 @@ import { YAMLReferenceError } from '../../errors'
 import { Type } from '../../cst/Node'
 import { stringifyString } from '../../stringify'
 import { resolveString } from '../failsafe/string'
-
-const options = { defaultType: Type.BLOCK_LITERAL, lineWidth: 76 }
+import { binaryOptions as options } from '../options'
 
 export default {
   identify: value => value instanceof Uint8Array, // Buffer inherits from Uint8Array

--- a/src/tags/yaml-1.1/binary.js
+++ b/src/tags/yaml-1.1/binary.js
@@ -2,7 +2,7 @@
 
 import { YAMLReferenceError } from '../../errors'
 import { Type } from '../../cst/Node'
-import stringify from '../../stringify'
+import { stringifyString } from '../../stringify'
 import { resolveString } from '../failsafe/string'
 
 const options = { defaultType: Type.BLOCK_LITERAL, lineWidth: 76 }
@@ -67,6 +67,11 @@ export default {
       }
       value = lines.join(type === Type.BLOCK_LITERAL ? '\n' : ' ')
     }
-    return stringify({ comment, type, value }, ctx, onComment, onChompKeep)
+    return stringifyString(
+      { comment, type, value },
+      ctx,
+      onComment,
+      onChompKeep
+    )
   }
 }

--- a/src/tags/yaml-1.1/index.js
+++ b/src/tags/yaml-1.1/index.js
@@ -1,5 +1,5 @@
 import Scalar from '../../schema/Scalar'
-import { stringifyNumber } from '../core'
+import { stringifyNumber } from '../../stringify'
 import failsafe from '../failsafe'
 import { boolOptions, nullOptions } from '../options'
 import binary from './binary'

--- a/src/tags/yaml-1.1/index.js
+++ b/src/tags/yaml-1.1/index.js
@@ -2,7 +2,7 @@ import binary from './binary'
 import omap from './omap'
 import pairs from './pairs'
 import set from './set'
-import timestamp from './timestamp'
+import { intTime, floatTime, timestamp } from './timestamp'
 import { stringifyNumber } from '../core'
 import failsafe from '../failsafe'
 import Scalar from '../../schema/Scalar'
@@ -104,5 +104,7 @@ export default failsafe.concat(
   omap,
   pairs,
   set,
+  intTime,
+  floatTime,
   timestamp
 )

--- a/src/tags/yaml-1.1/index.js
+++ b/src/tags/yaml-1.1/index.js
@@ -1,14 +1,12 @@
+import Scalar from '../../schema/Scalar'
+import { stringifyNumber } from '../core'
+import failsafe from '../failsafe'
+import { boolOptions, nullOptions } from '../options'
 import binary from './binary'
 import omap from './omap'
 import pairs from './pairs'
 import set from './set'
 import { intTime, floatTime, timestamp } from './timestamp'
-import { stringifyNumber } from '../core'
-import failsafe from '../failsafe'
-import Scalar from '../../schema/Scalar'
-
-export const nullOptions = { nullStr: 'null' }
-export const boolOptions = { trueStr: 'true', falseStr: 'false' }
 
 export default failsafe.concat(
   [

--- a/src/tags/yaml-1.1/omap.js
+++ b/src/tags/yaml-1.1/omap.js
@@ -68,7 +68,5 @@ export default {
   default: false,
   tag: 'tag:yaml.org,2002:omap',
   resolve: parseOMap,
-  createNode: createOMap,
-  stringify: (value, ctx, onComment, onChompKeep) =>
-    value.toString(ctx, onComment, onChompKeep)
+  createNode: createOMap
 }

--- a/src/tags/yaml-1.1/pairs.js
+++ b/src/tags/yaml-1.1/pairs.js
@@ -59,7 +59,5 @@ export default {
   default: false,
   tag: 'tag:yaml.org,2002:pairs',
   resolve: parsePairs,
-  createNode: createPairs,
-  stringify: (value, ctx, onComment, onChompKeep) =>
-    value.toString(ctx, onComment, onChompKeep)
+  createNode: createPairs
 }

--- a/src/tags/yaml-1.1/pairs.js
+++ b/src/tags/yaml-1.1/pairs.js
@@ -49,9 +49,8 @@ export function createPairs(schema, iterable, ctx) {
     } else {
       key = it
     }
-    const k = schema.createNode(key, ctx.wrapScalars, null, ctx)
-    const v = schema.createNode(value, ctx.wrapScalars, null, ctx)
-    pairs.items.push(new Pair(k, v))
+    const pair = schema.createPair(key, value, ctx)
+    pairs.items.push(pair)
   }
   return pairs
 }

--- a/src/tags/yaml-1.1/set.js
+++ b/src/tags/yaml-1.1/set.js
@@ -1,7 +1,5 @@
 import { YAMLSemanticError } from '../../errors'
-import toJSON from '../../toJSON'
 import YAMLMap, { findPair } from '../../schema/Map'
-import Merge from '../../schema/Merge'
 import Pair from '../../schema/Pair'
 import parseMap from '../../schema/parseMap'
 import Scalar from '../../schema/Scalar'

--- a/src/tags/yaml-1.1/set.js
+++ b/src/tags/yaml-1.1/set.js
@@ -91,7 +91,5 @@ export default {
   default: false,
   tag: 'tag:yaml.org,2002:set',
   resolve: parseSet,
-  createNode: createSet,
-  stringify: (value, ctx, onComment, onChompKeep) =>
-    value.toString(ctx, onComment, onChompKeep)
+  createNode: createSet
 }

--- a/src/tags/yaml-1.1/set.js
+++ b/src/tags/yaml-1.1/set.js
@@ -43,24 +43,7 @@ export class YAMLSet extends YAMLMap {
   }
 
   toJSON(_, ctx) {
-    const set = new Set()
-    if (ctx && ctx.onCreate) ctx.onCreate(set)
-    for (const item of this.items) {
-      if (item instanceof Merge) {
-        const { items } = item.value
-        for (let i = items.length - 1; i >= 0; --i) {
-          const { source } = items[i]
-          if (source instanceof YAMLMap) {
-            for (const [key] of source.toJSMap(ctx)) set.add(key)
-          } else {
-            throw new Error('Merge sources must be maps')
-          }
-        }
-      } else {
-        set.add(toJSON(item.key, '', ctx))
-      }
-    }
-    return set
+    return super.toJSON(_, ctx, Set)
   }
 
   toString(ctx, onComment, onChompKeep) {

--- a/src/tags/yaml-1.1/set.js
+++ b/src/tags/yaml-1.1/set.js
@@ -80,10 +80,8 @@ function parseSet(doc, cst) {
 
 function createSet(schema, iterable, ctx) {
   const set = new YAMLSet()
-  for (const value of iterable) {
-    const v = schema.createNode(value, ctx.wrapScalars, null, ctx)
-    set.items.push(new Pair(v))
-  }
+  for (const value of iterable)
+    set.items.push(schema.createPair(value, null, ctx))
   return set
 }
 

--- a/src/tags/yaml-1.1/timestamp.js
+++ b/src/tags/yaml-1.1/timestamp.js
@@ -1,5 +1,3 @@
-// Published as 'yaml/types/timestamp'
-
 import { stringifyNumber } from '../core'
 
 const parseSexagesimal = (sign, parts) => {
@@ -94,5 +92,3 @@ export const timestamp = {
   stringify: ({ value }) =>
     value.toISOString().replace(/((T00:00)?:00)?\.000Z$/, '')
 }
-
-export default [intTime, floatTime, timestamp]

--- a/src/tags/yaml-1.1/timestamp.js
+++ b/src/tags/yaml-1.1/timestamp.js
@@ -1,4 +1,4 @@
-import { stringifyNumber } from '../core'
+import { stringifyNumber } from '../../stringify'
 
 const parseSexagesimal = (sign, parts) => {
   const n = parts.split(':').reduce((n, p) => n * 60 + Number(p), 0)

--- a/tests/doc/YAML-1.2.spec.js
+++ b/tests/doc/YAML-1.2.spec.js
@@ -1,5 +1,5 @@
 import YAML from '../../src/index'
-import { strOptions } from '../../src/stringify'
+import { strOptions } from '../../src/tags/options'
 
 const spec = {
   '2.1. Collections': {

--- a/tests/doc/collection-access.js
+++ b/tests/doc/collection-access.js
@@ -179,9 +179,9 @@ describe('Set', () => {
   beforeEach(() => {
     set = doc.schema.createNode([1, 2, 3], true, '!!set')
     expect(set.items).toMatchObject([
-      { key: { value: 1 }, value: null },
-      { key: { value: 2 }, value: null },
-      { key: { value: 3 }, value: null }
+      { key: { value: 1 }, value: { value: null } },
+      { key: { value: 2 }, value: { value: null } },
+      { key: { value: 3 }, value: { value: null } }
     ])
   })
 
@@ -198,7 +198,10 @@ describe('Set', () => {
 
   test('get', () => {
     expect(set.get(1)).toBe(1)
-    expect(set.get(1, true)).toMatchObject({ key: { value: 1 }, value: null })
+    expect(set.get(1, true)).toMatchObject({
+      key: { value: 1 },
+      value: { value: null }
+    })
     expect(set.get(0)).toBeUndefined()
     expect(set.get('1')).toBeUndefined()
   })

--- a/tests/doc/foldFlowLines.js
+++ b/tests/doc/foldFlowLines.js
@@ -1,6 +1,6 @@
 import fold, { FOLD_FLOW, FOLD_QUOTED } from '../../src/foldFlowLines'
 import YAML from '../../src/index'
-import { strOptions } from '../../src/stringify'
+import { strOptions } from '../../src/tags/options'
 
 describe('plain', () => {
   const src = 'abc def ghi jkl mno pqr stu vwx yz\n'

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -1,5 +1,5 @@
 import YAML from '../../src/index'
-import stringify from '../../src/stringify'
+import { stringifyString } from '../../src/stringify'
 import { strOptions } from '../../src/tags/options'
 
 test('undefined', () => {
@@ -212,7 +212,7 @@ describe('eemeli/yaml#80: custom tags', () => {
       const key = Symbol.keyFor(item.value)
       if (key === undefined)
         throw new Error('Only shared symbols are supported')
-      return stringify({ value: key }, ctx, onComment, onChompKeep)
+      return stringifyString({ value: key }, ctx, onComment, onChompKeep)
     }
   }
 

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -1,5 +1,6 @@
 import YAML from '../../src/index'
-import stringify, { strOptions } from '../../src/stringify'
+import stringify from '../../src/stringify'
+import { strOptions } from '../../src/tags/options'
 
 test('undefined', () => {
   expect(YAML.stringify()).toBe('\n')

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -2,7 +2,7 @@ import YAML from '../../src/index'
 import { strOptions } from '../../src/stringify'
 import Scalar from '../../src/schema/Scalar'
 import YAMLSeq from '../../src/schema/Seq'
-import { binary } from '../../src/tags/yaml-1.1/binary'
+import binary from '../../src/tags/yaml-1.1/binary'
 import { YAMLOMap } from '../../src/tags/yaml-1.1/omap'
 import { YAMLSet } from '../../src/tags/yaml-1.1/set'
 

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -624,6 +624,16 @@ invoice:
       expect(bin).toBeInstanceOf(Uint8Array)
     })
 
+    test('tag string in tags', () => {
+      const bin = YAML.parse(src, { tags: ['binary'] })
+      expect(bin).toBeInstanceOf(Uint8Array)
+    })
+
+    test('tag string in tag array', () => {
+      const bin = YAML.parse(src, { tags: [['binary']] })
+      expect(bin).toBeInstanceOf(Uint8Array)
+    })
+
     test('no custom tag object', () => {
       const doc = YAML.parseDocument(src)
       const message =

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -1,7 +1,7 @@
 import YAML from '../../src/index'
-import { strOptions } from '../../src/stringify'
 import Scalar from '../../src/schema/Scalar'
 import YAMLSeq from '../../src/schema/Seq'
+import { strOptions } from '../../src/tags/options'
 import binary from '../../src/tags/yaml-1.1/binary'
 import { YAMLOMap } from '../../src/tags/yaml-1.1/omap'
 import { YAMLSet } from '../../src/tags/yaml-1.1/set'

--- a/tests/yaml-test-suite.js
+++ b/tests/yaml-test-suite.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 
 import YAML from '../src/index'
-import { strOptions } from '../src/stringify'
+import { strOptions } from '../src/tags/options'
 import testEvents from '../src/test-events'
 
 const testDirs = fs

--- a/types.js
+++ b/types.js
@@ -1,0 +1,18 @@
+exports.Schema = require('./dist/schema').default
+exports.nullOptions = require('./dist/tags/core').nullOptions
+exports.strOptions = require('./dist/stringify').strOptions
+
+exports.Map = exports.YAMLMap = require('./dist/schema/Map').default
+exports.Seq = exports.YAMLSeq = require('./dist/schema/Seq').default
+exports.Pair = require('./dist/schema/Pair').default
+exports.Scalar = require('./dist/schema/Scalar').default
+
+exports.binary = require('./dist/tags/yaml-1.1/binary').default
+exports.omap = require('./dist/tags/yaml-1.1/omap').default
+exports.pairs = require('./dist/tags/yaml-1.1/pairs').default
+exports.set = require('./dist/tags/yaml-1.1/set').default
+
+var ts = require('./dist/tags/yaml-1.1/timestamp')
+exports.floatTime = ts.floatTime
+exports.intTime = ts.intTime
+exports.timestamp = ts.timestamp

--- a/types.js
+++ b/types.js
@@ -1,7 +1,9 @@
-exports.Schema = require('./dist/schema').default
-exports.nullOptions = require('./dist/tags/core').nullOptions
+var opt = require('./dist/tags/options')
+exports.boolOptions = opt.boolOptions
+exports.nullOptions = opt.nullOptions
 exports.strOptions = require('./dist/stringify').strOptions
 
+exports.Schema = require('./dist/schema').default
 exports.Map = exports.YAMLMap = require('./dist/schema/Map').default
 exports.Seq = exports.YAMLSeq = require('./dist/schema/Seq').default
 exports.Pair = require('./dist/schema/Pair').default

--- a/types.js
+++ b/types.js
@@ -1,11 +1,11 @@
 var opt = require('./dist/tags/options')
 exports.boolOptions = opt.boolOptions
 exports.nullOptions = opt.nullOptions
-exports.strOptions = require('./dist/stringify').strOptions
+exports.strOptions = opt.strOptions
 
 exports.Schema = require('./dist/schema').default
-exports.Map = exports.YAMLMap = require('./dist/schema/Map').default
-exports.Seq = exports.YAMLSeq = require('./dist/schema/Seq').default
+exports.YAMLMap = require('./dist/schema/Map').default
+exports.YAMLSeq = require('./dist/schema/Seq').default
 exports.Pair = require('./dist/schema/Pair').default
 exports.Scalar = require('./dist/schema/Scalar').default
 

--- a/types.js
+++ b/types.js
@@ -1,4 +1,5 @@
 var opt = require('./dist/tags/options')
+exports.binaryOptions = opt.binaryOptions
 exports.boolOptions = opt.boolOptions
 exports.nullOptions = opt.nullOptions
 exports.strOptions = opt.strOptions
@@ -8,13 +9,3 @@ exports.YAMLMap = require('./dist/schema/Map').default
 exports.YAMLSeq = require('./dist/schema/Seq').default
 exports.Pair = require('./dist/schema/Pair').default
 exports.Scalar = require('./dist/schema/Scalar').default
-
-exports.binary = require('./dist/tags/yaml-1.1/binary').default
-exports.omap = require('./dist/tags/yaml-1.1/omap').default
-exports.pairs = require('./dist/tags/yaml-1.1/pairs').default
-exports.set = require('./dist/tags/yaml-1.1/set').default
-
-var ts = require('./dist/tags/yaml-1.1/timestamp')
-exports.floatTime = ts.floatTime
-exports.intTime = ts.intTime
-exports.timestamp = ts.timestamp

--- a/types/binary.js
+++ b/types/binary.js
@@ -1,1 +1,5 @@
-module.exports = require('../dist/tags/yaml-1.1/binary')
+'use strict'
+Object.defineProperty(exports, '__esModule', { value: true })
+
+exports.binary = require('../dist/tags/yaml-1.1/binary').default
+exports.default = [exports.binary]

--- a/types/binary.js
+++ b/types/binary.js
@@ -3,3 +3,5 @@ Object.defineProperty(exports, '__esModule', { value: true })
 
 exports.binary = require('../dist/tags/yaml-1.1/binary').default
 exports.default = [exports.binary]
+
+require('../dist/deprecation').warn(__filename)

--- a/types/omap.js
+++ b/types/omap.js
@@ -1,1 +1,2 @@
 module.exports = require('../dist/tags/yaml-1.1/omap').default
+require('../dist/deprecation').warn(__filename)

--- a/types/pairs.js
+++ b/types/pairs.js
@@ -1,1 +1,2 @@
 module.exports = require('../dist/tags/yaml-1.1/pairs').default
+require('../dist/deprecation').warn(__filename)

--- a/types/set.js
+++ b/types/set.js
@@ -1,1 +1,2 @@
 module.exports = require('../dist/tags/yaml-1.1/set').default
+require('../dist/deprecation').warn(__filename)

--- a/types/timestamp.js
+++ b/types/timestamp.js
@@ -6,3 +6,5 @@ exports.default = [ts.intTime, ts.floatTime, ts.timestamp]
 exports.floatTime = ts.floatTime
 exports.intTime = ts.intTime
 exports.timestamp = ts.timestamp
+
+require('../dist/deprecation').warn(__filename)

--- a/types/timestamp.js
+++ b/types/timestamp.js
@@ -1,1 +1,8 @@
-module.exports = require('../dist/tags/yaml-1.1/timestamp')
+'use strict'
+Object.defineProperty(exports, '__esModule', { value: true })
+
+var ts = require('../dist/tags/yaml-1.1/timestamp')
+exports.default = [ts.intTime, ts.floatTime, ts.timestamp]
+exports.floatTime = ts.floatTime
+exports.intTime = ts.intTime
+exports.timestamp = ts.timestamp

--- a/util.js
+++ b/util.js
@@ -1,0 +1,16 @@
+exports.createMap = require('./dist/tags/failsafe/map').createMap
+exports.createSeq = require('./dist/tags/failsafe/seq').createSeq
+exports.findPair = require('./dist/schema/Map').findPair
+exports.parseMap = require('./dist/schema/parseMap').default
+exports.parseSeq = require('./dist/schema/parseSeq').default
+
+exports.stringifyNumber = require('./dist/tags/core').stringifyNumber
+exports.stringifyString = require('./dist/stringify').default
+exports.toJSON = require('./dist/toJSON').default
+exports.Type = require('./dist/cst/Node').Type
+
+var err = require('./dist/errors')
+exports.YAMLReferenceError = err.YAMLReferenceError
+exports.YAMLSemanticError = err.YAMLSemanticError
+exports.YAMLSyntaxError = err.YAMLSyntaxError
+exports.YAMLWarning = err.YAMLWarning

--- a/util.js
+++ b/util.js
@@ -2,8 +2,9 @@ exports.findPair = require('./dist/schema/Map').findPair
 exports.parseMap = require('./dist/schema/parseMap').default
 exports.parseSeq = require('./dist/schema/parseSeq').default
 
-exports.stringifyNumber = require('./dist/tags/core').stringifyNumber
-exports.stringifyString = require('./dist/stringify').stringifyString
+var str = require('./dist/stringify')
+exports.stringifyNumber = str.stringifyNumber
+exports.stringifyString = str.stringifyString
 exports.toJSON = require('./dist/toJSON').default
 exports.Type = require('./dist/cst/Node').Type
 

--- a/util.js
+++ b/util.js
@@ -3,7 +3,7 @@ exports.parseMap = require('./dist/schema/parseMap').default
 exports.parseSeq = require('./dist/schema/parseSeq').default
 
 exports.stringifyNumber = require('./dist/tags/core').stringifyNumber
-exports.stringifyString = require('./dist/stringify').default
+exports.stringifyString = require('./dist/stringify').stringifyString
 exports.toJSON = require('./dist/toJSON').default
 exports.Type = require('./dist/cst/Node').Type
 

--- a/util.js
+++ b/util.js
@@ -1,5 +1,3 @@
-exports.createMap = require('./dist/tags/failsafe/map').createMap
-exports.createSeq = require('./dist/tags/failsafe/seq').createSeq
 exports.findPair = require('./dist/schema/Map').findPair
 exports.parseMap = require('./dist/schema/parseMap').default
 exports.parseSeq = require('./dist/schema/parseSeq').default


### PR DESCRIPTION
Closes #94; see also #89.

After this, the public API will be:

```js
const YAML = require('yaml')
const parseCST = require('yaml/parse-cst')

const {
  binaryOptions, boolOptions, nullOptions, strOptions,
  Pair,
  Scalar,
  Schema,
  YAMLMap,
  YAMLSeq
} = require('yaml/types')

const {
  findPair,
  parseMap, parseSeq,
  stringifyNumber, stringifyString,
  toJSON,
  Type,
  YAMLReferenceError, YAMLSemanticError, YAMLSyntaxError, YAMLWarning
} = require('yaml/util')
```

The previous endpoints (e.g. `yaml/schema`, `yaml/types/omap`, etc.) will still work, but they should be considered deprecated and liable to be removed in the next major update.

The built-in custom tags are now available using string identifiers, so they don't need to be publicly exported, e.g. `YAML.parse(src, { tags: ['intTime', 'omap'] })`

In related changes, this PR drops babel-plugin-add-module-exports, using instead a custom non-compiled `main` export, and improves the API for writing custom types.

**Edit:** Updated API description with changes made in 4f9d104