### PR TITLE
Fix types, dropping AST.{AstNode,ScalarNode,CollectionNode}

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -194,7 +194,7 @@ export class Document extends AST.Collection {
    */
   anchors: Document.Anchors
   /** The document contents. */
-  contents: AST.AstNode | null
+  contents: any
   /** Errors encountered during parsing. */
   errors: YAMLError[]
   /**
@@ -249,6 +249,7 @@ export class Document extends AST.Collection {
 
 export namespace Document {
   interface Parsed extends Document {
+    contents: AST.Node | null
     /** The schema used with the document. */
     schema: Schema
   }

--- a/tests/typings.ts
+++ b/tests/typings.ts
@@ -1,7 +1,7 @@
 // To test types, compile this file with tsc
 
 import * as YAML from '../index'
-import { YAMLMap, YAMLSeq } from '../types'
+import { YAMLMap, YAMLSeq, Pair } from '../types'
 
 YAML.parse('3.14159')
 // 3.14159
@@ -45,9 +45,9 @@ YAML.stringify({ number: 3, plain: 'string', block: 'two\nlines\n' })
 
 const src = '[{ a: A }, { b: B }]'
 const doc = YAML.parseDocument(src)
-const contents = doc.contents as YAMLSeq
+const seq = doc.contents as YAMLSeq
 const { anchors } = doc
-const [a, b] = contents.items as YAMLMap[]
+const [a, b] = seq.items as YAMLMap[]
 anchors.setAnchor(a.items[0].value) // 'a1'
 anchors.setAnchor(b.items[0].value) // 'a2'
 anchors.setAnchor(null, 'a1') // 'a1'
@@ -58,7 +58,7 @@ String(doc)
 // [ { a: A }, { b: &a2 B } ]
 
 const alias = anchors.createAlias(a, 'AA')
-contents.items.push(alias)
+seq.items.push(alias)
 const refs = new Map()
 doc.toJSON(null, (value, count) => refs.set(value, count))
 // [ { a: 'A' }, { b: 'B' }, { a: 'A' } ]
@@ -87,3 +87,7 @@ String(doc)
 //     },
 //   *AA
 // ]
+
+const map = new YAMLMap()
+map.items.push(new Pair('foo', 'bar'))
+doc.contents = map

--- a/types.d.ts
+++ b/types.d.ts
@@ -249,17 +249,6 @@ export class YAMLSeq extends AST.Collection {
 }
 
 export namespace AST {
-  type AstNode = ScalarNode | CollectionNode | Alias
-
-  type ScalarNode =
-    | BlockFolded
-    | BlockLiteral
-    | PlainValue
-    | QuoteDouble
-    | QuoteSingle
-
-  type CollectionNode = FlowMap | BlockMap | FlowSeq | BlockSeq
-
   class Node {
     /** A comment on or immediately after this */
     comment?: string | null
@@ -357,7 +346,7 @@ export namespace AST {
 
   interface Alias extends Node {
     type: Type.ALIAS
-    source: AstNode
+    source: Node
     cstNode?: CST.Alias
   }
 
@@ -381,13 +370,13 @@ export namespace AST {
 
   interface FlowSeq extends YAMLSeq {
     type: Type.FLOW_SEQ
-    items: Array<AstNode | Pair>
+    items: Array<Node>
     cstNode?: CST.FlowSeq
   }
 
   interface BlockSeq extends YAMLSeq {
     type: Type.SEQ
-    items: Array<AstNode | null>
+    items: Array<Node | null>
     cstNode?: CST.Seq
   }
 }


### PR DESCRIPTION
Fixes #156 

Some of the utility types were extraneous and incorrect. This also clarifies that `doc.contents` should only be strongly typed when the document has been parsed.
