### PR TITLE
Switch browser build to use Rollup, drop @babel/runtime dependency

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,9 +4,7 @@ const plugins = [
 ]
 const envOptions = { modules: false, useBuiltIns: false }
 
-if (process.env.BABEL_ENV === 'browser') {
-  plugins.push('@babel/plugin-transform-runtime')
-} else {
+if (process.env.BABEL_ENV !== 'browser') {
   plugins.push(['@babel/plugin-transform-modules-commonjs', { strict: true }])
   envOptions.targets = { node: '6.5' }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `yaml` is a JavaScript parser and stringifier for [YAML](http://yaml.org/), a human friendly data serialization standard. It supports both parsing and stringifying data using all versions of YAML, along with all common data schemas. As a particularly distinguishing feature, `yaml` fully supports reading and writing comments and blank lines in YAML documents.
 
-The library is released under the ISC open source license, and the code is [available on GitHub](https://github.com/eemeli/yaml/). It runs on Node.js 6 and later with no external dependencies, and in browsers from IE 11 upwards (Note: `@babel/runtime` is used only by the `"browser"` entry point).
+The library is released under the ISC open source license, and the code is [available on GitHub](https://github.com/eemeli/yaml/). It has no external dependencies, and runs on Node.js 6 and later, and in browsers from IE 11 upwards.
 
 For more information, see the project's documentation site: [**eemeli.org/yaml**](https://eemeli.org/yaml/)
 

--- a/browser/map.js
+++ b/browser/map.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/ast').YAMLMap
-require('./dist/warnings').warnFileDeprecation(__filename)
+module.exports = require('./dist/types').YAMLMap
+require('./dist/legacy-exports').warnFileDeprecation(__filename)

--- a/browser/pair.js
+++ b/browser/pair.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/ast').Pair
-require('./dist/warnings').warnFileDeprecation(__filename)
+module.exports = require('./dist/types').Pair
+require('./dist/legacy-exports').warnFileDeprecation(__filename)

--- a/browser/parse-cst.js
+++ b/browser/parse-cst.js
@@ -1,1 +1,1 @@
-module.exports = require('./dist/cst/parse').parse
+module.exports = require('./dist/parse-cst').parse

--- a/browser/scalar.js
+++ b/browser/scalar.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/ast').Scalar
-require('./dist/warnings').warnFileDeprecation(__filename)
+module.exports = require('./dist/types').Scalar
+require('./dist/legacy-exports').warnFileDeprecation(__filename)

--- a/browser/schema.js
+++ b/browser/schema.js
@@ -1,7 +1,9 @@
-module.exports = require('./dist/doc/Schema').Schema
-const opt = require('./dist/tags/options')
-module.exports.nullOptions = opt.nullOptions
-module.exports.strOptions = opt.strOptions
-module.exports.stringify = require('./dist/stringify/stringifyString').stringifyString
+const types = require('./dist/types')
+const util = require('./dist/util')
 
-require('./dist/warnings').warnFileDeprecation(__filename)
+module.exports = types.Schema
+module.exports.nullOptions = types.nullOptions
+module.exports.strOptions = types.strOptions
+module.exports.stringify = util.stringifyString
+
+require('./dist/legacy-exports').warnFileDeprecation(__filename)

--- a/browser/seq.js
+++ b/browser/seq.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/ast').YAMLSeq
-require('./dist/warnings').warnFileDeprecation(__filename)
+module.exports = require('./dist/types').YAMLSeq
+require('./dist/legacy-exports').warnFileDeprecation(__filename)

--- a/browser/types.js
+++ b/browser/types.js
@@ -1,10 +1,1 @@
-export {
-  binaryOptions,
-  boolOptions,
-  intOptions,
-  nullOptions,
-  strOptions
-} from './dist/tags/options'
-
-export { Schema } from './dist/doc/Schema'
-export { Pair, Scalar, YAMLMap, YAMLSeq } from './dist/ast'
+export * from './dist/types.js'

--- a/browser/types/binary.js
+++ b/browser/types/binary.js
@@ -1,7 +1,8 @@
 'use strict'
 Object.defineProperty(exports, '__esModule', { value: true })
 
-exports.binary = require('../dist/tags/yaml-1.1/binary').binary
+const legacy = require('../dist/legacy-exports')
+exports.binary = legacy.binary
 exports.default = [exports.binary]
 
-require('../dist/warnings').warnFileDeprecation(__filename)
+legacy.warnFileDeprecation(__filename)

--- a/browser/types/omap.js
+++ b/browser/types/omap.js
@@ -1,2 +1,3 @@
-module.exports = require('../dist/tags/yaml-1.1/omap').omap
-require('../dist/warnings').warnFileDeprecation(__filename)
+const legacy = require('../dist/legacy-exports')
+module.exports = legacy.omap
+legacy.warnFileDeprecation(__filename)

--- a/browser/types/pairs.js
+++ b/browser/types/pairs.js
@@ -1,2 +1,3 @@
-module.exports = require('../dist/tags/yaml-1.1/pairs').pairs
-require('../dist/warnings').warnFileDeprecation(__filename)
+const legacy = require('../dist/legacy-exports')
+module.exports = legacy.pairs
+legacy.warnFileDeprecation(__filename)

--- a/browser/types/set.js
+++ b/browser/types/set.js
@@ -1,2 +1,3 @@
-module.exports = require('../dist/tags/yaml-1.1/set').set
-require('../dist/warnings').warnFileDeprecation(__filename)
+const legacy = require('../dist/legacy-exports')
+module.exports = legacy.set
+legacy.warnFileDeprecation(__filename)

--- a/browser/types/timestamp.js
+++ b/browser/types/timestamp.js
@@ -1,10 +1,10 @@
 'use strict'
 Object.defineProperty(exports, '__esModule', { value: true })
 
-const ts = require('../dist/tags/yaml-1.1/timestamp')
-exports.default = [ts.intTime, ts.floatTime, ts.timestamp]
-exports.floatTime = ts.floatTime
-exports.intTime = ts.intTime
-exports.timestamp = ts.timestamp
+const legacy = require('../dist/legacy-exports')
+exports.default = [legacy.intTime, legacy.floatTime, legacy.timestamp]
+exports.floatTime = legacy.floatTime
+exports.intTime = legacy.intTime
+exports.timestamp = legacy.timestamp
 
-require('../dist/warnings').warnFileDeprecation(__filename)
+legacy.warnFileDeprecation(__filename)

--- a/browser/util.js
+++ b/browser/util.js
@@ -1,15 +1,1 @@
-export { findPair, toJSON } from './dist/ast'
-export { resolveMap as parseMap } from './dist/resolve/resolveMap'
-export { resolveSeq as parseSeq } from './dist/resolve/resolveSeq'
-
-export { stringifyNumber } from './dist/stringify/stringifyNumber'
-export { stringifyString } from './dist/stringify/stringifyString'
-export { Type } from './dist/constants'
-
-export {
-  YAMLError,
-  YAMLReferenceError,
-  YAMLSemanticError,
-  YAMLSyntaxError,
-  YAMLWarning
-} from './dist/errors'
+export * from './dist/util.js'

--- a/docs/01_intro.md
+++ b/docs/01_intro.md
@@ -15,7 +15,7 @@ yarn add yaml
 - Can accept any string as input without throwing, parsing as much YAML out of it as it can, and
 - Supports parsing, modifying, and writing YAML comments.
 
-The library is released under the ISC open source license, and the code is [available on GitHub](https://github.com/eemeli/yaml/). It runs on Node.js 6 and later with no external dependencies, and in browsers from IE 11 upwards (Note: `@babel/runtime` is used only by the `"browser"` entry point).
+The library is released under the ISC open source license, and the code is [available on GitHub](https://github.com/eemeli/yaml/). It has no external dependencies, and runs on Node.js 6 and later, and in browsers from IE 11 upwards.
 
 For the purposes of versioning, any changes that break any of the endpoints or APIs documented here will be considered semver-major breaking changes. Undocumented library internals may change between minor versions, and previous APIs may be deprecated (but not removed).
 

--- a/map.js
+++ b/map.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/ast').YAMLMap
-require('./dist/warnings').warnFileDeprecation(__filename)
+module.exports = require('./dist/types').YAMLMap
+require('./dist/legacy-exports').warnFileDeprecation(__filename)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1738,6 +1738,27 @@
         }
       }
     },
+    "@rollup/plugin-babel": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.0.0.tgz",
+      "integrity": "sha512-YpVnwdUeVj/fDFN75Y3CAzJTMYNcqbH05SJs551wqj+BSwLT9pS3dqJrVDPYl3eH4OrI8ueiEseX5VgUn+0HLA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.7.4",
+        "@rollup/pluginutils": "^3.0.8"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.10.tgz",
+      "integrity": "sha512-d44M7t+PjmMrASHbhgpSbVgtL6EFyX7J4mYxwQ/c5eoaE6N2VgCgEcWVzNnwycIloti+/MpwFr8qfw+nRw00sw==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
@@ -1792,6 +1813,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
     "@types/istanbul-lib-coverage": {
@@ -3095,6 +3122,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
     },
     "esutils": {
@@ -7285,6 +7318,24 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.7.6.tgz",
+      "integrity": "sha512-AdHosxHBKyBsdtbT1/AqbWNQ87O4SSxS4N9iMwEpoCDAT6e4Du3uJSy83mp3ckgmCxly5VeXGx0WHsm21Djytg==",
+      "dev": true,
+      "requires": {
+        "fsevents": "~2.1.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "rsvp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -837,18 +837,6 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
-    "@babel/plugin-transform-runtime": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.0.tgz",
-      "integrity": "sha512-pUu9VSf3kI1OqbWINQ7MaugnitRss1z533436waNXp+0N3ur3zfut37sXiQMxkuCF4VUjwZucen/quskCh7NHw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-plugin-utils": "^7.8.3",
-        "resolve": "^1.8.1",
-        "semver": "^5.5.1"
-      }
-    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
@@ -1010,6 +998,7 @@
       "version": "7.9.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
       "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -7098,7 +7087,8 @@
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.4",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
+    "@rollup/plugin-babel": "^5.0.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^25.3.0",
     "babel-plugin-trace": "^1.1.0",
@@ -110,6 +111,7 @@
     "fast-check": "^1.24.1",
     "jest": "^25.3.0",
     "prettier": "^2.0.4",
+    "rollup": "^2.7.6",
     "typescript": "^3.8.3"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "@babel/cli": "^7.8.4",
     "@babel/core": "^7.9.0",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-transform-runtime": "^7.9.0",
     "@babel/preset-env": "^7.9.5",
     "@rollup/plugin-babel": "^5.0.0",
     "babel-eslint": "^10.1.0",
@@ -113,9 +112,6 @@
     "prettier": "^2.0.4",
     "rollup": "^2.7.6",
     "typescript": "^3.8.3"
-  },
-  "dependencies": {
-    "@babel/runtime": "^7.9.2"
   },
   "engines": {
     "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "./": "./"
   },
   "scripts": {
-    "browser:build": "cross-env BABEL_ENV=browser babel src/ --out-dir browser/dist/",
+    "browser:build": "cross-env BABEL_ENV=browser rollup -c",
     "clean": "git clean -fdxe node_modules",
     "dist:build": "babel src/ --out-dir dist/",
     "build": "npm run dist:build && npm run browser:build",

--- a/pair.js
+++ b/pair.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/ast').Pair
-require('./dist/warnings').warnFileDeprecation(__filename)
+module.exports = require('./dist/types').Pair
+require('./dist/legacy-exports').warnFileDeprecation(__filename)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,13 @@
+import babel from '@rollup/plugin-babel'
+
+export default {
+  input: {
+    index: 'src/index.js',
+    'legacy-exports': 'src/legacy-exports.js',
+    'parse-cst': 'src/cst/parse.js',
+    types: 'src/types.js',
+    util: 'src/util.js'
+  },
+  output: { dir: 'browser/dist', format: 'esm' },
+  plugins: [babel({ babelHelpers: 'runtime' })]
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,5 +9,5 @@ export default {
     util: 'src/util.js'
   },
   output: { dir: 'browser/dist', format: 'esm' },
-  plugins: [babel({ babelHelpers: 'runtime' })]
+  plugins: [babel({ babelHelpers: 'bundled' })]
 }

--- a/scalar.js
+++ b/scalar.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/ast').Scalar
-require('./dist/warnings').warnFileDeprecation(__filename)
+module.exports = require('./dist/types').Scalar
+require('./dist/legacy-exports').warnFileDeprecation(__filename)

--- a/schema.js
+++ b/schema.js
@@ -1,7 +1,9 @@
-module.exports = require('./dist/doc/Schema').Schema
-const opt = require('./dist/tags/options')
-module.exports.nullOptions = opt.nullOptions
-module.exports.strOptions = opt.strOptions
-module.exports.stringify = require('./dist/stringify/stringifyString').stringifyString
+const types = require('./dist/types')
+const util = require('./dist/util')
 
-require('./dist/warnings').warnFileDeprecation(__filename)
+module.exports = types.Schema
+module.exports.nullOptions = types.nullOptions
+module.exports.strOptions = types.strOptions
+module.exports.stringify = util.stringifyString
+
+require('./dist/legacy-exports').warnFileDeprecation(__filename)

--- a/seq.js
+++ b/seq.js
@@ -1,2 +1,2 @@
-module.exports = require('./dist/ast').YAMLSeq
-require('./dist/warnings').warnFileDeprecation(__filename)
+module.exports = require('./dist/types').YAMLSeq
+require('./dist/legacy-exports').warnFileDeprecation(__filename)

--- a/src/legacy-exports.js
+++ b/src/legacy-exports.js
@@ -1,0 +1,7 @@
+export { binary } from './tags/yaml-1.1/binary.js'
+export { omap } from './tags/yaml-1.1/omap.js'
+export { pairs } from './tags/yaml-1.1/pairs.js'
+export { set } from './tags/yaml-1.1/set.js'
+export { floatTime, intTime, timestamp } from './tags/yaml-1.1/timestamp.js'
+
+export { warnFileDeprecation } from './warnings'

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,10 @@
+export {
+  binaryOptions,
+  boolOptions,
+  intOptions,
+  nullOptions,
+  strOptions
+} from './tags/options.js'
+
+export { Schema } from './doc/Schema.js'
+export { Pair, Scalar, YAMLMap, YAMLSeq } from './ast/index.js'

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,15 @@
+export { findPair, toJSON } from './ast/index.js'
+export { resolveMap as parseMap } from './resolve/resolveMap.js'
+export { resolveSeq as parseSeq } from './resolve/resolveSeq.js'
+
+export { stringifyNumber } from './stringify/stringifyNumber.js'
+export { stringifyString } from './stringify/stringifyString.js'
+export { Type } from './constants.js'
+
+export {
+  YAMLError,
+  YAMLReferenceError,
+  YAMLSemanticError,
+  YAMLSyntaxError,
+  YAMLWarning
+} from './errors.js'

--- a/types.js
+++ b/types.js
@@ -1,15 +1,13 @@
-const opt = require('./dist/tags/options')
-exports.binaryOptions = opt.binaryOptions
-exports.boolOptions = opt.boolOptions
-exports.intOptions = opt.intOptions
-exports.nullOptions = opt.nullOptions
-exports.strOptions = opt.strOptions
+const types = require('./dist/types')
 
-const schema = require('./dist/doc/Schema')
-exports.Schema = schema.Schema
+exports.binaryOptions = types.binaryOptions
+exports.boolOptions = types.boolOptions
+exports.intOptions = types.intOptions
+exports.nullOptions = types.nullOptions
+exports.strOptions = types.strOptions
 
-const ast = require('./dist/ast')
-exports.Pair = ast.Pair
-exports.Scalar = ast.Scalar
-exports.YAMLMap = ast.YAMLMap
-exports.YAMLSeq = ast.YAMLSeq
+exports.Schema = types.Schema
+exports.Pair = types.Pair
+exports.Scalar = types.Scalar
+exports.YAMLMap = types.YAMLMap
+exports.YAMLSeq = types.YAMLSeq

--- a/types.mjs
+++ b/types.mjs
@@ -1,15 +1,13 @@
-import opt from './dist/tags/options.js'
-export const binaryOptions = opt.binaryOptions
-export const boolOptions = opt.boolOptions
-export const intOptions = opt.intOptions
-export const nullOptions = opt.nullOptions
-export const strOptions = opt.strOptions
+import types from './dist/types.js'
 
-import schema from './dist/doc/Schema.js'
-export const Schema = schema.Schema
+export const binaryOptions = types.binaryOptions
+export const boolOptions = types.boolOptions
+export const intOptions = types.intOptions
+export const nullOptions = types.nullOptions
+export const strOptions = types.strOptions
 
-import ast from './dist/ast/index.js'
-export const Pair = ast.Pair
-export const Scalar = ast.Scalar
-export const YAMLMap = ast.YAMLMap
-export const YAMLSeq = ast.YAMLSeq
+export const Schema = types.Schema
+export const Pair = types.Pair
+export const Scalar = types.Scalar
+export const YAMLMap = types.YAMLMap
+export const YAMLSeq = types.YAMLSeq

--- a/types/binary.js
+++ b/types/binary.js
@@ -1,7 +1,8 @@
 'use strict'
 Object.defineProperty(exports, '__esModule', { value: true })
 
-exports.binary = require('../dist/tags/yaml-1.1/binary').binary
+const legacy = require('../dist/legacy-exports')
+exports.binary = legacy.binary
 exports.default = [exports.binary]
 
-require('../dist/warnings').warnFileDeprecation(__filename)
+legacy.warnFileDeprecation(__filename)

--- a/types/omap.js
+++ b/types/omap.js
@@ -1,2 +1,3 @@
-module.exports = require('../dist/tags/yaml-1.1/omap').omap
-require('../dist/warnings').warnFileDeprecation(__filename)
+const legacy = require('../dist/legacy-exports')
+module.exports = legacy.omap
+legacy.warnFileDeprecation(__filename)

--- a/types/pairs.js
+++ b/types/pairs.js
@@ -1,2 +1,3 @@
-module.exports = require('../dist/tags/yaml-1.1/pairs').pairs
-require('../dist/warnings').warnFileDeprecation(__filename)
+const legacy = require('../dist/legacy-exports')
+module.exports = legacy.pairs
+legacy.warnFileDeprecation(__filename)

--- a/types/set.js
+++ b/types/set.js
@@ -1,2 +1,3 @@
-module.exports = require('../dist/tags/yaml-1.1/set').set
-require('../dist/warnings').warnFileDeprecation(__filename)
+const legacy = require('../dist/legacy-exports')
+module.exports = legacy.set
+legacy.warnFileDeprecation(__filename)

--- a/types/timestamp.js
+++ b/types/timestamp.js
@@ -1,10 +1,10 @@
 'use strict'
 Object.defineProperty(exports, '__esModule', { value: true })
 
-const ts = require('../dist/tags/yaml-1.1/timestamp')
-exports.default = [ts.intTime, ts.floatTime, ts.timestamp]
-exports.floatTime = ts.floatTime
-exports.intTime = ts.intTime
-exports.timestamp = ts.timestamp
+const legacy = require('../dist/legacy-exports')
+exports.default = [legacy.intTime, legacy.floatTime, legacy.timestamp]
+exports.floatTime = legacy.floatTime
+exports.intTime = legacy.intTime
+exports.timestamp = legacy.timestamp
 
-require('../dist/warnings').warnFileDeprecation(__filename)
+legacy.warnFileDeprecation(__filename)

--- a/util.js
+++ b/util.js
@@ -1,20 +1,16 @@
-const ast = require('./dist/ast')
-exports.findPair = ast.findPair
-exports.toJSON = ast.toJSON
+const util = require('./dist/util')
 
-const resolveMapPkg = require('./dist/resolve/resolveMap')
-exports.parseMap = resolveMapPkg.resolveMap
+exports.findPair = util.findPair
+exports.toJSON = util.toJSON
+exports.parseMap = util.parseMap
+exports.parseSeq = util.parseSeq
 
-const resolveSeqPkg = require('./dist/resolve/resolveSeq')
-exports.parseSeq = resolveSeqPkg.resolveSeq
+exports.stringifyNumber = util.stringifyNumber
+exports.stringifyString = util.stringifyString
+exports.Type = util.Type
 
-exports.stringifyNumber = require('./dist/stringify/stringifyNumber').stringifyNumber
-exports.stringifyString = require('./dist/stringify/stringifyString').stringifyString
-exports.Type = require('./dist/constants').Type
-
-const err = require('./dist/errors')
-exports.YAMLError = err.YAMLError
-exports.YAMLReferenceError = err.YAMLReferenceError
-exports.YAMLSemanticError = err.YAMLSemanticError
-exports.YAMLSyntaxError = err.YAMLSyntaxError
-exports.YAMLWarning = err.YAMLWarning
+exports.YAMLError = util.YAMLError
+exports.YAMLReferenceError = util.YAMLReferenceError
+exports.YAMLSemanticError = util.YAMLSemanticError
+exports.YAMLSyntaxError = util.YAMLSyntaxError
+exports.YAMLWarning = util.YAMLWarning

--- a/util.mjs
+++ b/util.mjs
@@ -1,25 +1,18 @@
-import ast from './dist/ast/index.js'
-export const findPair = ast.findPair
-export const toJSON = ast.toJSON
+import util from './dist/util.js'
 
-import resolveMapPkg from './dist/resolve/resolveMap.js'
-export const parseMap = resolveMapPkg.resolveMap
+export const findPair = util.findPair
+export const toJSON = util.toJSON
 
-import resolveSeqPkg from './dist/resolve/resolveSeq.js'
-export const parseSeq = resolveSeqPkg.resolveSeq
+export const parseMap = util.parseMap
+export const parseSeq = util.parseSeq
 
-import strNumPkg from './dist/stringify/stringifyNumber.js'
-export const stringifyNumber = strNumPkg.stringifyNumber
+export const stringifyNumber = util.stringifyNumber
+export const stringifyString = util.stringifyString
 
-import strStrPkg from './dist/stringify/stringifyString.js'
-export const stringifyString = strStrPkg.stringifyString
+export const Type = util.Type
 
-import constants from './dist/constants.js'
-export const Type = constants.Type
-
-import err from './dist/errors.js'
-export const YAMLError = err.YAMLError
-export const YAMLReferenceError = err.YAMLReferenceError
-export const YAMLSemanticError = err.YAMLSemanticError
-export const YAMLSyntaxError = err.YAMLSyntaxError
-export const YAMLWarning = err.YAMLWarning
+export const YAMLError = util.YAMLError
+export const YAMLReferenceError = util.YAMLReferenceError
+export const YAMLSemanticError = util.YAMLSemanticError
+export const YAMLSyntaxError = util.YAMLSyntaxError
+export const YAMLWarning = util.YAMLWarning


### PR DESCRIPTION
One of the nice things Rollup does is that given multiple entry points, it'll automatically dedupe all their dependencies. This allows the 70-ish source files of `yaml` to be bundled into a much smaller number, which I figured might make it more bearable to bundle in the helpers that we've been getting from `@babel/runtime`.

As it turns out, the final output is actually _smaller_ with Rollup if the helpers are bundled in. I have no idea why. But everything still seems to work fine, even in IE 11. The current total minified, gzipped size of the library is about 56k.

To help with this, the various public entry points are now pointing to a much smaller set of re-exporters, rather than deep within the library.