### PR TITLE
Improve code & documentation around Pair.commentBefore

### DIFF
--- a/docs/05_content_nodes.md
+++ b/docs/05_content_nodes.md
@@ -194,7 +194,7 @@ doc.toString()
 
 To construct a `YAMLSeq` or `YAMLMap`, use [`YAML.createNode()`](#yaml-createnode) with array, object or iterable input, or create the collections directly by importing the classes from `yaml/types`.
 
-Once created, normal array operations may be used to modify the `items` array. New `Pair` objects may created by importing the class from `yaml/types` and using its `new Pair(key, value)` constructor.
+Once created, normal array operations may be used to modify the `items` array. New `Pair` objects may created either by importing the class from `yaml/types` and using its `new Pair(key, value)` constructor, or by using the `doc.schema.createPair(key, value)` method. The latter will recursively wrap the `key` and `value` as nodes.
 
 ## Comments
 

--- a/src/schema/Pair.js
+++ b/src/schema/Pair.js
@@ -37,12 +37,17 @@ export class Pair extends Node {
   }
 
   get commentBefore() {
-    return this.key && this.key.commentBefore
+    return this.key instanceof Node ? this.key.commentBefore : undefined
   }
 
   set commentBefore(cb) {
     if (this.key == null) this.key = new Scalar(null)
-    this.key.commentBefore = cb
+    if (this.key instanceof Node) this.key.commentBefore = cb
+    else {
+      const msg =
+        'Pair.commentBefore is an alias for Pair.key.commentBefore. To set it, the key must be a Node.'
+      throw new Error(msg)
+    }
   }
 
   addToJSMap(ctx, map) {

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -122,6 +122,7 @@ export class Schema {
   }
 
   createPair(key, value, ctx) {
+    if (!ctx) ctx = { wrapScalars: true }
     const k = this.createNode(key, ctx.wrapScalars, null, ctx)
     const v = this.createNode(value, ctx.wrapScalars, null, ctx)
     return new Pair(k, v)

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -1,5 +1,6 @@
 import { source } from 'common-tags'
 import { YAML } from '../../src/index'
+import { Pair } from '../../src/schema/Pair'
 
 describe('parse comments', () => {
   describe('body', () => {
@@ -838,5 +839,36 @@ a:
       ]
     })
     expect(String(doc)).toBe(src)
+  })
+})
+
+describe('Pair.commentBefore', () => {
+  test('Should get key comment', () => {
+    const key = YAML.createNode('foo', true)
+    const pair = new Pair(key, 42)
+    key.commentBefore = 'cc'
+    expect(pair.commentBefore).toBe('cc')
+  })
+
+  test('Should set key comment', () => {
+    const key = YAML.createNode('foo', true)
+    const pair = new Pair(key, 42)
+    pair.commentBefore = 'cc'
+    expect(key.commentBefore).toBe('cc')
+  })
+
+  test('Should create a key from a null value', () => {
+    const pair = new Pair(null, 42)
+    expect(pair.key).toBeNull()
+    pair.commentBefore = 'cc'
+    expect(pair.key).not.toBeNull()
+    expect(pair.key.commentBefore).toBe('cc')
+  })
+
+  test('Should throw for non-Node key', () => {
+    const pair = new Pair({ foo: 'bar' }, 42)
+    expect(() => {
+      pair.commentBefore = 'cc'
+    }).toThrow(/commentBefore is an alias/)
   })
 })

--- a/types.d.ts
+++ b/types.d.ts
@@ -22,7 +22,7 @@ export class Schema {
   constructor(options: Schema.Options)
   /**
    * Convert any value into a `Node` using this schema, recursively turning
-   * objects into collectsions.
+   * objects into collections.
    *
    * @param wrapScalars If `true`, also wraps plain values in `Scalar` objects;
    *   if undefined or `false` and `value` is not an object, it will be returned
@@ -36,6 +36,13 @@ export class Schema {
     tag?: string,
     ctx?: Schema.CreateNodeContext
   ): AST.Node
+  /**
+   * Convert a key and a value into a `Pair` using this schema, recursively
+   * wrapping all values as `Scalar` or `Collection` nodes.
+   *
+   * @param ctx To not wrap scalars, use a context `{ wrapScalars: false }`
+   */
+  createPair(key: any, value: any, ctx?: Schema.CreateNodeContext): Pair
   merge: boolean
   name: Schema.Name
   sortMapEntries: ((a: Pair, b: Pair) => number) | null


### PR DESCRIPTION
Fixes #157 

Following on from discussion with @cmoesel in the linked issue, this PR is doing two things:
1. Document the pre-existing `doc.schema.createPair(key, value)` method as an alternative way of creating a `Pair` object, which automatically wraps the `key` and `value` into nodes.
2. Be more explicit about `key` needing to be a node when getting or setting `pair.commentBefore`.