### PR TITLE
[perf/stringify]: Use a Map for prevObjects in createNode

### DIFF
--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -103,14 +103,14 @@ export default class Schema {
     }
     const obj = {}
     if (value && typeof value === 'object' && ctx.prevObjects) {
-      const prev = ctx.prevObjects.find(o => o.value === value)
+      const prev = ctx.prevObjects.get(value)
       if (prev) {
         const alias = new Alias(prev) // leaves source dirty; must be cleaned by caller
         ctx.aliasNodes.push(alias)
         return alias
       }
       obj.value = value
-      ctx.prevObjects.push(obj)
+      ctx.prevObjects.set(value, obj)
     }
     obj.node = tagObj.createNode
       ? tagObj.createNode(this, value, ctx)
@@ -247,7 +247,7 @@ export default class Schema {
       const createCtx = {
         aliasNodes: [],
         onTagObj: o => (tagObj = o),
-        prevObjects: []
+        prevObjects: new Map()
       }
       item = this.createNode(item, true, null, createCtx)
       const { anchors } = ctx.doc


### PR DESCRIPTION
Using the `Array.find` method for `prevObjects` seems to be a serious bottleneck in the `stringify` method (`src/schema/index` `createNode` method).

On a [14Mb YAML file](https://raw.githubusercontent.com/APIs-guru/openapi-directory/master/APIs/microsoft.com/graph/1.0.1/openapi.yaml), with this change, time to run `stringify` dropped from around 4 minutes to 4 seconds on my machine.

I get the same test results before and after.