### PR TITLE
Support BigInt values

### DIFF
--- a/browser/types.js
+++ b/browser/types.js
@@ -1,6 +1,7 @@
 export {
   binaryOptions,
   boolOptions,
+  intOptions,
   nullOptions,
   strOptions
 } from './dist/tags/options'

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,13 @@ import { parse as parseCST } from './cst/parse'
 import { Document as YAMLDocument } from './Document'
 import { YAMLSemanticError } from './errors'
 import { Schema } from './schema'
+import {
+  binaryOptions,
+  boolOptions,
+  intOptions,
+  nullOptions,
+  strOptions
+} from './tags/options'
 import { warn } from './warnings'
 
 const defaultOptions = {
@@ -15,6 +22,39 @@ const defaultOptions = {
   prettyErrors: false, // TODO Set true in v2
   simpleKeys: false,
   version: '1.2'
+}
+
+const scalarOptions = {
+  get binary() {
+    return binaryOptions
+  },
+  set binary(opt) {
+    Object.assign(binaryOptions, opt)
+  },
+  get bool() {
+    return boolOptions
+  },
+  set bool(opt) {
+    Object.assign(boolOptions, opt)
+  },
+  get int() {
+    return intOptions
+  },
+  set int(opt) {
+    Object.assign(intOptions, opt)
+  },
+  get null() {
+    return nullOptions
+  },
+  set null(opt) {
+    Object.assign(nullOptions, opt)
+  },
+  get str() {
+    return strOptions
+  },
+  set str(opt) {
+    Object.assign(strOptions, opt)
+  }
 }
 
 function createNode(value, wrapScalars = true, tag) {
@@ -81,5 +121,6 @@ export const YAML = {
   parseAllDocuments,
   parseCST,
   parseDocument,
+  scalarOptions,
   stringify
 }

--- a/src/stringify.js
+++ b/src/stringify.js
@@ -14,6 +14,7 @@ const getFoldOptions = ({ indentAtStart }) =>
     : strOptions.fold
 
 export function stringifyNumber({ format, minFractionDigits, tag, value }) {
+  if (typeof value === 'bigint') return String(value)
   if (!isFinite(value))
     return isNaN(value) ? '.nan' : value < 0 ? '-.inf' : '.inf'
   let n = JSON.stringify(value)

--- a/src/tags/options.js
+++ b/src/tags/options.js
@@ -7,6 +7,8 @@ export const binaryOptions = {
 
 export const boolOptions = { trueStr: 'true', falseStr: 'false' }
 
+export const intOptions = { asBigInt: false }
+
 export const nullOptions = { nullStr: 'null' }
 
 export const strOptions = {

--- a/src/toJSON.js
+++ b/src/toJSON.js
@@ -12,5 +12,6 @@ export function toJSON(value, arg, ctx) {
     if (anchor && ctx.onCreate) ctx.onCreate(res)
     return res
   }
+  if ((!ctx || !ctx.keep) && typeof value === 'bigint') return Number(value)
   return value
 }

--- a/tests/doc/YAML-1.2.spec.js
+++ b/tests/doc/YAML-1.2.spec.js
@@ -1,5 +1,4 @@
 import { YAML } from '../../src/index'
-import { strOptions } from '../../src/tags/options'
 
 const collectionKeyWarning =
   'Keys with collection values will be stringified as YAML due to JS Object restrictions. Use mapAsMap: true to avoid this.'
@@ -1840,15 +1839,15 @@ matches %: 20`,
 let origFoldOptions
 
 beforeAll(() => {
-  origFoldOptions = strOptions.fold
-  strOptions.fold = {
+  origFoldOptions = YAML.scalarOptions.str.fold
+  YAML.scalarOptions.str.fold = {
     lineWidth: 20,
     minContentWidth: 0
   }
 })
 
 afterAll(() => {
-  strOptions.fold = origFoldOptions
+  YAML.scalarOptions.str.fold = origFoldOptions
 })
 
 for (const section in spec) {

--- a/tests/doc/foldFlowLines.js
+++ b/tests/doc/foldFlowLines.js
@@ -4,7 +4,6 @@ import {
   FOLD_QUOTED
 } from '../../src/foldFlowLines'
 import { YAML } from '../../src/index'
-import { strOptions } from '../../src/tags/options'
 
 describe('plain', () => {
   const src = 'abc def ghi jkl mno pqr stu vwx yz\n'
@@ -195,15 +194,15 @@ describe('end-to-end', () => {
   let origFoldOptions
 
   beforeAll(() => {
-    origFoldOptions = strOptions.fold
-    strOptions.fold = {
+    origFoldOptions = YAML.scalarOptions.str.fold
+    YAML.scalarOptions.str.fold = {
       lineWidth: 20,
       minContentWidth: 0
     }
   })
 
   afterAll(() => {
-    strOptions.fold = origFoldOptions
+    YAML.scalarOptions.str.fold = origFoldOptions
   })
 
   test('more-indented folded block', () => {

--- a/tests/doc/parse.js
+++ b/tests/doc/parse.js
@@ -1,7 +1,6 @@
 import fs from 'fs'
 import path from 'path'
 import { YAML } from '../../src/index'
-import { intOptions } from '../../src/tags/options'
 
 describe('tags', () => {
   describe('implicit tags', () => {
@@ -142,11 +141,11 @@ describe('number types', () => {
   describe('asBigInt: true', () => {
     let prevAsBigInt
     beforeAll(() => {
-      prevAsBigInt = intOptions.asBigInt
-      intOptions.asBigInt = true
+      prevAsBigInt = YAML.scalarOptions.int.asBigInt
+      YAML.scalarOptions.int.asBigInt = true
     })
     afterAll(() => {
-      intOptions.asBigInt = prevAsBigInt
+      YAML.scalarOptions.int.asBigInt = prevAsBigInt
     })
 
     test('Version 1.1', () => {

--- a/tests/doc/parse.js
+++ b/tests/doc/parse.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import { YAML } from '../../src/index'
+import { intOptions } from '../../src/tags/options'
 
 describe('tags', () => {
   describe('implicit tags', () => {
@@ -76,8 +77,9 @@ describe('tags', () => {
 })
 
 describe('number types', () => {
-  test('Version 1.1', () => {
-    const src = `
+  describe('asBigInt: false', () => {
+    test('Version 1.1', () => {
+      const src = `
 - 0b10_10
 - 0123
 - -00
@@ -88,27 +90,27 @@ describe('number types', () => {
 - 4.20
 - .42
 - 00.4`
-    const doc = YAML.parseDocument(src, { version: '1.1' })
-    expect(doc.contents.items).toMatchObject([
-      { value: 10, format: 'BIN' },
-      { value: 83, format: 'OCT' },
-      { value: 0, format: 'OCT' },
-      { value: 123456 },
-      { value: 310, format: 'EXP' },
-      { value: 0.5123, format: 'EXP' },
-      { value: 4.02 },
-      { value: 4.2, minFractionDigits: 2 },
-      { value: 0.42 },
-      { value: 0.4 }
-    ])
-    expect(doc.contents.items[3]).not.toHaveProperty('format')
-    expect(doc.contents.items[6]).not.toHaveProperty('format')
-    expect(doc.contents.items[6]).not.toHaveProperty('minFractionDigits')
-    expect(doc.contents.items[7]).not.toHaveProperty('format')
-  })
+      const doc = YAML.parseDocument(src, { version: '1.1' })
+      expect(doc.contents.items).toMatchObject([
+        { value: 10, format: 'BIN' },
+        { value: 83, format: 'OCT' },
+        { value: -0, format: 'OCT' },
+        { value: 123456 },
+        { value: 310, format: 'EXP' },
+        { value: 0.5123, format: 'EXP' },
+        { value: 4.02 },
+        { value: 4.2, minFractionDigits: 2 },
+        { value: 0.42 },
+        { value: 0.4 }
+      ])
+      expect(doc.contents.items[3]).not.toHaveProperty('format')
+      expect(doc.contents.items[6]).not.toHaveProperty('format')
+      expect(doc.contents.items[6]).not.toHaveProperty('minFractionDigits')
+      expect(doc.contents.items[7]).not.toHaveProperty('format')
+    })
 
-  test('Version 1.2', () => {
-    const src = `
+    test('Version 1.2', () => {
+      const src = `
 - 0o123
 - 0o0
 - 123456
@@ -118,22 +120,80 @@ describe('number types', () => {
 - 4.20
 - .42
 - 00.4`
-    const doc = YAML.parseDocument(src, { version: '1.2' })
-    expect(doc.contents.items).toMatchObject([
-      { value: 83, format: 'OCT' },
-      { value: 0, format: 'OCT' },
-      { value: 123456 },
-      { value: 310, format: 'EXP' },
-      { value: 0.5123, format: 'EXP' },
-      { value: 4.02 },
-      { value: 4.2, minFractionDigits: 2 },
-      { value: 0.42 },
-      { value: 0.4 }
-    ])
-    expect(doc.contents.items[2]).not.toHaveProperty('format')
-    expect(doc.contents.items[5]).not.toHaveProperty('format')
-    expect(doc.contents.items[5]).not.toHaveProperty('minFractionDigits')
-    expect(doc.contents.items[6]).not.toHaveProperty('format')
+      const doc = YAML.parseDocument(src, { version: '1.2' })
+      expect(doc.contents.items).toMatchObject([
+        { value: 83, format: 'OCT' },
+        { value: 0, format: 'OCT' },
+        { value: 123456 },
+        { value: 310, format: 'EXP' },
+        { value: 0.5123, format: 'EXP' },
+        { value: 4.02 },
+        { value: 4.2, minFractionDigits: 2 },
+        { value: 0.42 },
+        { value: 0.4 }
+      ])
+      expect(doc.contents.items[2]).not.toHaveProperty('format')
+      expect(doc.contents.items[5]).not.toHaveProperty('format')
+      expect(doc.contents.items[5]).not.toHaveProperty('minFractionDigits')
+      expect(doc.contents.items[6]).not.toHaveProperty('format')
+    })
+  })
+
+  describe('asBigInt: true', () => {
+    let prevAsBigInt
+    beforeAll(() => {
+      prevAsBigInt = intOptions.asBigInt
+      intOptions.asBigInt = true
+    })
+    afterAll(() => {
+      intOptions.asBigInt = prevAsBigInt
+    })
+
+    test('Version 1.1', () => {
+      const src = `
+- 0b10_10
+- 0123
+- -00
+- 123_456
+- 3.1e+2
+- 5.1_2_3E-1
+- 4.02`
+      const doc = YAML.parseDocument(src, { version: '1.1' })
+      expect(doc.contents.items).toMatchObject([
+        { value: 10n, format: 'BIN' },
+        { value: 83n, format: 'OCT' },
+        { value: 0n, format: 'OCT' },
+        { value: 123456n },
+        { value: 310, format: 'EXP' },
+        { value: 0.5123, format: 'EXP' },
+        { value: 4.02 }
+      ])
+      expect(doc.contents.items[3]).not.toHaveProperty('format')
+      expect(doc.contents.items[6]).not.toHaveProperty('format')
+      expect(doc.contents.items[6]).not.toHaveProperty('minFractionDigits')
+    })
+
+    test('Version 1.2', () => {
+      const src = `
+- 0o123
+- 0o0
+- 123456
+- 3.1e+2
+- 5.123E-1
+- 4.02`
+      const doc = YAML.parseDocument(src, { version: '1.2' })
+      expect(doc.contents.items).toMatchObject([
+        { value: 83n, format: 'OCT' },
+        { value: 0n, format: 'OCT' },
+        { value: 123456n },
+        { value: 310, format: 'EXP' },
+        { value: 0.5123, format: 'EXP' },
+        { value: 4.02 }
+      ])
+      expect(doc.contents.items[2]).not.toHaveProperty('format')
+      expect(doc.contents.items[5]).not.toHaveProperty('format')
+      expect(doc.contents.items[5]).not.toHaveProperty('minFractionDigits')
+    })
   })
 })
 

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -5,7 +5,6 @@ import { YAML } from '../../src/index'
 import { Pair } from '../../src/schema/Pair'
 import { Type } from '../../src/constants'
 import { stringifyString } from '../../src/stringify'
-import { strOptions } from '../../src/tags/options'
 
 for (const [name, version] of [
   ['YAML 1.1', '1.1'],
@@ -114,14 +113,14 @@ for (const [name, version] of [
     describe('string', () => {
       let origFoldOptions
       beforeAll(() => {
-        origFoldOptions = strOptions.fold
-        strOptions.fold = {
+        origFoldOptions = YAML.scalarOptions.str.fold
+        YAML.scalarOptions.str.fold = {
           lineWidth: 20,
           minContentWidth: 0
         }
       })
       afterAll(() => {
-        strOptions.fold = origFoldOptions
+        YAML.scalarOptions.str.fold = origFoldOptions
       })
 
       test('plain', () => {

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -78,7 +78,10 @@ describe('json schema', () => {
     expect(doc.errors).toHaveLength(2)
     doc.errors = []
     doc.contents.items.splice(2, 2)
-    expect(String(doc)).toBe('"canonical": 685230\n"decimal": -685230\n')
+    doc.set('bigint', 42n)
+    expect(String(doc)).toBe(
+      '"canonical": 685230\n"decimal": -685230\n"bigint": 42\n'
+    )
   })
 
   test('!!null', () => {

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -1,7 +1,6 @@
 import { YAML } from '../../src/index'
 import { Scalar } from '../../src/schema/Scalar'
 import { YAMLSeq } from '../../src/schema/Seq'
-import { strOptions } from '../../src/tags/options'
 import { binary } from '../../src/tags/yaml-1.1/binary'
 import { YAMLOMap } from '../../src/tags/yaml-1.1/omap'
 import { YAMLSet } from '../../src/tags/yaml-1.1/set'
@@ -9,15 +8,15 @@ import { YAMLSet } from '../../src/tags/yaml-1.1/set'
 let origFoldOptions
 
 beforeAll(() => {
-  origFoldOptions = strOptions.fold
-  strOptions.fold = {
+  origFoldOptions = YAML.scalarOptions.str.fold
+  YAML.scalarOptions.str.fold = {
     lineWidth: 20,
     minContentWidth: 0
   }
 })
 
 afterAll(() => {
-  strOptions.fold = origFoldOptions
+  YAML.scalarOptions.str.fold = origFoldOptions
 })
 
 describe('json schema', () => {
@@ -259,7 +258,7 @@ description:
       genericStr += String.fromCharCode(generic[i])
     expect(canonicalStr).toBe(genericStr)
     expect(canonicalStr.substr(0, 5)).toBe('GIF89')
-    strOptions.fold.lineWidth = 80
+    YAML.scalarOptions.str.fold.lineWidth = 80
     expect(String(doc))
       .toBe(`canonical: !!binary "R0lGODlhDAAMAIQAAP//9/X17unp5WZmZgAAAOfn515eXvPz7Y6OjuDg4J\\
   +fn5OTk6enp56enmlpaWNjY6Ojo4SEhP/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/++f/\\
@@ -271,7 +270,7 @@ generic: !!binary |-
   ZGUgd2l0aCBHSU1QACwAAAAADAAMAAAFLCAgjoEwnuNAFOhpEMTRiggcz4BNJHrv/zCFcLiwMWYN
   G84BwwEeECcgggoBADs=
 description: The binary value above is a tiny arrow encoded as a gif image.\n`)
-    strOptions.fold.lineWidth = 20
+    YAML.scalarOptions.str.fold.lineWidth = 20
   })
 
   test('!!bool', () => {

--- a/tests/yaml-test-suite.js
+++ b/tests/yaml-test-suite.js
@@ -2,7 +2,6 @@ import fs from 'fs'
 import path from 'path'
 
 import { YAML } from '../src/index'
-import { strOptions } from '../src/tags/options'
 import { testEvents } from '../src/test-events'
 
 const testDirs = fs
@@ -29,15 +28,15 @@ const matchJson = (docs, json) => {
 let origFoldOptions
 
 beforeAll(() => {
-  origFoldOptions = strOptions.fold
-  strOptions.fold = {
+  origFoldOptions = YAML.scalarOptions.str.fold
+  YAML.scalarOptions.str.fold = {
     lineWidth: 20,
     minContentWidth: 0
   }
 })
 
 afterAll(() => {
-  strOptions.fold = origFoldOptions
+  YAML.scalarOptions.str.fold = origFoldOptions
 })
 
 testDirs.forEach(dir => {

--- a/types.js
+++ b/types.js
@@ -1,6 +1,7 @@
 const opt = require('./dist/tags/options')
 exports.binaryOptions = opt.binaryOptions
 exports.boolOptions = opt.boolOptions
+exports.intOptions = opt.intOptions
 exports.nullOptions = opt.nullOptions
 exports.strOptions = opt.strOptions
 

--- a/types.mjs
+++ b/types.mjs
@@ -1,6 +1,7 @@
 import opt from './dist/tags/options.js'
 export const binaryOptions = opt.binaryOptions
 export const boolOptions = opt.boolOptions
+export const intOptions = opt.intOptions
 export const nullOptions = opt.nullOptions
 export const strOptions = opt.strOptions
 


### PR DESCRIPTION
The JavaScript [`number`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Number) is a 64-bit floating-point value, which means that for large values (above `Number.MIN_SAFE_INTEGER`, 2**53 - 1) it is unable to represent integers with complete accuracy. To help with that, [`BigInt`](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/BigInt) is now a part of the ECMAScript 2020 spec.

This PR adds support for stringifying `BigInt` values, and if the `asBigInt` scalar option is set, to parse all integers into BigInts. I also added `YAML.scalarOptions` as a more user-friendly endpoint for scalar options:

```js
YAML.parse('42')
// 42

YAML.scalarOptions.int.asBigInt = true
const n = YAML.parse('42')
// 42n

YAML.stringify(n)
// '42\n'
```