### PR TITLE
Rename tags option as customTags

### DIFF
--- a/map.js
+++ b/map.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/schema/Map').default
-require('./dist/deprecation').warn(__filename)
+require('./dist/deprecation').warnFileDeprecation(__filename)

--- a/pair.js
+++ b/pair.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/schema/Pair').default
-require('./dist/deprecation').warn(__filename)
+require('./dist/deprecation').warnFileDeprecation(__filename)

--- a/scalar.js
+++ b/scalar.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/schema/Scalar').default
-require('./dist/deprecation').warn(__filename)
+require('./dist/deprecation').warnFileDeprecation(__filename)

--- a/schema.js
+++ b/schema.js
@@ -4,4 +4,4 @@ module.exports.nullOptions = opt.nullOptions
 module.exports.strOptions = opt.strOptions
 module.exports.stringify = require('./dist/stringify').stringifyString
 
-require('./dist/deprecation').warn(__filename)
+require('./dist/deprecation').warnFileDeprecation(__filename)

--- a/seq.js
+++ b/seq.js
@@ -1,2 +1,2 @@
 module.exports = require('./dist/schema/Seq').default
-require('./dist/deprecation').warn(__filename)
+require('./dist/deprecation').warnFileDeprecation(__filename)

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -1,5 +1,5 @@
 /* global global, console */
-export function warn(filename) {
+export function warnFileDeprecation(filename) {
   if (global && global._YAML_SILENCE_DEPRECATION_WARNINGS) return
   const path = filename
     .replace(/.*yaml[/\\]/i, '')

--- a/src/deprecation.js
+++ b/src/deprecation.js
@@ -1,15 +1,29 @@
 /* global global, console */
-export function warnFileDeprecation(filename) {
-  if (global && global._YAML_SILENCE_DEPRECATION_WARNINGS) return
-  const path = filename
-    .replace(/.*yaml[/\\]/i, '')
-    .replace(/\.js$/, '')
-    .replace(/\\/g, '/')
-  const msg = `The endpoint 'yaml/${path}' will be removed in a future release.`
+
+function warn(msg) {
   if (global && global.process && global.process.emitWarning) {
     global.process.emitWarning(msg, 'DeprecationWarning')
   } else {
     // eslint-disable-next-line no-console
     console.warn(`DeprecationWarning: ${msg}`)
   }
+}
+
+export function warnFileDeprecation(filename) {
+  if (global && global._YAML_SILENCE_DEPRECATION_WARNINGS) return
+  const path = filename
+    .replace(/.*yaml[/\\]/i, '')
+    .replace(/\.js$/, '')
+    .replace(/\\/g, '/')
+  warn(`The endpoint 'yaml/${path}' will be removed in a future release.`)
+}
+
+const warned = {}
+export function warnOptionDeprecation(name, alternative) {
+  if (global && global._YAML_SILENCE_DEPRECATION_WARNINGS) return
+  if (warned[name]) return
+  warned[name] = true
+  let msg = `The option '${name}' will be removed in a future release`
+  msg += alternative ? `, use '${alternative}' instead.` : '.'
+  warn(msg)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const defaultOptions = {
   keepBlobsInJSON: true,
   mapAsMap: false,
   maxAliasCount: 100,
-  tags: null,
+  customTags: null,
   version: '1.2'
 }
 

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -1,3 +1,4 @@
+import { warnOptionDeprecation } from '../deprecation'
 import { Type } from '../constants'
 import { YAMLReferenceError, YAMLWarning } from '../errors'
 import { stringifyString } from '../stringify'
@@ -22,7 +23,7 @@ export default class Schema {
     STR: 'tag:yaml.org,2002:str'
   }
 
-  constructor({ merge, schema, tags: customTags }) {
+  constructor({ customTags, merge, schema, tags: deprecatedCustomTags }) {
     this.merge = !!merge
     this.name = schema
     this.tags = schemas[schema.replace(/\W/g, '')] // 'yaml-1.1' -> 'yaml11'
@@ -31,6 +32,10 @@ export default class Schema {
         .map(key => JSON.stringify(key))
         .join(', ')
       throw new Error(`Unknown schema "${schema}"; use one of ${keys}`)
+    }
+    if (!customTags && deprecatedCustomTags) {
+      customTags = deprecatedCustomTags
+      warnOptionDeprecation('tags', 'customTags')
     }
     if (Array.isArray(customTags)) {
       for (const tag of customTags) this.tags = this.tags.concat(tag)

--- a/tests/doc/YAML-1.2.spec.js
+++ b/tests/doc/YAML-1.2.spec.js
@@ -678,7 +678,7 @@ alias: *anchor`,
           tag: '!local',
           resolve: (doc, node) => 'local:' + node.strValue
         }
-        const res = YAML.parse(src, { tags: [tag] })
+        const res = YAML.parse(src, { customTags: [tag] })
         expect(res).toMatchObject({
           anchored: 'local:value',
           alias: 'local:value'
@@ -995,7 +995,7 @@ bar`,
         ]
       ],
       special: src => {
-        const tags = [
+        const customTags = [
           {
             tag: '!foo',
             resolve: () => 'private'
@@ -1005,7 +1005,7 @@ bar`,
             resolve: () => 'global'
           }
         ]
-        const docs = YAML.parseAllDocuments(src, { tags })
+        const docs = YAML.parseAllDocuments(src, { customTags })
         expect(docs.map(d => d.toJSON())).toMatchObject(['private', 'global'])
       }
     },
@@ -1025,7 +1025,7 @@ bar`,
           tag: 'tag:example.com,2000:app/int',
           resolve: () => 'interval'
         }
-        const res = YAML.parse(src, { tags: [tag] })
+        const res = YAML.parse(src, { customTags: [tag] })
         expect(res).toBe('interval')
       }
     },
@@ -1045,7 +1045,7 @@ bar`,
           tag: 'tag:example.com,2000:app/foo',
           resolve: (doc, node) => 'foo' + node.strValue
         }
-        const res = YAML.parse(src, { tags: [tag] })
+        const res = YAML.parse(src, { customTags: [tag] })
         expect(res).toBe('foobar')
       }
     },
@@ -1072,7 +1072,7 @@ bar`,
           tag: '!my-light',
           resolve: (doc, node) => 'light:' + node.strValue
         }
-        const docs = YAML.parseAllDocuments(src, { tags: [tag] })
+        const docs = YAML.parseAllDocuments(src, { customTags: [tag] })
         expect(docs.map(d => d.toJSON())).toMatchObject([
           'light:fluorescent',
           'light:green'
@@ -1095,7 +1095,7 @@ bar`,
           tag: 'tag:example.com,2000:app/foo',
           resolve: (doc, node) => 'foo' + node.strValue
         }
-        const res = YAML.parse(src, { tags: [tag] })
+        const res = YAML.parse(src, { customTags: [tag] })
         expect(res).toMatchObject(['foobar'])
       }
     }
@@ -1120,7 +1120,7 @@ bar`,
           tag: '!bar',
           resolve: (doc, node) => 'bar' + node.strValue
         }
-        const res = YAML.parse(src, { tags: [tag] })
+        const res = YAML.parse(src, { customTags: [tag] })
         expect(res).toMatchObject({ foo: 'barbaz' })
       }
     },
@@ -1149,7 +1149,7 @@ bar`,
         ]
       ],
       special: src => {
-        const tags = [
+        const customTags = [
           {
             tag: '!local',
             resolve: (doc, node) => 'local:' + node.strValue
@@ -1159,7 +1159,7 @@ bar`,
             resolve: (doc, node) => 'tag!' + node.strValue
           }
         ]
-        const res = YAML.parse(src, { tags })
+        const res = YAML.parse(src, { customTags })
         expect(res).toMatchObject(['local:foo', 'bar', 'tag!baz'])
       }
     },
@@ -1712,7 +1712,7 @@ folded:
           tag: '!foo',
           resolve: (doc, node) => 'foo' + node.strValue
         }
-        const res = YAML.parse(src, { tags: [tag] })
+        const res = YAML.parse(src, { customTags: [tag] })
         expect(res).toMatchObject({ literal: 'value\n', folded: 'foovalue\n' })
       }
     },

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -230,11 +230,11 @@ describe('eemeli/yaml#80: custom tags', () => {
   }
 
   beforeAll(() => {
-    YAML.defaultOptions.tags = [regexp, sharedSymbol]
+    YAML.defaultOptions.customTags = [regexp, sharedSymbol]
   })
 
   afterAll(() => {
-    YAML.defaultOptions.tags = []
+    YAML.defaultOptions.customTags = []
   })
 
   describe('RegExp', () => {

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -615,22 +615,22 @@ invoice:
       AgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYNG84BwwEeECcgggoBADs=`
 
     test('tag object in tags', () => {
-      const bin = YAML.parse(src, { tags: [binary] })
+      const bin = YAML.parse(src, { customTags: [binary] })
       expect(bin).toBeInstanceOf(Uint8Array)
     })
 
     test('tag array in tags', () => {
-      const bin = YAML.parse(src, { tags: [[binary]] })
+      const bin = YAML.parse(src, { customTags: [[binary]] })
       expect(bin).toBeInstanceOf(Uint8Array)
     })
 
     test('tag string in tags', () => {
-      const bin = YAML.parse(src, { tags: ['binary'] })
+      const bin = YAML.parse(src, { customTags: ['binary'] })
       expect(bin).toBeInstanceOf(Uint8Array)
     })
 
     test('tag string in tag array', () => {
-      const bin = YAML.parse(src, { tags: [['binary']] })
+      const bin = YAML.parse(src, { customTags: [['binary']] })
       expect(bin).toBeInstanceOf(Uint8Array)
     })
 

--- a/types/binary.js
+++ b/types/binary.js
@@ -4,4 +4,4 @@ Object.defineProperty(exports, '__esModule', { value: true })
 exports.binary = require('../dist/tags/yaml-1.1/binary').default
 exports.default = [exports.binary]
 
-require('../dist/deprecation').warn(__filename)
+require('../dist/deprecation').warnFileDeprecation(__filename)

--- a/types/omap.js
+++ b/types/omap.js
@@ -1,2 +1,2 @@
 module.exports = require('../dist/tags/yaml-1.1/omap').default
-require('../dist/deprecation').warn(__filename)
+require('../dist/deprecation').warnFileDeprecation(__filename)

--- a/types/pairs.js
+++ b/types/pairs.js
@@ -1,2 +1,2 @@
 module.exports = require('../dist/tags/yaml-1.1/pairs').default
-require('../dist/deprecation').warn(__filename)
+require('../dist/deprecation').warnFileDeprecation(__filename)

--- a/types/set.js
+++ b/types/set.js
@@ -1,2 +1,2 @@
 module.exports = require('../dist/tags/yaml-1.1/set').default
-require('../dist/deprecation').warn(__filename)
+require('../dist/deprecation').warnFileDeprecation(__filename)

--- a/types/timestamp.js
+++ b/types/timestamp.js
@@ -7,4 +7,4 @@ exports.floatTime = ts.floatTime
 exports.intTime = ts.intTime
 exports.timestamp = ts.timestamp
 
-require('../dist/deprecation').warn(__filename)
+require('../dist/deprecation').warnFileDeprecation(__filename)


### PR DESCRIPTION
I've started to think that it's unclear to call the custom tags option just `tags`, as there are of course additional tags as well that'll be used by the schema. So I'm here renaming it as `customTags`. Using the old name will still work, but will now produce a deprecation warning.

In node environments the warning uses [`process.emitWarning`](https://nodejs.org/api/process.html#process_process_emitwarning_warning_options) internally, so its behaviour can be controlled by the `--{throw,no,trace}-deprecation` command-line options. Additionally, setting a global `_YAML_SILENCE_DEPRECATION_WARNINGS` to true will also silence the warnings.