### PR TITLE
Better errors for bad indents

### DIFF
--- a/tests/doc/errors.js
+++ b/tests/doc/errors.js
@@ -77,6 +77,52 @@ describe('eemeli/yaml#7', () => {
   })
 })
 
+describe('block collections', () => {
+  test('mapping with bad indentation', () => {
+    const src = 'foo: "1"\n bar: 2\n'
+    const doc = YAML.parseDocument(src)
+    expect(doc.errors).toMatchObject([
+      { message: 'All collection items must start at the same column' }
+    ])
+    expect(doc.contents).toMatchObject({
+      type: 'MAP',
+      items: [
+        { key: { value: 'foo' }, value: { value: '1' } },
+        { key: { value: 'bar' }, value: { value: 2 } }
+      ]
+    })
+  })
+
+  test('sequence with bad indentation', () => {
+    const src = '- "foo"\n - bar\n'
+    const doc = YAML.parseDocument(src)
+    expect(doc.errors).toMatchObject([
+      { message: 'All collection items must start at the same column' }
+    ])
+    expect(doc.contents).toMatchObject({
+      type: 'SEQ',
+      items: [{ value: 'foo' }, { value: 'bar' }]
+    })
+  })
+
+  test('seq item in mapping', () => {
+    const src = 'foo: "1"\n- bar\n'
+    const doc = YAML.parseDocument(src)
+    expect(doc.errors).toMatchObject([
+      { message: 'A collection cannot be both a mapping and a sequence' },
+      { message: 'Failed to resolve SEQ_ITEM node here' },
+      { message: 'Implicit map keys need to be followed by map values' }
+    ])
+    expect(doc.contents).toMatchObject({
+      type: 'MAP',
+      items: [
+        { key: { value: 'foo' }, value: { value: '1' } },
+        { key: null, value: null }
+      ]
+    })
+  })
+})
+
 describe('missing flow collection terminator', () => {
   test('start only of flow map (eemeli/yaml#8)', () => {
     const doc = YAML.parseDocument('{', { prettyErrors: true })

--- a/tests/doc/errors.js
+++ b/tests/doc/errors.js
@@ -243,10 +243,14 @@ describe('invalid options', () => {
 
 test('broken document with comment before first node', () => {
   const doc = YAML.parseDocument('#c\n*x\nfoo\n')
-  expect(doc.contents).toMatchObject([null, { type: 'PLAIN' }])
+  expect(doc.contents).toBeNull()
   expect(doc.errors).toMatchObject([
-    { name: 'YAMLReferenceError' },
-    { name: 'YAMLSyntaxError' }
+    { name: 'YAMLReferenceError', message: 'Aliased anchor not found: x' },
+    {
+      name: 'YAMLSyntaxError',
+      message:
+        'Document contains trailing content not separated by a ... or --- line'
+    }
   ])
 })
 


### PR DESCRIPTION
This replaces the single error "Document is not valid YAML (bad indentation?)" with three more specific ones:
- "All collection items must start at the same column"
- "A collection cannot be both a mapping and a sequence"
- "Document contains trailing content not separated by a ... or --- line"

I've also recently added the following related errors:
- "Block scalars must not be less indented than their first line"
- "Block scalars must not be less indented than their explicit indentation indicator"
- "Block scalars with more-indented leading empty lines must use an explicit indentation indicator"

Given all that, the CST parser should now far more rarely produce documents with more than one content node, and the AST `doc.parse(cst)` method could be modified to always set `doc.contents` to the first content node's value, rather than including all of them as an array in some cases.

These changes mean that invalid input is handled a little bit differently than before, including the CST that's produced from it. Where possible, the graph should now more closely resemble its intended form, rather than just breaking in two.