### PR TITLE
Use named exports internally + update browser endpoints

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,14 +1,15 @@
-const isBrowser = process.env.BABEL_ENV === 'browser'
-
-const envOptions = isBrowser
-  ? { modules: false, useBuiltIns: false }
-  : { targets: { node: '6.5' }, useBuiltIns: false }
-const presets = [['@babel/env', envOptions]]
-
 const plugins = [
   '@babel/plugin-proposal-class-properties',
   ['babel-plugin-trace', { strip: true }]
 ]
-if (isBrowser) plugins.push('@babel/plugin-transform-runtime')
+const envOptions = { modules: false, useBuiltIns: false }
 
+if (process.env.BABEL_ENV === 'browser') {
+  plugins.push('@babel/plugin-transform-runtime')
+} else {
+  plugins.push(['@babel/plugin-transform-modules-commonjs', { strict: true }])
+  envOptions.targets = { node: '6.5' }
+}
+
+const presets = [['@babel/env', envOptions]]
 module.exports = { presets, plugins }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .*
-browser/
 coverage/
 dist/
 node_modules/

--- a/browser/index.js
+++ b/browser/index.js
@@ -1,0 +1,1 @@
+export { YAML as default } from './dist'

--- a/browser/map.js
+++ b/browser/map.js
@@ -1,0 +1,4 @@
+export { YAMLMap as default } from './dist/schema/Map'
+
+import { warnFileDeprecation } from './dist/warnings'
+warnFileDeprecation(__filename)

--- a/browser/pair.js
+++ b/browser/pair.js
@@ -1,0 +1,4 @@
+export { Pair as default } from './dist/schema/Pair'
+
+import { warnFileDeprecation } from './dist/warnings'
+warnFileDeprecation(__filename)

--- a/browser/parse-cst.js
+++ b/browser/parse-cst.js
@@ -1,0 +1,1 @@
+export { parse as default } from './dist/cst/parse'

--- a/browser/scalar.js
+++ b/browser/scalar.js
@@ -1,0 +1,4 @@
+export { Scalar as default } from './dist/schema/Scalar'
+
+import { warnFileDeprecation } from './dist/warnings'
+warnFileDeprecation(__filename)

--- a/browser/schema.js
+++ b/browser/schema.js
@@ -1,0 +1,12 @@
+import { Schema } from './dist/schema'
+import { nullOptions, strOptions } from './dist/tags/options'
+import { stringifyString } from './dist/stringify'
+
+Schema.nullOptions = nullOptions
+Schema.strOptions = strOptions
+Schema.stringify = stringifyString
+export { Schema as default }
+export { nullOptions, strOptions, stringifyString as stringify }
+
+import { warnFileDeprecation } from './dist/warnings'
+warnFileDeprecation(__filename)

--- a/browser/seq.js
+++ b/browser/seq.js
@@ -1,0 +1,4 @@
+export { YAMLSeq as default } from './dist/schema/Seq'
+
+import { warnFileDeprecation } from './dist/warnings'
+warnFileDeprecation(__filename)

--- a/browser/types.js
+++ b/browser/types.js
@@ -1,0 +1,12 @@
+export {
+  binaryOptions,
+  boolOptions,
+  nullOptions,
+  strOptions
+} from './dist/tags/options'
+
+export { Schema } from './dist/schema'
+export { YAMLMap } from './dist/schema/Map'
+export { YAMLSeq } from './dist/schema/Seq'
+export { Pair } from './dist/schema/Pair'
+export { Scalar } from './dist/schema/Scalar'

--- a/browser/types/binary.js
+++ b/browser/types/binary.js
@@ -1,0 +1,6 @@
+import { binary } from '../dist/tags/yaml-1.1/binary'
+export { binary }
+export default [binary]
+
+import { warnFileDeprecation } from './dist/warnings'
+warnFileDeprecation(__filename)

--- a/browser/types/omap.js
+++ b/browser/types/omap.js
@@ -1,0 +1,4 @@
+export { omap as default } from '../dist/tags/yaml-1.1/omap'
+
+import { warnFileDeprecation } from './dist/warnings'
+warnFileDeprecation(__filename)

--- a/browser/types/pairs.js
+++ b/browser/types/pairs.js
@@ -1,0 +1,4 @@
+export { pairs as default } from '../dist/tags/yaml-1.1/pairs'
+
+import { warnFileDeprecation } from './dist/warnings'
+warnFileDeprecation(__filename)

--- a/browser/types/set.js
+++ b/browser/types/set.js
@@ -1,0 +1,4 @@
+export { set as default } from '../dist/tags/yaml-1.1/set'
+
+import { warnFileDeprecation } from './dist/warnings'
+warnFileDeprecation(__filename)

--- a/browser/types/timestamp.js
+++ b/browser/types/timestamp.js
@@ -1,0 +1,6 @@
+import { floatTime, intTime, timestamp } from '../dist/tags/yaml-1.1/timestamp'
+export { floatTime, intTime, timestamp }
+export default [intTime, floatTime, timestamp]
+
+import { warnFileDeprecation } from './dist/warnings'
+warnFileDeprecation(__filename)

--- a/browser/util.js
+++ b/browser/util.js
@@ -1,0 +1,17 @@
+export { findPair } from './dist/schema/Map'
+export { parseMap } from './dist/schema/parseMap'
+export { parseSeq } from './dist/schema/parseSeq'
+
+export {
+  stringifyNumber,
+  stringifyString,
+  toJSON,
+  Type
+} from './dist/stringify'
+
+export {
+  YAMLReferenceError,
+  YAMLSemanticError,
+  YAMLSyntaxError,
+  YAMLWarning
+} from './dist/errors'

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist').default
+module.exports = require('./dist').YAML

--- a/map.js
+++ b/map.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/schema/Map').default
+module.exports = require('./dist/schema/Map').YAMLMap
 require('./dist/warnings').warnFileDeprecation(__filename)

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,33 +31,34 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.8.6.tgz",
-      "integrity": "sha512-CurCIKPTkS25Mb8mz267vU95vy+TyUpnctEX2lV33xWNmHAfjruztgiPBbXZRh3xZZy1CYvGx6XfxyTVS+sk7Q==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.9.0.tgz",
+      "integrity": "sha512-zeFQrr+284Ekvd9e7KAX954LkapWiOmQtsfHirhxqfdlX6MEC32iRE+pqUGlYIBchdevaCwvzxWGSy/YBNI85g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.5",
+        "browserslist": "^4.9.1",
         "invariant": "^2.2.4",
         "semver": "^5.5.0"
       }
     },
     "@babel/core": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.7.tgz",
-      "integrity": "sha512-rBlqF3Yko9cynC5CCFy6+K/w2N+Sq/ff2BPy+Krp7rHlABIr5epbA7OxVeKoMHB39LZOp1UY5SuLjy6uWi35yA==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.7",
-        "@babel/helpers": "^7.8.4",
-        "@babel/parser": "^7.8.7",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helpers": "^7.9.0",
+        "@babel/parser": "^7.9.0",
         "@babel/template": "^7.8.6",
-        "@babel/traverse": "^7.8.6",
-        "@babel/types": "^7.8.7",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
-        "json5": "^2.1.0",
+        "json5": "^2.1.2",
         "lodash": "^4.17.13",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
@@ -82,12 +83,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.7.tgz",
-      "integrity": "sha512-DQwjiKJqH4C3qGiyQCAExJHoZssn49JTMJgZ8SANGgVFdkupcUhLOdkAeoC6kmHZCPfoDG5M0b6cFlSN5wW7Ew==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.0.tgz",
+      "integrity": "sha512-onl4Oy46oGCzymOXtKMQpI7VXtCbTSHK1kqBydZ6AmzuNcacEVqGk9tZtAS+48IA9IstZcDCgIg8hQKnb7suRw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.7",
+        "@babel/types": "^7.9.0",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -151,14 +152,14 @@
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.6.tgz",
-      "integrity": "sha512-bPyujWfsHhV/ztUkwGHz/RPV1T1TDEsSZDsN42JPehndA+p1KKTh3npvTadux0ZhCrytx9tvjpWNowKby3tM6A==",
+      "version": "7.8.8",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz",
+      "integrity": "sha512-LYVPdwkrQEiX9+1R29Ld/wTrmQu1SSKYnuOk3g0CkcZMA1p0gsNxJFj/3gBdaJ7Cg0Fnek5z0DsMULePP7Lrqg==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.8.3",
         "@babel/helper-regex": "^7.8.3",
-        "regexpu-core": "^4.6.0"
+        "regexpu-core": "^4.7.0"
       }
     },
     "@babel/helper-define-map": {
@@ -230,9 +231,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.8.6.tgz",
-      "integrity": "sha512-RDnGJSR5EFBJjG3deY0NiL0K9TO8SXxS9n/MPsbPK/s9LbQymuLNtlzvDiNS7IpecuL45cMeLVkA+HfmlrnkRg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+      "integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.8.3",
@@ -240,7 +241,7 @@
         "@babel/helper-simple-access": "^7.8.3",
         "@babel/helper-split-export-declaration": "^7.8.3",
         "@babel/template": "^7.8.6",
-        "@babel/types": "^7.8.6",
+        "@babel/types": "^7.9.0",
         "lodash": "^4.17.13"
       }
     },
@@ -312,6 +313,12 @@
         "@babel/types": "^7.8.3"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
+      "dev": true
+    },
     "@babel/helper-wrap-function": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
@@ -325,31 +332,31 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
-      "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.0.tgz",
+      "integrity": "sha512-/9GvfYTCG1NWCNwDj9e+XlnSCmWW/r9T794Xi58vPF9WCcnZCAZ0kWLSn54oqP40SUvh1T2G6VwKmFO5AOlW3A==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.8.4",
-        "@babel/types": "^7.8.3"
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0"
       }
     },
     "@babel/highlight": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-      "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
       "dev": true,
       "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.7.tgz",
-      "integrity": "sha512-9JWls8WilDXFGxs0phaXAZgpxTZhSk/yOYH2hTHC0X1yC7Z78IJfvR1vJ+rmJKq3I35td2XzXzN6ZLYlna+r/A==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.0.tgz",
+      "integrity": "sha512-Iwyp00CZsypoNJcpXCbq3G4tcDgphtlMwMVrMhhZ//XBkqjXF7LW6V511yk0+pBX3ZwwGnPea+pTKNJiqA7pUg==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
@@ -403,10 +410,20 @@
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
       }
     },
-    "@babel/plugin-proposal-object-rest-spread": {
+    "@babel/plugin-proposal-numeric-separator": {
       "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.8.3.tgz",
-      "integrity": "sha512-8qvuPwU/xxUCt78HocNlv0mXXo0wdh9VT1R04WU8HGOfaOob26pF+9P5/lYjN/q7DHOX1bvX60hnhOvuQUJdbA==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
+      "integrity": "sha512-jWioO1s6R/R+wEHizfaScNsAx+xKgwTLNXSh7tTC4Usj3ItsPEhYkEpU4h+lpnBwq7NBVOJXfO6cRFYcX69JUQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.0.tgz",
+      "integrity": "sha512-UgqBv6bjq4fDb8uku9f+wcm1J7YxJ5nT7WO/jBr0cl0PLKb7t1O6RNR1kZbjgx2LQtsDI9hwoQVmn0yhXeQyow==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
@@ -424,9 +441,9 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.8.3.tgz",
-      "integrity": "sha512-QIoIR9abkVn+seDE3OjA08jWcs3eZ9+wJCKSRgo3WdEU2csFYgdScb+8qHB3+WXsGJD55u+5hWCISI7ejXS+kg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz",
+      "integrity": "sha512-NDn5tu3tcv4W30jNhmc2hyD5c56G6cXx4TesJubhxrJeCvuuMpttxr0OnNCqbZGhFjLrg+NIhxxC+BK5F6yS3w==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3",
@@ -434,12 +451,12 @@
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.3.tgz",
-      "integrity": "sha512-1/1/rEZv2XGweRwwSkLpY+s60za9OZ1hJs4YDqFHCw0kYWYwL5IFljVY1MYBL+weT1l9pokDO2uhSTLVxzoHkQ==",
+      "version": "7.8.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.8.tgz",
+      "integrity": "sha512-EVhjVsMpbhLw9ZfHWSx2iy13Q8Z/eg8e8ccVWt23sWQK5l1UdkoLJPN5w69UA4uITGBnEZD2JOe4QOHycYKv8A==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+        "@babel/helper-create-regexp-features-plugin": "^7.8.8",
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
@@ -486,6 +503,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz",
+      "integrity": "sha512-H7dCMAdN83PcCmqmkHB5dtp+Xa9a6LKSvA2hiFBC/5alSHxM5VgWZXFqDi0YFe8XNGT6iCa+z4V4zSt/PdZ7Dw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -564,9 +590,9 @@
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.8.6.tgz",
-      "integrity": "sha512-k9r8qRay/R6v5aWZkrEclEhKO6mc1CCQr2dLsVHBmOQiMpN6I2bpjX3vgnldUWeEI1GHVNByULVxZ4BdP4Hmdg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.0.tgz",
+      "integrity": "sha512-xt/0CuBRBsBkqfk95ILxf0ge3gnXjEhOHrNxIiS8fdzSWgecuf9Vq2ogLUfaozJgt3LDO49ThMVWiyezGkei7A==",
       "dev": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.8.3",
@@ -589,9 +615,9 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.3.tgz",
-      "integrity": "sha512-H4X646nCkiEcHZUZaRkhE2XVsoz0J/1x3VVujnn96pSoGCtKPA99ZZA+va+gK+92Zycd6OBKCD8tDb/731bhgQ==",
+      "version": "7.8.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.8.8.tgz",
+      "integrity": "sha512-eRJu4Vs2rmttFCdhPUM3bV0Yo/xPSdPw6ML9KHs/bjB4bLA5HXlbvYXPOD5yASodGod+krjYx21xm1QmL8dCJQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -627,9 +653,9 @@
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.8.6.tgz",
-      "integrity": "sha512-M0pw4/1/KI5WAxPsdcUL/w2LJ7o89YHN3yLkzNjg7Yl15GlVGgzHyCU+FMeAxevHGsLVmUqbirlUIKTafPmzdw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.9.0.tgz",
+      "integrity": "sha512-lTAnWOpMwOXpyDx06N+ywmF3jNbafZEqZ96CGYabxHrxNX8l5ny7dt4bK/rGwAh9utyP2b2Hv7PlZh1AAS54FQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -664,47 +690,47 @@
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.8.3.tgz",
-      "integrity": "sha512-MadJiU3rLKclzT5kBH4yxdry96odTUwuqrZM+GllFI/VhxfPz+k9MshJM+MwhfkCdxxclSbSBbUGciBngR+kEQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
+      "integrity": "sha512-vZgDDF003B14O8zJy0XXLnPH4sg+9X5hFBBGN1V+B2rgrB+J2xIypSN6Rk9imB2hSTHQi5OHLrFWsZab1GMk+Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
         "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.8.3.tgz",
-      "integrity": "sha512-JpdMEfA15HZ/1gNuB9XEDlZM1h/gF/YOH7zaZzQu2xCFRfwc01NXBMHHSTT6hRjlXJJs5x/bfODM3LiCk94Sxg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
+      "integrity": "sha512-qzlCrLnKqio4SlgJ6FMMLBe4bySNis8DFn1VkGmOcxG9gqEyPIOzeQrA//u0HAKrWpJlpZbZMPB1n/OPa4+n8g==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
         "@babel/helper-simple-access": "^7.8.3",
         "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.8.3.tgz",
-      "integrity": "sha512-8cESMCJjmArMYqa9AO5YuMEkE4ds28tMpZcGZB/jl3n0ZzlsxOAi3mC+SKypTfT8gjMupCnd3YiXCkMjj2jfOg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
+      "integrity": "sha512-FsiAv/nao/ud2ZWy4wFacoLOm5uxl0ExSQ7ErvP7jpoihLR6Cq90ilOFyX9UXct3rbtKsAiZ9kFt5XGfPe/5SQ==",
       "dev": true,
       "requires": {
         "@babel/helper-hoist-variables": "^7.8.3",
-        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3",
         "babel-plugin-dynamic-import-node": "^2.3.0"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.8.3.tgz",
-      "integrity": "sha512-evhTyWhbwbI3/U6dZAnx/ePoV7H6OUG+OjiJFHmhr9FPn0VShjwC2kdxqIuQ/+1P50TMrneGzMeyMTFOjKSnAw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz",
+      "integrity": "sha512-uTWkXkIVtg/JGRSIABdBoMsoIeoHQHPTL0Y2E7xf5Oj7sLqwVsNXOkNk0VJc7vF0IMBsPeikHxFjGe+qmwPtTQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.8.3",
+        "@babel/helper-module-transforms": "^7.9.0",
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
@@ -737,9 +763,9 @@
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.7.tgz",
-      "integrity": "sha512-brYWaEPTRimOctz2NDA3jnBbDi7SVN2T4wYuu0aqSzxC3nozFZngGaw29CJ9ZPweB7k+iFmZuoG3IVPIcXmD2g==",
+      "version": "7.8.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.8.8.tgz",
+      "integrity": "sha512-hC4Ld/Ulpf1psQciWWwdnUspQoQco2bMzSrwU6TmzRlvoYQe4rQFy9vnCZDTlVeCQj0JPfL+1RX0V8hCJvkgBA==",
       "dev": true,
       "requires": {
         "@babel/helper-call-delegate": "^7.8.7",
@@ -775,9 +801,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz",
-      "integrity": "sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz",
+      "integrity": "sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.8.3",
@@ -844,12 +870,12 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.7.tgz",
-      "integrity": "sha512-BYftCVOdAYJk5ASsznKAUl53EMhfBbr8CJ1X+AJLfGPscQkwJFiaV/Wn9DPH/7fzm2v6iRYJKYHSqyynTGw0nw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.9.0.tgz",
+      "integrity": "sha512-712DeRXT6dyKAM/FMbQTV/FvRCms2hPCx+3weRjZ8iQVQWZejWWk1wwG6ViWMyqb/ouBbGOl5b6aCk0+j1NmsQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.8.6",
+        "@babel/compat-data": "^7.9.0",
         "@babel/helper-compilation-targets": "^7.8.7",
         "@babel/helper-module-imports": "^7.8.3",
         "@babel/helper-plugin-utils": "^7.8.3",
@@ -857,14 +883,16 @@
         "@babel/plugin-proposal-dynamic-import": "^7.8.3",
         "@babel/plugin-proposal-json-strings": "^7.8.3",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+        "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+        "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
         "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
-        "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+        "@babel/plugin-proposal-optional-chaining": "^7.9.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
         "@babel/plugin-syntax-async-generators": "^7.8.0",
         "@babel/plugin-syntax-dynamic-import": "^7.8.0",
         "@babel/plugin-syntax-json-strings": "^7.8.0",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.0",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.0",
@@ -873,20 +901,20 @@
         "@babel/plugin-transform-async-to-generator": "^7.8.3",
         "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
         "@babel/plugin-transform-block-scoping": "^7.8.3",
-        "@babel/plugin-transform-classes": "^7.8.6",
+        "@babel/plugin-transform-classes": "^7.9.0",
         "@babel/plugin-transform-computed-properties": "^7.8.3",
         "@babel/plugin-transform-destructuring": "^7.8.3",
         "@babel/plugin-transform-dotall-regex": "^7.8.3",
         "@babel/plugin-transform-duplicate-keys": "^7.8.3",
         "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
-        "@babel/plugin-transform-for-of": "^7.8.6",
+        "@babel/plugin-transform-for-of": "^7.9.0",
         "@babel/plugin-transform-function-name": "^7.8.3",
         "@babel/plugin-transform-literals": "^7.8.3",
         "@babel/plugin-transform-member-expression-literals": "^7.8.3",
-        "@babel/plugin-transform-modules-amd": "^7.8.3",
-        "@babel/plugin-transform-modules-commonjs": "^7.8.3",
-        "@babel/plugin-transform-modules-systemjs": "^7.8.3",
-        "@babel/plugin-transform-modules-umd": "^7.8.3",
+        "@babel/plugin-transform-modules-amd": "^7.9.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.9.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.9.0",
+        "@babel/plugin-transform-modules-umd": "^7.9.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
         "@babel/plugin-transform-new-target": "^7.8.3",
         "@babel/plugin-transform-object-super": "^7.8.3",
@@ -900,18 +928,32 @@
         "@babel/plugin-transform-template-literals": "^7.8.3",
         "@babel/plugin-transform-typeof-symbol": "^7.8.4",
         "@babel/plugin-transform-unicode-regex": "^7.8.3",
-        "@babel/types": "^7.8.7",
-        "browserslist": "^4.8.5",
+        "@babel/preset-modules": "^0.1.3",
+        "@babel/types": "^7.9.0",
+        "browserslist": "^4.9.1",
         "core-js-compat": "^3.6.2",
         "invariant": "^2.2.2",
         "levenary": "^1.1.1",
         "semver": "^5.5.0"
       }
     },
+    "@babel/preset-modules": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
+      "integrity": "sha512-Ra3JXOHBq2xd56xSF7lMKXdjBn3T772Y1Wet3yWnkDly9zHvJki029tAFzvAAK5cf4YV3yoxuP61crYRol6SVg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      }
+    },
     "@babel/runtime": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
-      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.0.tgz",
+      "integrity": "sha512-cTIudHnzuWLS56ik4DnRnqqNf8MkdUzV4iFFI1h7Jo9xvrpQROYaAnaSd2mHLQAzzZAPfATynX5ord6YlNYNMA==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -928,17 +970,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-      "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.0.tgz",
+      "integrity": "sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.8.6",
+        "@babel/generator": "^7.9.0",
         "@babel/helper-function-name": "^7.8.3",
         "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6",
+        "@babel/parser": "^7.9.0",
+        "@babel/types": "^7.9.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -962,12 +1004,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.8.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-      "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.0.tgz",
+      "integrity": "sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==",
       "dev": true,
       "requires": {
-        "esutils": "^2.0.2",
+        "@babel/helper-validator-identifier": "^7.9.0",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
@@ -998,6 +1040,42 @@
         "find-up": "^4.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
       }
     },
     "@istanbuljs/schema": {
@@ -1592,22 +1670,6 @@
         }
       }
     },
-    "@mrmlnc/readdir-enhanced": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-      "dev": true,
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
-      "dev": true
-    },
     "@sinonjs/commons": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
@@ -1664,23 +1726,6 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
-      "dev": true
-    },
-    "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-      "dev": true,
-      "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -1705,18 +1750,6 @@
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
       }
-    },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "13.7.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
-      "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==",
-      "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -1762,9 +1795,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         }
       }
@@ -1879,37 +1912,10 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
     },
     "asn1": {
@@ -2255,14 +2261,15 @@
       }
     },
     "browserslist": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
-      "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.10.0.tgz",
+      "integrity": "sha512-TpfK0TDgv71dzuTsEAlQiHeWQ/tiPqgNZVdv046fvNtBZrjbv2O3TsWCDU0AWGJJKCF/KsjNdLzR9hXOsh/CfA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001030",
-        "electron-to-chromium": "^1.3.363",
-        "node-releases": "^1.1.50"
+        "caniuse-lite": "^1.0.30001035",
+        "electron-to-chromium": "^1.3.378",
+        "node-releases": "^1.1.52",
+        "pkg-up": "^3.1.0"
       }
     },
     "bser": {
@@ -2297,12 +2304,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-      "dev": true
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2315,29 +2316,10 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
-    "camelcase-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-      "dev": true,
-      "requires": {
-        "camelcase": "^4.1.0",
-        "map-obj": "^2.0.0",
-        "quick-lru": "^1.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        }
-      }
-    },
     "caniuse-lite": {
-      "version": "1.0.30001032",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001032.tgz",
-      "integrity": "sha512-8joOm7BwcpEN4BfVHtfh0hBXSAPVYk+eUIcNntGtMkUWy/6AKRCDZINCLe3kB1vHhT2vBxBF85Hh9VlPXi/qjA==",
+      "version": "1.0.30001035",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
+      "integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ==",
       "dev": true
     },
     "capture-exit": {
@@ -2568,60 +2550,6 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cp-file": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-7.0.0.tgz",
-      "integrity": "sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "nested-error-stacks": "^2.0.0",
-        "p-event": "^4.1.0"
-      },
-      "dependencies": {
-        "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
-      }
-    },
-    "cpy": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cpy/-/cpy-8.0.1.tgz",
-      "integrity": "sha512-XplonbFkGld3KST+wKFutU+Al3srtT9RaeLTJeRY47QzzLDlA5kpK4s+o0DdgRx7W0cdkifOehGnCBCGIFfdeg==",
-      "dev": true,
-      "requires": {
-        "arrify": "^2.0.1",
-        "cp-file": "^7.0.0",
-        "globby": "^9.2.0",
-        "has-glob": "^1.0.0",
-        "junk": "^3.1.0",
-        "nested-error-stacks": "^2.1.0",
-        "p-all": "^2.1.0"
-      }
-    },
-    "cpy-cli": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cpy-cli/-/cpy-cli-3.1.0.tgz",
-      "integrity": "sha512-LJhHvFragWvIsJH1kjhzZwGSagukewJZ5nV5yjMc5TILs+Z/CbZSvX0W9t9XC26Mw32j56UHjR3co5kAXaeTwg==",
-      "dev": true,
-      "requires": {
-        "cpy": "^8.0.0",
-        "meow": "^5.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -2658,15 +2586,6 @@
         }
       }
     },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "requires": {
-        "array-find-index": "^1.0.1"
-      }
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2701,24 +2620,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
-    },
-    "decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-      "dev": true,
-      "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "dependencies": {
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        }
-      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -2800,15 +2701,6 @@
       "integrity": "sha512-nFIfVk5B/NStCsJ+zaPO4vYuLjlzQ6uFvPxzYyHlejNZ/UGa7G/n7peOXVrVNvRuyfstt+mZQYGpjxg9Z6N8Kw==",
       "dev": true
     },
-    "dir-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-      "dev": true,
-      "requires": {
-        "path-type": "^3.0.0"
-      }
-    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -2838,9 +2730,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.370",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.370.tgz",
-      "integrity": "sha512-399cXDE9C7qoVF2CUgCA/MLflfvxbo1F0kB/pkB94426freL/JgZ0HNaloomsOfnE+VC/qgTFZqzmivSdaNfPQ==",
+      "version": "1.3.379",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.379.tgz",
+      "integrity": "sha512-NK9DBBYEBb5f9D7zXI0hiE941gq3wkBeQmXs1ingigA/jnTg5mhwY2Z5egwA+ZI8OLGKCx0h1Cl8/xeuIBuLlg==",
       "dev": true
     },
     "emoji-regex": {
@@ -2856,15 +2748,6 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "es-abstract": {
@@ -2989,9 +2872,9 @@
           }
         },
         "globals": {
-          "version": "12.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-12.3.0.tgz",
-          "integrity": "sha512-wAfjdLgFsPZsklLJvOBUBmzYE8/CwhEqSBEMRXA3qxIiNtyqvjYurAtIfDh6chlEPUfmTY3MnZh5Hfh4q0UlIw==",
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.8.1"
@@ -3055,12 +2938,12 @@
       "dev": true
     },
     "espree": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.0.tgz",
-      "integrity": "sha512-Xs8airJ7RQolnDIbLtRutmfvSsAe0xqMMAantCN/GMoqf81TFbeI1T7Jpd56qYu1uuh32dOG5W/X9uO+ghPXzA==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==",
       "dev": true,
       "requires": {
-        "acorn": "^7.1.0",
+        "acorn": "^7.1.1",
         "acorn-jsx": "^5.2.0",
         "eslint-visitor-keys": "^1.1.0"
       }
@@ -3335,20 +3218,6 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
-    "fast-glob": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
-      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
-      "dev": true,
-      "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
-      }
-    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3419,13 +3288,12 @@
       }
     },
     "find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
+        "locate-path": "^3.0.0"
       }
     },
     "flat-cache": {
@@ -3490,9 +3358,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-      "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+      "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3546,7 +3414,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.3",
+          "version": "1.1.4",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3718,7 +3586,7 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "1.2.5",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -3743,12 +3611,12 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.1",
+          "version": "0.5.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -3758,7 +3626,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.4.0",
+          "version": "2.3.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3787,7 +3655,7 @@
           }
         },
         "nopt": {
-          "version": "4.0.1",
+          "version": "4.0.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -3812,13 +3680,14 @@
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.4.7",
+          "version": "1.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "npm-bundled": "^1.0.1",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npmlog": {
@@ -3898,18 +3767,10 @@
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
           }
         },
         "readable-stream": {
-          "version": "2.3.6",
+          "version": "2.3.7",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4120,6 +3981,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-glob": "^3.1.0",
         "path-dirname": "^1.0.0"
@@ -4130,39 +3992,18 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
         }
       }
     },
-    "glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-      "dev": true
-    },
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
-    },
-    "globby": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
-      "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
-      "dev": true,
-      "requires": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^1.0.2",
-        "dir-glob": "^2.2.2",
-        "fast-glob": "^2.2.6",
-        "glob": "^7.1.3",
-        "ignore": "^4.0.3",
-        "pify": "^4.0.1",
-        "slash": "^2.0.0"
-      }
     },
     "graceful-fs": {
       "version": "4.2.3",
@@ -4208,26 +4049,6 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
-    "has-glob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-glob/-/has-glob-1.0.0.tgz",
-      "integrity": "sha1-mqqe7b/7G6OZCnsAEPtnjuAIEgc=",
-      "dev": true,
-      "requires": {
-        "is-glob": "^3.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
-      }
-    },
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
@@ -4265,12 +4086,6 @@
           }
         }
       }
-    },
-    "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -4353,12 +4168,6 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
-    "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-      "dev": true
-    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4376,9 +4185,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.6.tgz",
-      "integrity": "sha512-7SVO4h+QIdMq6XcqIqrNte3gS5MzCCKZdsq9DO4PJziBFNYzP3PGFbDjgadDb//MCahzgjCxvQ/O2wa7kx9o4w==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
@@ -4491,12 +4300,6 @@
           }
         }
       }
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -4626,12 +4429,6 @@
           }
         }
       }
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -5913,12 +5710,6 @@
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         },
-        "strip-bom": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -6300,12 +6091,6 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -6331,12 +6116,12 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+      "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "^1.2.5"
       }
     },
     "jsprim": {
@@ -6350,12 +6135,6 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
-    },
-    "junk": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
-      "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
-      "dev": true
     },
     "kind-of": {
       "version": "6.0.3",
@@ -6394,33 +6173,14 @@
         "type-check": "~0.3.2"
       }
     },
-    "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
-    },
     "locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
-        "p-locate": "^4.1.0"
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -6453,16 +6213,6 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
-      }
-    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -6488,12 +6238,6 @@
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
       "dev": true
     },
-    "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-      "dev": true
-    },
     "map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -6503,33 +6247,10 @@
         "object-visit": "^1.0.0"
       }
     },
-    "meow": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-      "dev": true,
-      "requires": {
-        "camelcase-keys": "^4.0.0",
-        "decamelize-keys": "^1.0.0",
-        "loud-rejection": "^1.0.0",
-        "minimist-options": "^3.0.1",
-        "normalize-package-data": "^2.3.4",
-        "read-pkg-up": "^3.0.0",
-        "redent": "^2.0.0",
-        "trim-newlines": "^2.0.0",
-        "yargs-parser": "^10.0.0"
-      }
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
-    },
-    "merge2": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
       "dev": true
     },
     "micromatch": {
@@ -6584,28 +6305,10 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
-    },
-    "minimist-options": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
-      },
-      "dependencies": {
-        "arrify": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
-        }
-      }
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -6629,20 +6332,12 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
+      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "ms": {
@@ -6689,12 +6384,6 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
-    "nested-error-stacks": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
-      "dev": true
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -6737,9 +6426,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.50.tgz",
-      "integrity": "sha512-lgAmPv9eYZ0bGwUYAKlr8MG6K4CvWliWqnkcT2P8mMAgVrH3lqfBPorFlxiG1pHQnqmavJZ9vbMXUTNyMLbrgQ==",
+      "version": "1.1.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.52.tgz",
+      "integrity": "sha512-snSiT1UypkgGt2wxPqS6ImEUICbNCMb31yaxWrOLXjhlt2z2/IBpaOxzONExqSm4y5oLnAqjjRWu+wsDzK5yNQ==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -6751,18 +6440,6 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
-      }
-    },
-    "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -6913,29 +6590,11 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
-    "p-all": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-all/-/p-all-2.1.0.tgz",
-      "integrity": "sha512-HbZxz5FONzz/z2gJfk6bFca0BCiSRF8jU3yCsWOen/vR6lZjfPOu/e7L3uFzTW1i0H8TlC3vqQstEJPQL4/uLA==",
-      "dev": true,
-      "requires": {
-        "p-map": "^2.0.0"
-      }
-    },
     "p-each-series": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
       "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
       "dev": true
-    },
-    "p-event": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
-      "integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
-      "dev": true,
-      "requires": {
-        "p-timeout": "^2.0.1"
-      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -6953,27 +6612,12 @@
       }
     },
     "p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
-        "p-limit": "^2.2.0"
-      }
-    },
-    "p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-      "dev": true
-    },
-    "p-timeout": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-      "dev": true,
-      "requires": {
-        "p-finally": "^1.0.0"
+        "p-limit": "^2.0.0"
       }
     },
     "p-try": {
@@ -6989,16 +6633,6 @@
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
-      }
-    },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
       }
     },
     "parse5": {
@@ -7017,12 +6651,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
@@ -7042,23 +6677,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
-    },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
     },
     "performance-now": {
       "version": "2.1.0",
@@ -7094,6 +6712,51 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        }
+      }
+    },
+    "pkg-up": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
+      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
       }
     },
     "pn": {
@@ -7188,9 +6851,9 @@
       "dev": true
     },
     "prompts": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.1.tgz",
-      "integrity": "sha512-qIP2lQyCwYbdzcqHIUi2HAxiWixhoM9OdLCWf8txXsapC/X9YdsCoeyRIXE/GP+Q0J37Q7+XN/MFqbUa7IzXNA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.3.2.tgz",
+      "integrity": "sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==",
       "dev": true,
       "requires": {
         "kleur": "^3.0.3",
@@ -7231,89 +6894,11 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
-    "quick-lru": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-      "dev": true
-    },
     "react-is": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
-      "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
-    },
-    "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-      "dev": true,
-      "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^3.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        }
-      }
     },
     "readable-stream": {
       "version": "2.3.7",
@@ -7352,16 +6937,6 @@
         "util.promisify": "^1.0.0"
       }
     },
-    "redent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-      "dev": true,
-      "requires": {
-        "indent-string": "^3.0.0",
-        "strip-indent": "^2.0.0"
-      }
-    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -7369,23 +6944,23 @@
       "dev": true
     },
     "regenerate-unicode-properties": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.1.0.tgz",
-      "integrity": "sha512-LGZzkgtLY79GeXLm8Dp0BVLdQlWICzBnJz/ipWUgo59qBaZ+BHtq51P2q1uVZlppMuUAT37SDk39qUbjTWB7bA==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+      "integrity": "sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.0"
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
-      "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g=="
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
-      "version": "0.14.2",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.2.tgz",
-      "integrity": "sha512-V4+lGplCM/ikqi5/mkkpJ06e9Bujq1NFmNLvsCs56zg3ZbzrnUzAtizZ24TXxtRX/W2jcdScwQCnbL0CICTFkQ==",
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
+      "integrity": "sha512-EaJaKPBI9GvKpvUz2mz4fhx7WPgvwRLY9v3hlNHWmAuJHI13T4nwKnNvm5RWJzEdnI5g5UwtOww+S8IdoUC2bw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.4",
@@ -7409,17 +6984,17 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.6.0.tgz",
-      "integrity": "sha512-YlVaefl8P5BnFYOITTNzDvan1ulLOiXJzCNZxduTIosN17b87h3bvG9yHMoHaRuo88H4mQ06Aodj5VtYGGGiTg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
+      "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^8.1.0",
-        "regjsgen": "^0.5.0",
-        "regjsparser": "^0.6.0",
+        "regenerate-unicode-properties": "^8.2.0",
+        "regjsgen": "^0.5.1",
+        "regjsparser": "^0.6.4",
         "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.1.0"
+        "unicode-match-property-value-ecmascript": "^1.2.0"
       }
     },
     "regjsgen": {
@@ -7429,9 +7004,9 @@
       "dev": true
     },
     "regjsparser": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.3.tgz",
-      "integrity": "sha512-8uZvYbnfAtEm9Ab8NTb3hdLwL4g/LQzEYP7Xs27T96abJCCE2d6r3cPZPQEsLKy0vRSGVNG+/zVGtLr86HQduA==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.4.tgz",
+      "integrity": "sha512-64O87/dPDgfk8/RQqC4gkZoGyyWFIEUTTh80CU6CWuK5vkCGyekIx+oKcEIYtP/RAxSQltCZHCNu/mdd7fqlJw==",
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
@@ -7737,9 +7312,9 @@
       "dev": true
     },
     "sisteransi": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
-      "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
     },
     "slash": {
@@ -7917,38 +7492,6 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
-      "dev": true
-    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -8094,9 +7637,9 @@
       }
     },
     "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true
     },
     "strip-eof": {
@@ -8109,12 +7652,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true
-    },
-    "strip-indent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
     "strip-json-comments": {
@@ -8324,12 +7861,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "trim-newlines": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-      "dev": true
-    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -8398,15 +7929,15 @@
       }
     },
     "unicode-match-property-value-ecmascript": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
-      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "integrity": "sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
-      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
       "dev": true
     },
     "union-value": {
@@ -8537,16 +8068,6 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
-      }
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
       }
     },
     "verror": {
@@ -8717,9 +8238,9 @@
       }
     },
     "ws": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
-      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ==",
       "dev": true
     },
     "xml-name-validator": {
@@ -8741,9 +8262,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.1.0.tgz",
-      "integrity": "sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==",
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+      "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
       "dev": true,
       "requires": {
         "cliui": "^6.0.0",
@@ -8756,36 +8277,53 @@
         "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^16.1.0"
+        "yargs-parser": "^18.1.1"
       },
       "dependencies": {
-        "yargs-parser": {
-          "version": "16.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
-          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "dev": true,
           "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
         }
       }
     },
     "yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "version": "18.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
+      "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        }
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -93,15 +93,14 @@
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",
-    "@babel/core": "^7.8.7",
+    "@babel/core": "^7.9.0",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-transform-runtime": "^7.8.3",
-    "@babel/preset-env": "^7.8.7",
+    "@babel/plugin-transform-runtime": "^7.9.0",
+    "@babel/preset-env": "^7.9.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.1.0",
     "babel-plugin-trace": "^1.1.0",
     "common-tags": "^1.8.0",
-    "cpy-cli": "^3.1.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
     "eslint-plugin-prettier": "^3.1.2",
@@ -110,7 +109,7 @@
     "prettier": "^1.19.1"
   },
   "dependencies": {
-    "@babel/runtime": "^7.8.7"
+    "@babel/runtime": "^7.9.0"
   },
   "engines": {
     "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -60,10 +60,9 @@
   },
   "scripts": {
     "browser:build": "BABEL_ENV=browser babel src/ --out-dir browser/dist/",
-    "browser:copy": "cpy '*.js' '!*.config.js' types/ browser/ --parents",
     "clean": "git clean -fdxe node_modules",
     "dist:build": "babel src/ --out-dir dist/",
-    "build": "npm run dist:build && npm run browser:build && npm run browser:copy",
+    "build": "npm run dist:build && npm run browser:build",
     "prettier": "prettier --write \"{src,tests}/**/*.js\"",
     "lint": "eslint src/",
     "start": "npm run dist:build && node -i -e 'YAML=require(\".\")'",

--- a/pair.js
+++ b/pair.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/schema/Pair').default
+module.exports = require('./dist/schema/Pair').Pair
 require('./dist/warnings').warnFileDeprecation(__filename)

--- a/parse-cst.js
+++ b/parse-cst.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cst/parse').default
+module.exports = require('./dist/cst/parse').parse

--- a/scalar.js
+++ b/scalar.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/schema/Scalar').default
+module.exports = require('./dist/schema/Scalar').Scalar
 require('./dist/warnings').warnFileDeprecation(__filename)

--- a/schema.js
+++ b/schema.js
@@ -1,5 +1,5 @@
-module.exports = require('./dist/schema').default
-var opt = require('./dist/tags/options')
+module.exports = require('./dist/schema').Schema
+const opt = require('./dist/tags/options')
 module.exports.nullOptions = opt.nullOptions
 module.exports.strOptions = opt.strOptions
 module.exports.stringify = require('./dist/stringify').stringifyString

--- a/seq.js
+++ b/seq.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/schema/Seq').default
+module.exports = require('./dist/schema/Seq').YAMLSeq
 require('./dist/warnings').warnFileDeprecation(__filename)

--- a/src/Anchors.js
+++ b/src/Anchors.js
@@ -1,12 +1,16 @@
-import Alias from './schema/Alias'
-import Map from './schema/Map'
-import Merge from './schema/Merge'
-import Scalar from './schema/Scalar'
-import Seq from './schema/Seq'
+import { Alias } from './schema/Alias'
+import { YAMLMap } from './schema/Map'
+import { Merge } from './schema/Merge'
+import { Scalar } from './schema/Scalar'
+import { YAMLSeq } from './schema/Seq'
 
-export default class Anchors {
+export class Anchors {
   static validAnchorNode(node) {
-    return node instanceof Scalar || node instanceof Seq || node instanceof Map
+    return (
+      node instanceof Scalar ||
+      node instanceof YAMLSeq ||
+      node instanceof YAMLMap
+    )
   }
 
   map = {}
@@ -24,8 +28,8 @@ export default class Anchors {
     const merge = new Merge()
     merge.value.items = sources.map(s => {
       if (s instanceof Alias) {
-        if (s.source instanceof Map) return s
-      } else if (s instanceof Map) {
+        if (s.source instanceof YAMLMap) return s
+      } else if (s instanceof YAMLMap) {
         return this.createAlias(s)
       }
       throw new Error('Merge sources must be Map nodes or their Aliases')

--- a/src/Document.js
+++ b/src/Document.js
@@ -1,5 +1,5 @@
-import addComment from './addComment'
-import Anchors from './Anchors'
+import { addComment } from './addComment'
+import { Anchors } from './Anchors'
 import { Char, Type } from './constants'
 import {
   YAMLError,
@@ -8,18 +8,18 @@ import {
   YAMLSyntaxError,
   YAMLWarning
 } from './errors'
-import listTagNames from './listTagNames'
-import Schema from './schema'
-import Alias from './schema/Alias'
-import Collection, { isEmptyPath } from './schema/Collection'
-import Node from './schema/Node'
-import Scalar from './schema/Scalar'
-import toJSON from './toJSON'
+import { listTagNames } from './listTagNames'
+import { Schema } from './schema'
+import { Alias } from './schema/Alias'
+import { Collection, isEmptyPath } from './schema/Collection'
+import { Node } from './schema/Node'
+import { Scalar } from './schema/Scalar'
+import { toJSON } from './toJSON'
 
 const isCollectionItem = node =>
   node && [Type.MAP_KEY, Type.MAP_VALUE, Type.SEQ_ITEM].includes(node.type)
 
-export default class Document {
+export class Document {
   static defaults = {
     '1.0': {
       schema: 'yaml-1.1',

--- a/src/addComment.js
+++ b/src/addComment.js
@@ -4,7 +4,7 @@ export function addCommentBefore(str, indent, comment) {
   return `#${cc}\n${indent}${str}`
 }
 
-export default function addComment(str, indent, comment) {
+export function addComment(str, indent, comment) {
   return !comment
     ? str
     : comment.indexOf('\n') === -1

--- a/src/cst/Alias.js
+++ b/src/cst/Alias.js
@@ -1,7 +1,7 @@
-import Node from './Node'
-import Range from './Range'
+import { Node } from './Node'
+import { Range } from './Range'
 
-export default class Alias extends Node {
+export class Alias extends Node {
   /**
    * Parses an *alias from the source
    *

--- a/src/cst/BlankLine.js
+++ b/src/cst/BlankLine.js
@@ -1,8 +1,8 @@
 import { Type } from '../constants'
-import Node from './Node'
-import Range from './Range'
+import { Node } from './Node'
+import { Range } from './Range'
 
-export default class BlankLine extends Node {
+export class BlankLine extends Node {
   constructor() {
     super(Type.BLANK_LINE)
   }

--- a/src/cst/BlockValue.js
+++ b/src/cst/BlockValue.js
@@ -1,6 +1,6 @@
 import { Type } from '../constants'
-import Node from './Node'
-import Range from './Range'
+import { Node } from './Node'
+import { Range } from './Range'
 
 export const Chomp = {
   CLIP: 'CLIP',
@@ -8,7 +8,7 @@ export const Chomp = {
   STRIP: 'STRIP'
 }
 
-export default class BlockValue extends Node {
+export class BlockValue extends Node {
   constructor(type, props) {
     super(type, props)
     this.blockIndent = null

--- a/src/cst/Collection.js
+++ b/src/cst/Collection.js
@@ -1,9 +1,9 @@
 import { Type } from '../constants'
-import BlankLine from './BlankLine'
-import CollectionItem from './CollectionItem'
-import Comment from './Comment'
-import Node from './Node'
-import Range from './Range'
+import { BlankLine } from './BlankLine'
+import { CollectionItem } from './CollectionItem'
+import { Comment } from './Comment'
+import { Node } from './Node'
+import { Range } from './Range'
 
 export function grabCollectionEndComments(node) {
   let cnode = node
@@ -35,7 +35,7 @@ export function grabCollectionEndComments(node) {
   return ca
 }
 
-export default class Collection extends Node {
+export class Collection extends Node {
   static nextContentHasIndent(src, offset, indent) {
     const lineStart = Node.endOfLine(src, offset) + 1
     offset = Node.endOfWhiteSpace(src, lineStart)

--- a/src/cst/CollectionItem.js
+++ b/src/cst/CollectionItem.js
@@ -1,10 +1,10 @@
 import { Type } from '../constants'
 import { YAMLSemanticError } from '../errors'
-import BlankLine from './BlankLine'
-import Node from './Node'
-import Range from './Range'
+import { BlankLine } from './BlankLine'
+import { Node } from './Node'
+import { Range } from './Range'
 
-export default class CollectionItem extends Node {
+export class CollectionItem extends Node {
   constructor(type, props) {
     super(type, props)
     this.node = null

--- a/src/cst/Comment.js
+++ b/src/cst/Comment.js
@@ -1,8 +1,8 @@
 import { Type } from '../constants'
-import Node from './Node'
-import Range from './Range'
+import { Node } from './Node'
+import { Range } from './Range'
 
-export default class Comment extends Node {
+export class Comment extends Node {
   constructor() {
     super(Type.COMMENT)
   }

--- a/src/cst/Directive.js
+++ b/src/cst/Directive.js
@@ -1,8 +1,8 @@
 import { Type } from '../constants'
-import Node from './Node'
-import Range from './Range'
+import { Node } from './Node'
+import { Range } from './Range'
 
-export default class Directive extends Node {
+export class Directive extends Node {
   constructor() {
     super(Type.DIRECTIVE)
     this.name = null

--- a/src/cst/Document.js
+++ b/src/cst/Document.js
@@ -1,13 +1,13 @@
 import { Char, Type } from '../constants'
 import { YAMLSemanticError, YAMLSyntaxError } from '../errors'
-import BlankLine from './BlankLine'
+import { BlankLine } from './BlankLine'
 import { grabCollectionEndComments } from './Collection'
-import Comment from './Comment'
-import Directive from './Directive'
-import Node from './Node'
-import Range from './Range'
+import { Comment } from './Comment'
+import { Directive } from './Directive'
+import { Node } from './Node'
+import { Range } from './Range'
 
-export default class Document extends Node {
+export class Document extends Node {
   static startCommentOrEndBlankLine(src, start) {
     const offset = Node.endOfWhiteSpace(src, start)
     const ch = src[offset]

--- a/src/cst/FlowCollection.js
+++ b/src/cst/FlowCollection.js
@@ -1,11 +1,11 @@
 import { Type } from '../constants'
 import { YAMLSemanticError } from '../errors'
-import BlankLine from './BlankLine'
-import Comment from './Comment'
-import Node from './Node'
-import Range from './Range'
+import { BlankLine } from './BlankLine'
+import { Comment } from './Comment'
+import { Node } from './Node'
+import { Range } from './Range'
 
-export default class FlowCollection extends Node {
+export class FlowCollection extends Node {
   constructor(type, props) {
     super(type, props)
     this.items = null

--- a/src/cst/Node.js
+++ b/src/cst/Node.js
@@ -1,9 +1,9 @@
 import { Char, Type } from '../constants'
 import { getLinePos } from './source-utils'
-import Range from './Range'
+import { Range } from './Range'
 
 /** Root class of all nodes */
-export default class Node {
+export class Node {
   static addStringTerminator(src, offset, str) {
     if (str[str.length - 1] === '\n') return str
     const next = Node.endOfWhiteSpace(src, offset)

--- a/src/cst/ParseContext.js
+++ b/src/cst/ParseContext.js
@@ -1,15 +1,15 @@
 import { Char, Type } from '../constants'
 import { YAMLSyntaxError } from '../errors'
-import Alias from './Alias'
-import BlockValue from './BlockValue'
-import Collection from './Collection'
-import CollectionItem from './CollectionItem'
-import FlowCollection from './FlowCollection'
-import Node from './Node'
-import PlainValue from './PlainValue'
-import QuoteDouble from './QuoteDouble'
-import QuoteSingle from './QuoteSingle'
-import Range from './Range'
+import { Alias } from './Alias'
+import { BlockValue } from './BlockValue'
+import { Collection } from './Collection'
+import { CollectionItem } from './CollectionItem'
+import { FlowCollection } from './FlowCollection'
+import { Node } from './Node'
+import { PlainValue } from './PlainValue'
+import { QuoteDouble } from './QuoteDouble'
+import { QuoteSingle } from './QuoteSingle'
+import { Range } from './Range'
 
 function createNewNode(type, props) {
   switch (type) {
@@ -47,7 +47,7 @@ function createNewNode(type, props) {
  * @param {Node} parent - The parent of the node
  * @param {string} src - Source of the YAML document
  */
-export default class ParseContext {
+export class ParseContext {
   static parseType(src, offset, inFlow) {
     switch (src[offset]) {
       case '*':

--- a/src/cst/PlainValue.js
+++ b/src/cst/PlainValue.js
@@ -1,7 +1,7 @@
-import Node from './Node'
-import Range from './Range'
+import { Node } from './Node'
+import { Range } from './Range'
 
-export default class PlainValue extends Node {
+export class PlainValue extends Node {
   static endOfLine(src, start, inFlow) {
     let ch = src[start]
     let offset = start

--- a/src/cst/QuoteDouble.js
+++ b/src/cst/QuoteDouble.js
@@ -1,8 +1,8 @@
 import { YAMLSemanticError, YAMLSyntaxError } from '../errors'
-import Node from './Node'
-import Range from './Range'
+import { Node } from './Node'
+import { Range } from './Range'
 
-export default class QuoteDouble extends Node {
+export class QuoteDouble extends Node {
   static endOfQuote(src, offset) {
     let ch = src[offset]
     while (ch && ch !== '"') {

--- a/src/cst/QuoteSingle.js
+++ b/src/cst/QuoteSingle.js
@@ -1,8 +1,8 @@
 import { YAMLSemanticError, YAMLSyntaxError } from '../errors'
-import Node from './Node'
-import Range from './Range'
+import { Node } from './Node'
+import { Range } from './Range'
 
-export default class QuoteSingle extends Node {
+export class QuoteSingle extends Node {
   static endOfQuote(src, offset) {
     let ch = src[offset]
     while (ch) {

--- a/src/cst/Range.js
+++ b/src/cst/Range.js
@@ -1,4 +1,4 @@
-export default class Range {
+export class Range {
   static copy(orig) {
     return new Range(orig.start, orig.end)
   }

--- a/src/cst/parse.js
+++ b/src/cst/parse.js
@@ -1,9 +1,9 @@
 // Published as 'yaml/parse-cst'
 
-import Document from './Document'
-import ParseContext from './ParseContext'
+import { Document } from './Document'
+import { ParseContext } from './ParseContext'
 
-export default function parse(src) {
+export function parse(src) {
   const cr = []
   if (src.indexOf('\r') !== -1) {
     src = src.replace(/\r\n?/g, (match, offset) => {

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,6 @@
-import Node from './cst/Node'
+import { Node } from './cst/Node'
 import { getLinePos, getPrettyContext } from './cst/source-utils'
-import Range from './cst/Range'
+import { Range } from './cst/Range'
 
 export class YAMLError extends Error {
   constructor(name, source, message) {

--- a/src/foldFlowLines.js
+++ b/src/foldFlowLines.js
@@ -35,7 +35,7 @@ const consumeMoreIndentedLines = (text, i) => {
  * @param {function} options.onFold Called once if any line of text exceeds
  *   lineWidth characters
  */
-export default function foldFlowLines(
+export function foldFlowLines(
   text,
   indent,
   mode,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import parseCST from './cst/parse'
-import YAMLDocument from './Document'
+import { parse as parseCST } from './cst/parse'
+import { Document as YAMLDocument } from './Document'
 import { YAMLSemanticError } from './errors'
-import Schema from './schema'
+import { Schema } from './schema'
 import { warn } from './warnings'
 
 const defaultOptions = {
@@ -73,7 +73,7 @@ function stringify(value, options) {
   return String(doc)
 }
 
-export default {
+export const YAML = {
   createNode,
   defaultOptions,
   Document,

--- a/src/listTagNames.js
+++ b/src/listTagNames.js
@@ -1,6 +1,6 @@
-import Collection from './schema/Collection'
-import Pair from './schema/Pair'
-import Scalar from './schema/Scalar'
+import { Collection } from './schema/Collection'
+import { Pair } from './schema/Pair'
+import { Scalar } from './schema/Scalar'
 
 const visit = (node, tags) => {
   if (node && typeof node === 'object') {
@@ -18,4 +18,4 @@ const visit = (node, tags) => {
   return tags
 }
 
-export default node => Object.keys(visit(node, {}))
+export const listTagNames = node => Object.keys(visit(node, {}))

--- a/src/schema/Alias.js
+++ b/src/schema/Alias.js
@@ -1,9 +1,9 @@
 import { Type } from '../constants'
 import { YAMLReferenceError } from '../errors'
-import toJSON from '../toJSON'
-import Collection from './Collection'
-import Node from './Node'
-import Pair from './Pair'
+import { toJSON } from '../toJSON'
+import { Collection } from './Collection'
+import { Node } from './Node'
+import { Pair } from './Pair'
 
 const getAliasCount = (node, anchors) => {
   if (node instanceof Alias) {
@@ -24,7 +24,7 @@ const getAliasCount = (node, anchors) => {
   return 1
 }
 
-export default class Alias extends Node {
+export class Alias extends Node {
   static default = true
 
   static stringify(

--- a/src/schema/Collection.js
+++ b/src/schema/Collection.js
@@ -1,7 +1,7 @@
-import addComment from '../addComment'
-import Node from './Node'
-import Pair from './Pair'
-import Scalar from './Scalar'
+import { addComment } from '../addComment'
+import { Node } from './Node'
+import { Pair } from './Pair'
+import { Scalar } from './Scalar'
 
 function collectionFromPath(schema, path, value) {
   let v = value
@@ -19,7 +19,7 @@ export const isEmptyPath = path =>
   path == null ||
   (typeof path === 'object' && path[Symbol.iterator]().next().done)
 
-export default class Collection extends Node {
+export class Collection extends Node {
   static maxFlowStringSingleLineLength = 60
 
   items = []

--- a/src/schema/Map.js
+++ b/src/schema/Map.js
@@ -1,6 +1,6 @@
-import Collection from './Collection'
-import Pair from './Pair'
-import Scalar from './Scalar'
+import { Collection } from './Collection'
+import { Pair } from './Pair'
+import { Scalar } from './Scalar'
 
 export function findPair(items, key) {
   const k = key instanceof Scalar ? key.value : key
@@ -13,7 +13,7 @@ export function findPair(items, key) {
   return undefined
 }
 
-export default class YAMLMap extends Collection {
+export class YAMLMap extends Collection {
   add(pair, overwrite) {
     if (!pair) pair = new Pair(pair)
     else if (!(pair instanceof Pair))

--- a/src/schema/Merge.js
+++ b/src/schema/Merge.js
@@ -1,23 +1,23 @@
-import YAMLMap from './Map'
-import Pair from './Pair'
-import Scalar from './Scalar'
-import Seq from './Seq'
+import { YAMLMap } from './Map'
+import { Pair } from './Pair'
+import { Scalar } from './Scalar'
+import { YAMLSeq } from './Seq'
 
 export const MERGE_KEY = '<<'
 
-export default class Merge extends Pair {
+export class Merge extends Pair {
   constructor(pair) {
     if (pair instanceof Pair) {
       let seq = pair.value
-      if (!(seq instanceof Seq)) {
-        seq = new Seq()
+      if (!(seq instanceof YAMLSeq)) {
+        seq = new YAMLSeq()
         seq.items.push(pair.value)
         seq.range = pair.value.range
       }
       super(pair.key, seq)
       this.range = pair.range
     } else {
-      super(new Scalar(MERGE_KEY), new Seq())
+      super(new Scalar(MERGE_KEY), new YAMLSeq())
     }
     this.type = 'MERGE_PAIR'
   }

--- a/src/schema/Node.js
+++ b/src/schema/Node.js
@@ -1,1 +1,1 @@
-export default class Node {}
+export class Node {}

--- a/src/schema/Pair.js
+++ b/src/schema/Pair.js
@@ -1,11 +1,11 @@
 // Published as 'yaml/pair'
 
-import addComment from '../addComment'
+import { addComment } from '../addComment'
 import { Type } from '../constants'
-import toJSON from '../toJSON'
-import Collection from './Collection'
-import Node from './Node'
-import Scalar from './Scalar'
+import { toJSON } from '../toJSON'
+import { Collection } from './Collection'
+import { Node } from './Node'
+import { Scalar } from './Scalar'
 
 const stringifyKey = (key, jsKey, ctx) => {
   if (jsKey === null) return ''
@@ -21,7 +21,7 @@ const stringifyKey = (key, jsKey, ctx) => {
   return JSON.stringify(jsKey)
 }
 
-export default class Pair extends Node {
+export class Pair extends Node {
   constructor(key, value = null) {
     super()
     this.key = key

--- a/src/schema/Scalar.js
+++ b/src/schema/Scalar.js
@@ -1,9 +1,9 @@
 // Published as 'yaml/scalar'
 
-import toJSON from '../toJSON'
-import Node from './Node'
+import { toJSON } from '../toJSON'
+import { Node } from './Node'
 
-export default class Scalar extends Node {
+export class Scalar extends Node {
   constructor(value) {
     super()
     this.value = value

--- a/src/schema/Seq.js
+++ b/src/schema/Seq.js
@@ -1,8 +1,8 @@
 // Published as 'yaml/seq'
 
-import toJSON from '../toJSON'
-import Collection from './Collection'
-import Scalar from './Scalar'
+import { toJSON } from '../toJSON'
+import { Collection } from './Collection'
+import { Scalar } from './Scalar'
 
 function asItemIndex(key) {
   let idx = key instanceof Scalar ? key.value : key
@@ -10,7 +10,7 @@ function asItemIndex(key) {
   return Number.isInteger(idx) && idx >= 0 ? idx : null
 }
 
-export default class YAMLSeq extends Collection {
+export class YAMLSeq extends Collection {
   add(value) {
     this.items.push(value)
   }

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -4,17 +4,17 @@ import { YAMLReferenceError, YAMLWarning } from '../errors'
 import { stringifyString } from '../stringify'
 import { schemas, tags } from '../tags'
 import { resolveString } from '../tags/failsafe/string'
-import Alias from './Alias'
-import Collection from './Collection'
-import Node from './Node'
-import Pair from './Pair'
-import Scalar from './Scalar'
+import { Alias } from './Alias'
+import { Collection } from './Collection'
+import { Node } from './Node'
+import { Pair } from './Pair'
+import { Scalar } from './Scalar'
 
 const isMap = ({ type }) => type === Type.FLOW_MAP || type === Type.MAP
 
 const isSeq = ({ type }) => type === Type.FLOW_SEQ || type === Type.SEQ
 
-export default class Schema {
+export class Schema {
   static defaultPrefix = 'tag:yaml.org,2002:'
 
   static defaultTags = {

--- a/src/schema/parseMap.js
+++ b/src/schema/parseMap.js
@@ -1,18 +1,18 @@
 import { Char, Type } from '../constants'
-import PlainValue from '../cst/PlainValue'
+import { PlainValue } from '../cst/PlainValue'
 import { YAMLSemanticError, YAMLSyntaxError, YAMLWarning } from '../errors'
-import Map from './Map'
-import Merge, { MERGE_KEY } from './Merge'
-import Pair from './Pair'
+import { YAMLMap } from './Map'
+import { Merge, MERGE_KEY } from './Merge'
+import { Pair } from './Pair'
 import {
   checkFlowCollectionEnd,
   checkKeyLength,
   resolveComments
 } from './parseUtils'
-import Alias from './Alias'
-import Collection from './Collection'
+import { Alias } from './Alias'
+import { Collection } from './Collection'
 
-export default function parseMap(doc, cst) {
+export function parseMap(doc, cst) {
   if (cst.type !== Type.MAP && cst.type !== Type.FLOW_MAP) {
     const msg = `A ${cst.type} node cannot be resolved as a mapping`
     doc.errors.push(new YAMLSyntaxError(cst, msg))
@@ -22,7 +22,7 @@ export default function parseMap(doc, cst) {
     cst.type === Type.FLOW_MAP
       ? resolveFlowMapItems(doc, cst)
       : resolveBlockMapItems(doc, cst)
-  const map = new Map()
+  const map = new YAMLMap()
   map.items = items
   resolveComments(map, comments)
   let hasCollectionKey = false

--- a/src/schema/parseSeq.js
+++ b/src/schema/parseSeq.js
@@ -1,15 +1,15 @@
 import { Type } from '../constants'
 import { YAMLSemanticError, YAMLSyntaxError, YAMLWarning } from '../errors'
-import Pair from './Pair'
+import { Pair } from './Pair'
 import {
   checkFlowCollectionEnd,
   checkKeyLength,
   resolveComments
 } from './parseUtils'
-import Seq from './Seq'
-import Collection from './Collection'
+import { YAMLSeq } from './Seq'
+import { Collection } from './Collection'
 
-export default function parseSeq(doc, cst) {
+export function parseSeq(doc, cst) {
   if (cst.type !== Type.SEQ && cst.type !== Type.FLOW_SEQ) {
     const msg = `A ${cst.type} node cannot be resolved as a sequence`
     doc.errors.push(new YAMLSyntaxError(cst, msg))
@@ -19,7 +19,7 @@ export default function parseSeq(doc, cst) {
     cst.type === Type.FLOW_SEQ
       ? resolveFlowSeqItems(doc, cst)
       : resolveBlockSeqItems(doc, cst)
-  const seq = new Seq()
+  const seq = new YAMLSeq()
   seq.items = items
   resolveComments(seq, comments)
   if (

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -1,6 +1,7 @@
 import { addCommentBefore } from './addComment'
 import { Type } from './constants'
-import foldFlowLines, {
+import {
+  foldFlowLines,
   FOLD_BLOCK,
   FOLD_FLOW,
   FOLD_QUOTED

--- a/src/tags/core.js
+++ b/src/tags/core.js
@@ -1,6 +1,6 @@
-import Scalar from '../schema/Scalar'
+import { Scalar } from '../schema/Scalar'
 import { stringifyNumber } from '../stringify'
-import failsafe from './failsafe'
+import { failsafe } from './failsafe'
 import { boolOptions, nullOptions } from './options'
 
 export const nullObj = {
@@ -93,7 +93,7 @@ export const floatObj = {
   stringify: stringifyNumber
 }
 
-export default failsafe.concat([
+export const core = failsafe.concat([
   nullObj,
   boolObj,
   octObj,

--- a/src/tags/failsafe/index.js
+++ b/src/tags/failsafe/index.js
@@ -1,5 +1,5 @@
-import map from './map'
-import seq from './seq'
-import str from './string'
+import { map } from './map'
+import { seq } from './seq'
+import { string } from './string'
 
-export default [map, seq, str]
+export const failsafe = [map, seq, string]

--- a/src/tags/failsafe/map.js
+++ b/src/tags/failsafe/map.js
@@ -1,5 +1,5 @@
-import YAMLMap from '../../schema/Map'
-import parseMap from '../../schema/parseMap'
+import { YAMLMap } from '../../schema/Map'
+import { parseMap } from '../../schema/parseMap'
 
 function createMap(schema, obj, ctx) {
   const map = new YAMLMap(schema)
@@ -16,7 +16,7 @@ function createMap(schema, obj, ctx) {
   return map
 }
 
-export default {
+export const map = {
   createNode: createMap,
   default: true,
   nodeClass: YAMLMap,

--- a/src/tags/failsafe/seq.js
+++ b/src/tags/failsafe/seq.js
@@ -1,5 +1,5 @@
-import parseSeq from '../../schema/parseSeq'
-import YAMLSeq from '../../schema/Seq'
+import { parseSeq } from '../../schema/parseSeq'
+import { YAMLSeq } from '../../schema/Seq'
 
 function createSeq(schema, obj, ctx) {
   const seq = new YAMLSeq(schema)
@@ -12,7 +12,7 @@ function createSeq(schema, obj, ctx) {
   return seq
 }
 
-export default {
+export const seq = {
   createNode: createSeq,
   default: true,
   nodeClass: YAMLSeq,

--- a/src/tags/failsafe/string.js
+++ b/src/tags/failsafe/string.js
@@ -13,7 +13,7 @@ export const resolveString = (doc, node) => {
   return res.str
 }
 
-export default {
+export const string = {
   identify: value => typeof value === 'string',
   default: true,
   tag: 'tag:yaml.org,2002:str',

--- a/src/tags/index.js
+++ b/src/tags/index.js
@@ -1,4 +1,5 @@
-import core, {
+import {
+  core,
   nullObj,
   boolObj,
   octObj,
@@ -8,16 +9,16 @@ import core, {
   expObj,
   floatObj
 } from './core'
-import failsafe from './failsafe'
-import json from './json'
-import yaml11 from './yaml-1.1'
+import { failsafe } from './failsafe'
+import { json } from './json'
+import { yaml11 } from './yaml-1.1'
 
-import map from './failsafe/map'
-import seq from './failsafe/seq'
-import binary from './yaml-1.1/binary'
-import omap from './yaml-1.1/omap'
-import pairs from './yaml-1.1/pairs'
-import set from './yaml-1.1/set'
+import { map } from './failsafe/map'
+import { seq } from './failsafe/seq'
+import { binary } from './yaml-1.1/binary'
+import { omap } from './yaml-1.1/omap'
+import { pairs } from './yaml-1.1/pairs'
+import { set } from './yaml-1.1/set'
 import { floatTime, intTime, timestamp } from './yaml-1.1/timestamp'
 
 export const schemas = { core, failsafe, json, yaml11 }

--- a/src/tags/json.js
+++ b/src/tags/json.js
@@ -1,9 +1,9 @@
-import map from './failsafe/map'
-import seq from './failsafe/seq'
-import Scalar from '../schema/Scalar'
+import { map } from './failsafe/map'
+import { seq } from './failsafe/seq'
+import { Scalar } from '../schema/Scalar'
 import { resolveString } from './failsafe/string'
 
-const schema = [
+export const json = [
   map,
   seq,
   {
@@ -49,8 +49,6 @@ const schema = [
   }
 ]
 
-schema.scalarFallback = str => {
+json.scalarFallback = str => {
   throw new SyntaxError(`Unresolved plain scalar ${JSON.stringify(str)}`)
 }
-
-export default schema

--- a/src/tags/yaml-1.1/binary.js
+++ b/src/tags/yaml-1.1/binary.js
@@ -6,7 +6,7 @@ import { stringifyString } from '../../stringify'
 import { resolveString } from '../failsafe/string'
 import { binaryOptions as options } from '../options'
 
-export default {
+export const binary = {
   identify: value => value instanceof Uint8Array, // Buffer inherits from Uint8Array
   default: false,
   tag: 'tag:yaml.org,2002:binary',

--- a/src/tags/yaml-1.1/index.js
+++ b/src/tags/yaml-1.1/index.js
@@ -1,17 +1,17 @@
-import Scalar from '../../schema/Scalar'
+import { Scalar } from '../../schema/Scalar'
 import { stringifyNumber } from '../../stringify'
-import failsafe from '../failsafe'
+import { failsafe } from '../failsafe'
 import { boolOptions, nullOptions } from '../options'
-import binary from './binary'
-import omap from './omap'
-import pairs from './pairs'
-import set from './set'
+import { binary } from './binary'
+import { omap } from './omap'
+import { pairs } from './pairs'
+import { set } from './set'
 import { intTime, floatTime, timestamp } from './timestamp'
 
 const boolStringify = ({ value }) =>
   value ? boolOptions.trueStr : boolOptions.falseStr
 
-export default failsafe.concat(
+export const yaml11 = failsafe.concat(
   [
     {
       identify: value => value == null,

--- a/src/tags/yaml-1.1/omap.js
+++ b/src/tags/yaml-1.1/omap.js
@@ -1,9 +1,9 @@
 import { YAMLSemanticError } from '../../errors'
-import toJSON from '../../toJSON'
-import YAMLMap from '../../schema/Map'
-import Pair from '../../schema/Pair'
-import Scalar from '../../schema/Scalar'
-import YAMLSeq from '../../schema/Seq'
+import { toJSON } from '../../toJSON'
+import { YAMLMap } from '../../schema/Map'
+import { Pair } from '../../schema/Pair'
+import { Scalar } from '../../schema/Scalar'
+import { YAMLSeq } from '../../schema/Seq'
 import { createPairs, parsePairs } from './pairs'
 
 export class YAMLOMap extends YAMLSeq {
@@ -62,7 +62,7 @@ function createOMap(schema, iterable, ctx) {
   return omap
 }
 
-export default {
+export const omap = {
   identify: value => value instanceof Map,
   nodeClass: YAMLOMap,
   default: false,

--- a/src/tags/yaml-1.1/pairs.js
+++ b/src/tags/yaml-1.1/pairs.js
@@ -1,8 +1,8 @@
 import { YAMLSemanticError } from '../../errors'
-import YAMLMap from '../../schema/Map'
-import Pair from '../../schema/Pair'
-import parseSeq from '../../schema/parseSeq'
-import YAMLSeq from '../../schema/Seq'
+import { YAMLMap } from '../../schema/Map'
+import { Pair } from '../../schema/Pair'
+import { parseSeq } from '../../schema/parseSeq'
+import { YAMLSeq } from '../../schema/Seq'
 
 export function parsePairs(doc, cst) {
   const seq = parseSeq(doc, cst)
@@ -55,7 +55,7 @@ export function createPairs(schema, iterable, ctx) {
   return pairs
 }
 
-export default {
+export const pairs = {
   default: false,
   tag: 'tag:yaml.org,2002:pairs',
   resolve: parsePairs,

--- a/src/tags/yaml-1.1/set.js
+++ b/src/tags/yaml-1.1/set.js
@@ -1,8 +1,8 @@
 import { YAMLSemanticError } from '../../errors'
-import YAMLMap, { findPair } from '../../schema/Map'
-import Pair from '../../schema/Pair'
-import parseMap from '../../schema/parseMap'
-import Scalar from '../../schema/Scalar'
+import { YAMLMap, findPair } from '../../schema/Map'
+import { Pair } from '../../schema/Pair'
+import { parseMap } from '../../schema/parseMap'
+import { Scalar } from '../../schema/Scalar'
 
 export class YAMLSet extends YAMLMap {
   static tag = 'tag:yaml.org,2002:set'
@@ -66,7 +66,7 @@ function createSet(schema, iterable, ctx) {
   return set
 }
 
-export default {
+export const set = {
   identify: value => value instanceof Set,
   nodeClass: YAMLSet,
   default: false,

--- a/src/test-events.js
+++ b/src/test-events.js
@@ -1,13 +1,13 @@
-import parseCST from './cst/parse'
-import Document from './Document'
+import { parse } from './cst/parse'
+import { Document } from './Document'
 
 // test harness for yaml-test-suite event tests
-export default function testEvents(src, options) {
+export function testEvents(src, options) {
   const opt = Object.assign(
     { keepCstNodes: true, keepNodeTypes: true, version: '1.2' },
     options
   )
-  const docs = parseCST(src).map(cstDoc => new Document(opt).parse(cstDoc))
+  const docs = parse(src).map(cstDoc => new Document(opt).parse(cstDoc))
   const errDoc = docs.find(doc => doc.errors.length > 0)
   const error = errDoc ? errDoc.errors[0].message : null
   const events = ['+STR']

--- a/src/toJSON.js
+++ b/src/toJSON.js
@@ -1,4 +1,4 @@
-export default function toJSON(value, arg, ctx) {
+export function toJSON(value, arg, ctx) {
   if (Array.isArray(value))
     return value.map((v, i) => toJSON(v, String(i), ctx))
   if (value && typeof value.toJSON === 'function') {

--- a/tests/cst/Node.js
+++ b/tests/cst/Node.js
@@ -1,6 +1,6 @@
 import { Type } from '../../src/constants'
-import Node from '../../src/cst/Node'
-import Range from '../../src/cst/Range'
+import { Node } from '../../src/cst/Node'
+import { Range } from '../../src/cst/Range'
 
 describe('internals', () => {
   test('constructor', () => {

--- a/tests/cst/YAML-1.2.spec.js
+++ b/tests/cst/YAML-1.2.spec.js
@@ -1,5 +1,5 @@
 import { Type } from '../../src/constants'
-import parse from '../../src/cst/parse'
+import { parse } from '../../src/cst/parse'
 import { pretty, testSpec } from './common'
 
 const spec = {

--- a/tests/cst/common.js
+++ b/tests/cst/common.js
@@ -1,4 +1,4 @@
-import Node from '../../src/cst/Node'
+import { Node } from '../../src/cst/Node'
 
 export const pretty = node => {
   if (!node || typeof node !== 'object') return node

--- a/tests/cst/corner-cases.js
+++ b/tests/cst/corner-cases.js
@@ -1,5 +1,5 @@
 import { source } from 'common-tags'
-import parse from '../../src/cst/parse'
+import { parse } from '../../src/cst/parse'
 
 describe('folded block with chomp: keep', () => {
   test('nl + nl', () => {

--- a/tests/cst/parse.js
+++ b/tests/cst/parse.js
@@ -1,4 +1,4 @@
-import parse from '../../src/cst/parse'
+import { parse } from '../../src/cst/parse'
 
 test('return value', () => {
   const src = '---\n- foo\n- bar\n'

--- a/tests/cst/set-value.js
+++ b/tests/cst/set-value.js
@@ -1,6 +1,6 @@
 import { Type } from '../../src/constants'
-import parse from '../../src/cst/parse'
-import CollectionItem from '../../src/cst/CollectionItem'
+import { parse } from '../../src/cst/parse'
+import { CollectionItem } from '../../src/cst/CollectionItem'
 
 test('set value in collection', () => {
   const src = `- Mark McGwire

--- a/tests/cst/source-utils.js
+++ b/tests/cst/source-utils.js
@@ -1,5 +1,5 @@
 import { getLinePos } from '../../src/cst/source-utils'
-import parse from '../../src/cst/parse'
+import { parse } from '../../src/cst/parse'
 
 test('lineStarts for empty document', () => {
   const src = ''

--- a/tests/doc/YAML-1.1.spec.js
+++ b/tests/doc/YAML-1.1.spec.js
@@ -1,4 +1,4 @@
-import YAML from '../../src/index'
+import { YAML } from '../../src/index'
 import { source } from 'common-tags'
 
 const orig = {}

--- a/tests/doc/YAML-1.2.spec.js
+++ b/tests/doc/YAML-1.2.spec.js
@@ -1,4 +1,4 @@
-import YAML from '../../src/index'
+import { YAML } from '../../src/index'
 import { strOptions } from '../../src/tags/options'
 
 const collectionKeyWarning =

--- a/tests/doc/anchors.js
+++ b/tests/doc/anchors.js
@@ -1,6 +1,6 @@
-import YAML from '../../src/index'
-import YAMLMap from '../../src/schema/Map'
-import Merge from '../../src/schema/Merge'
+import { YAML } from '../../src/index'
+import { YAMLMap } from '../../src/schema/Map'
+import { Merge } from '../../src/schema/Merge'
 
 test('basic', () => {
   const src = `- &a 1\n- *a\n`

--- a/tests/doc/collection-access.js
+++ b/tests/doc/collection-access.js
@@ -1,5 +1,5 @@
-import YAML from '../../src/index'
-import Pair from '../../src/schema/Pair'
+import { YAML } from '../../src/index'
+import { Pair } from '../../src/schema/Pair'
 
 describe('Map', () => {
   let map

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -1,5 +1,5 @@
 import { source } from 'common-tags'
-import YAML from '../../src/index'
+import { YAML } from '../../src/index'
 
 describe('parse comments', () => {
   describe('body', () => {

--- a/tests/doc/createNode.js
+++ b/tests/doc/createNode.js
@@ -1,8 +1,8 @@
-import YAML from '../../src/index'
-import YAMLMap from '../../src/schema/Map'
-import Pair from '../../src/schema/Pair'
-import Scalar from '../../src/schema/Scalar'
-import YAMLSeq from '../../src/schema/Seq'
+import { YAML } from '../../src/index'
+import { YAMLMap } from '../../src/schema/Map'
+import { Pair } from '../../src/schema/Pair'
+import { Scalar } from '../../src/schema/Scalar'
+import { YAMLSeq } from '../../src/schema/Seq'
 import { YAMLSet } from '../../src/tags/yaml-1.1/set'
 
 describe('scalars', () => {

--- a/tests/doc/errors.js
+++ b/tests/doc/errors.js
@@ -1,9 +1,9 @@
 import fs from 'fs'
 import path from 'path'
-import Node from '../../src/cst/Node'
+import { Node } from '../../src/cst/Node'
 import { YAMLError } from '../../src/errors'
 import { warnFileDeprecation, warnOptionDeprecation } from '../../src/warnings'
-import YAML from '../../src/index'
+import { YAML } from '../../src/index'
 
 test('require a message and source for all errors', () => {
   const exp = /Invalid arguments/

--- a/tests/doc/foldFlowLines.js
+++ b/tests/doc/foldFlowLines.js
@@ -1,5 +1,9 @@
-import fold, { FOLD_FLOW, FOLD_QUOTED } from '../../src/foldFlowLines'
-import YAML from '../../src/index'
+import {
+  foldFlowLines as fold,
+  FOLD_FLOW,
+  FOLD_QUOTED
+} from '../../src/foldFlowLines'
+import { YAML } from '../../src/index'
 import { strOptions } from '../../src/tags/options'
 
 describe('plain', () => {

--- a/tests/doc/parse.js
+++ b/tests/doc/parse.js
@@ -1,6 +1,6 @@
 import fs from 'fs'
 import path from 'path'
-import YAML from '../../src/index'
+import { YAML } from '../../src/index'
 
 describe('tags', () => {
   describe('implicit tags', () => {

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -1,6 +1,6 @@
 import { source } from 'common-tags'
-import YAML from '../../src/index'
-import Pair from '../../src/schema/Pair'
+import { YAML } from '../../src/index'
+import { Pair } from '../../src/schema/Pair'
 import { Type } from '../../src/constants'
 import { stringifyString } from '../../src/stringify'
 import { strOptions } from '../../src/tags/options'

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -1,8 +1,8 @@
-import YAML from '../../src/index'
-import Scalar from '../../src/schema/Scalar'
-import YAMLSeq from '../../src/schema/Seq'
+import { YAML } from '../../src/index'
+import { Scalar } from '../../src/schema/Scalar'
+import { YAMLSeq } from '../../src/schema/Seq'
 import { strOptions } from '../../src/tags/options'
-import binary from '../../src/tags/yaml-1.1/binary'
+import { binary } from '../../src/tags/yaml-1.1/binary'
 import { YAMLOMap } from '../../src/tags/yaml-1.1/omap'
 import { YAMLSet } from '../../src/tags/yaml-1.1/set'
 

--- a/tests/properties.js
+++ b/tests/properties.js
@@ -1,4 +1,4 @@
-import YAML from '../src/index'
+import { YAML } from '../src/index'
 import * as fc from 'fast-check'
 
 describe('properties', () => {

--- a/tests/yaml-test-suite.js
+++ b/tests/yaml-test-suite.js
@@ -1,9 +1,9 @@
 import fs from 'fs'
 import path from 'path'
 
-import YAML from '../src/index'
+import { YAML } from '../src/index'
 import { strOptions } from '../src/tags/options'
-import testEvents from '../src/test-events'
+import { testEvents } from '../src/test-events'
 
 const testDirs = fs
   .readdirSync(path.resolve(__dirname, 'yaml-test-suite'))

--- a/types.js
+++ b/types.js
@@ -1,11 +1,11 @@
-var opt = require('./dist/tags/options')
+const opt = require('./dist/tags/options')
 exports.binaryOptions = opt.binaryOptions
 exports.boolOptions = opt.boolOptions
 exports.nullOptions = opt.nullOptions
 exports.strOptions = opt.strOptions
 
-exports.Schema = require('./dist/schema').default
-exports.YAMLMap = require('./dist/schema/Map').default
-exports.YAMLSeq = require('./dist/schema/Seq').default
-exports.Pair = require('./dist/schema/Pair').default
-exports.Scalar = require('./dist/schema/Scalar').default
+exports.Schema = require('./dist/schema').Schema
+exports.YAMLMap = require('./dist/schema/Map').YAMLMap
+exports.YAMLSeq = require('./dist/schema/Seq').YAMLSeq
+exports.Pair = require('./dist/schema/Pair').Pair
+exports.Scalar = require('./dist/schema/Scalar').Scalar

--- a/types.mjs
+++ b/types.mjs
@@ -5,16 +5,16 @@ export const nullOptions = opt.nullOptions
 export const strOptions = opt.strOptions
 
 import schema from './dist/schema/index.js'
-export const Schema = schema.default
+export const Schema = schema.Schema
 
 import map from './dist/schema/Map.js'
-export const YAMLMap = map.default
+export const YAMLMap = map.YAMLMap
 
 import seq from './dist/schema/Seq.js'
-export const YAMLSeq = seq.default
+export const YAMLSeq = seq.YAMLSeq
 
 import pair from './dist/schema/Pair.js'
-export const Pair = pair.default
+export const Pair = pair.Pair
 
 import scalar from './dist/schema/Scalar.js'
-export const Scalar = scalar.default
+export const Scalar = scalar.Scalar

--- a/types/binary.js
+++ b/types/binary.js
@@ -1,7 +1,7 @@
 'use strict'
 Object.defineProperty(exports, '__esModule', { value: true })
 
-exports.binary = require('../dist/tags/yaml-1.1/binary').default
+exports.binary = require('../dist/tags/yaml-1.1/binary').binary
 exports.default = [exports.binary]
 
 require('../dist/warnings').warnFileDeprecation(__filename)

--- a/types/omap.js
+++ b/types/omap.js
@@ -1,2 +1,2 @@
-module.exports = require('../dist/tags/yaml-1.1/omap').default
+module.exports = require('../dist/tags/yaml-1.1/omap').omap
 require('../dist/warnings').warnFileDeprecation(__filename)

--- a/types/pairs.js
+++ b/types/pairs.js
@@ -1,2 +1,2 @@
-module.exports = require('../dist/tags/yaml-1.1/pairs').default
+module.exports = require('../dist/tags/yaml-1.1/pairs').pairs
 require('../dist/warnings').warnFileDeprecation(__filename)

--- a/types/set.js
+++ b/types/set.js
@@ -1,2 +1,2 @@
-module.exports = require('../dist/tags/yaml-1.1/set').default
+module.exports = require('../dist/tags/yaml-1.1/set').set
 require('../dist/warnings').warnFileDeprecation(__filename)

--- a/types/timestamp.js
+++ b/types/timestamp.js
@@ -1,7 +1,7 @@
 'use strict'
 Object.defineProperty(exports, '__esModule', { value: true })
 
-var ts = require('../dist/tags/yaml-1.1/timestamp')
+const ts = require('../dist/tags/yaml-1.1/timestamp')
 exports.default = [ts.intTime, ts.floatTime, ts.timestamp]
 exports.floatTime = ts.floatTime
 exports.intTime = ts.intTime

--- a/util.js
+++ b/util.js
@@ -1,14 +1,14 @@
 exports.findPair = require('./dist/schema/Map').findPair
-exports.parseMap = require('./dist/schema/parseMap').default
-exports.parseSeq = require('./dist/schema/parseSeq').default
+exports.parseMap = require('./dist/schema/parseMap').parseMap
+exports.parseSeq = require('./dist/schema/parseSeq').parseSeq
 
-var str = require('./dist/stringify')
+const str = require('./dist/stringify')
 exports.stringifyNumber = str.stringifyNumber
 exports.stringifyString = str.stringifyString
-exports.toJSON = require('./dist/toJSON').default
+exports.toJSON = require('./dist/toJSON').toJSON
 exports.Type = require('./dist/constants').Type
 
-var err = require('./dist/errors')
+const err = require('./dist/errors')
 exports.YAMLReferenceError = err.YAMLReferenceError
 exports.YAMLSemanticError = err.YAMLSemanticError
 exports.YAMLSyntaxError = err.YAMLSyntaxError

--- a/util.mjs
+++ b/util.mjs
@@ -2,17 +2,17 @@ import map from './dist/schema/Map.js'
 export const findPair = map.findPair
 
 import parseMapPkg from './dist/schema/parseMap.js'
-export const parseMap = parseMapPkg.default
+export const parseMap = parseMapPkg.parseMap
 
 import parseSeqPkg from './dist/schema/parseSeq.js'
-export const parseSeq = parseSeqPkg.default
+export const parseSeq = parseSeqPkg.parseSeq
 
 import str from './dist/stringify.js'
 export const stringifyNumber = str.stringifyNumber
 export const stringifyString = str.stringifyString
 
 import toJsonPkg from './dist/toJSON.js'
-export const toJSON = toJsonPkg.default
+export const toJSON = toJsonPkg.toJSON
 
 import constants from './dist/constants.js'
 export const Type = constants.Type


### PR DESCRIPTION
It's tricky to get multi-platform targeting libraries right these days. Currently, `yaml` supports:

- CJS Node >=6
- ESM Node >=13
- Bundlers like Webpack & Rollup

To achieve that, the ESM sources are transpiled first to CJS under `dist/`, with a Node 6.5 target (actually giving us 6.0 support), and then to ESM under `browser/dist/`, with a Browserslist target that includes IE 11.

CJS Node finds its sources by just automatically adding a `.js` file extension, and then finding a manually crafted re-exporter from `dist/`. ESM Node goes via the `"exports"` object in the package.json, but does much the same. Both of these use the same CJS implementation internally.

Bundlers find their target via the `"browser"` package.json object, which leads to similar re-exporters from `browser/dist/` as for Node.

Eventually, I'd really like to be able to consolidate all of those into one ESM build, but that'll take some time yet for earlier Node versions to go out of favor, and possibly IE 11 as well -- and require a semver-major update to this library. Meanwhile, this PR is about taking a couple of small steps towards a bit more sanity.

Internally, this switches all exports and imports to be named, rather than defaults. This allows us to drop Webpack's `_interopRequire*` wrappers for `require()` calls, and not need an `__esModule` prop in each module.

The browser re-exporters are switched from CJS to ESM, as the implementation they're re-exporting is already ESM. This should be completely transparent to any normal users, but in the particular case of having a custom UMD build of just `yaml`, you may need to specify that you want its `default` export exposed. The Webpack option for this is `output.libraryExport: 'default'`. 