### PR TITLE
Add directivesEndMarker to Document type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -187,6 +187,7 @@ export class Document extends AST.Collection {
   cstNode?: CST.Document
   constructor(options?: Options)
   tag: never
+  directivesEndMarker?: boolean
   type: Type.DOCUMENT
   /**
    * Anchors associated with the document's nodes;


### PR DESCRIPTION
Noticed this was missing when I tried to create a document in typescript on v1.9.2

Not sure if this is the right place to add or if the `.d.ts` files are generated in someway