### PR TITLE
Improve quoted string flexibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -163,7 +163,7 @@ export namespace scalarOptions {
      */
     defaultType: Scalar.Type
     /**
-     * Use single quote (') as a default quoting style of strings
+     * Use 'single quote' rather than "double quote" by default
      *
      * Default: `false`
      */

--- a/index.d.ts
+++ b/index.d.ts
@@ -163,11 +163,11 @@ export namespace scalarOptions {
      */
     defaultType: Scalar.Type
     /**
-     * The default quoting style of strings
+     * Use single quote (') as a default quoting style of strings
      *
-     * Default: `'QUOTE_DOUBLE'`
+     * Default: `false`
      */
-    defaultQuote: Scalar.Type
+    defaultQuoteSingle: boolean
     doubleQuoted: {
       /**
        * Whether to restrict double-quoted strings to use JSON-compatible syntax.

--- a/index.d.ts
+++ b/index.d.ts
@@ -162,6 +162,12 @@ export namespace scalarOptions {
      * Default: `'PLAIN'`
      */
     defaultType: Scalar.Type
+    /**
+     * The default quoting style of strings
+     *
+     * Default: `'QUOTE_DOUBLE'`
+     */
+    defaultQuote: Scalar.Type
     doubleQuoted: {
       /**
        * Whether to restrict double-quoted strings to use JSON-compatible syntax.

--- a/src/stringify/stringifyString.js
+++ b/src/stringify/stringifyString.js
@@ -219,10 +219,12 @@ function plainString(item, ctx, onComment, onChompKeep) {
       value
     )
   ) {
+    const hasDouble = value.indexOf('"') !== -1
+    const hasSingle = value.indexOf("'") !== -1
     let quotedString
-    if (value.indexOf('"') !== -1 && value.indexOf("'") === -1) {
+    if (hasDouble && !hasSingle) {
       quotedString = singleQuotedString
-    } else if (value.indexOf("'") !== -1 && value.indexOf('"') === -1) {
+    } else if (hasSingle && !hasDouble) {
       quotedString = doubleQuotedString
     } else if (strOptions.defaultQuoteSingle) {
       quotedString = singleQuotedString

--- a/src/stringify/stringifyString.js
+++ b/src/stringify/stringifyString.js
@@ -204,7 +204,7 @@ function blockString({ comment, type, value }, ctx, onComment, onChompKeep) {
   return `${header}\n${indent}${body}`
 }
 
-function plainString(item, ctx, onComment, onChompKeep) {
+function plainString(item, ctx, onComment, onChompKeep, defaultQuote) {
   const { comment, type, value } = item
   const { actualString, implicitKey, indent, inFlow } = ctx
   if (
@@ -219,6 +219,15 @@ function plainString(item, ctx, onComment, onChompKeep) {
       value
     )
   ) {
+    // prettier-ignore
+    const defaultQuotedString =
+      value.indexOf('"') !== -1 && value.indexOf("'") === -1
+        ? singleQuotedString
+        : value.indexOf("'") !== -1 && value.indexOf('"') === -1
+          ? doubleQuotedString
+          : defaultQuote === Type.QUOTE_SINGLE
+            ? singleQuotedString
+            : doubleQuotedString
     // not allowed:
     // - empty string, '-' or '?'
     // - start with an indicator character (except [?:-]) or /[?-] /
@@ -226,9 +235,7 @@ function plainString(item, ctx, onComment, onChompKeep) {
     // - '#' not preceded by a non-space char
     // - end with ' ' or ':'
     return implicitKey || inFlow || value.indexOf('\n') === -1
-      ? value.indexOf('"') !== -1 && value.indexOf("'") === -1
-        ? singleQuotedString(value, ctx)
-        : doubleQuotedString(value, ctx)
+      ? defaultQuotedString(value, ctx)
       : blockString(item, ctx, onComment, onChompKeep)
   }
   if (
@@ -268,7 +275,7 @@ function plainString(item, ctx, onComment, onChompKeep) {
 }
 
 export function stringifyString(item, ctx, onComment, onChompKeep) {
-  const { defaultType } = strOptions
+  const { defaultType, defaultQuote } = strOptions
   const { implicitKey, inFlow } = ctx
   let { type, value } = item
   if (typeof value !== 'string') {
@@ -285,7 +292,7 @@ export function stringifyString(item, ctx, onComment, onChompKeep) {
       case Type.QUOTE_SINGLE:
         return singleQuotedString(value, ctx)
       case Type.PLAIN:
-        return plainString(item, ctx, onComment, onChompKeep)
+        return plainString(item, ctx, onComment, onChompKeep, defaultQuote)
       default:
         return null
     }

--- a/src/stringify/stringifyString.js
+++ b/src/stringify/stringifyString.js
@@ -204,7 +204,7 @@ function blockString({ comment, type, value }, ctx, onComment, onChompKeep) {
   return `${header}\n${indent}${body}`
 }
 
-function plainString(item, ctx, onComment, onChompKeep, defaultQuote) {
+function plainString(item, ctx, onComment, onChompKeep) {
   const { comment, type, value } = item
   const { actualString, implicitKey, indent, inFlow } = ctx
   if (
@@ -219,15 +219,16 @@ function plainString(item, ctx, onComment, onChompKeep, defaultQuote) {
       value
     )
   ) {
-    // prettier-ignore
-    const defaultQuotedString =
-      value.indexOf('"') !== -1 && value.indexOf("'") === -1
-        ? singleQuotedString
-        : value.indexOf("'") !== -1 && value.indexOf('"') === -1
-          ? doubleQuotedString
-          : defaultQuote === Type.QUOTE_SINGLE
-            ? singleQuotedString
-            : doubleQuotedString
+    let quotedString
+    if (value.indexOf('"') !== -1 && value.indexOf("'") === -1) {
+      quotedString = singleQuotedString
+    } else if (value.indexOf("'") !== -1 && value.indexOf('"') === -1) {
+      quotedString = doubleQuotedString
+    } else if (strOptions.defaultQuoteSingle) {
+      quotedString = singleQuotedString
+    } else {
+      quotedString = doubleQuotedString
+    }
     // not allowed:
     // - empty string, '-' or '?'
     // - start with an indicator character (except [?:-]) or /[?-] /
@@ -235,7 +236,7 @@ function plainString(item, ctx, onComment, onChompKeep, defaultQuote) {
     // - '#' not preceded by a non-space char
     // - end with ' ' or ':'
     return implicitKey || inFlow || value.indexOf('\n') === -1
-      ? defaultQuotedString(value, ctx)
+      ? quotedString(value, ctx)
       : blockString(item, ctx, onComment, onChompKeep)
   }
   if (
@@ -275,7 +276,7 @@ function plainString(item, ctx, onComment, onChompKeep, defaultQuote) {
 }
 
 export function stringifyString(item, ctx, onComment, onChompKeep) {
-  const { defaultType, defaultQuote } = strOptions
+  const { defaultType } = strOptions
   const { implicitKey, inFlow } = ctx
   let { type, value } = item
   if (typeof value !== 'string') {
@@ -292,7 +293,7 @@ export function stringifyString(item, ctx, onComment, onChompKeep) {
       case Type.QUOTE_SINGLE:
         return singleQuotedString(value, ctx)
       case Type.PLAIN:
-        return plainString(item, ctx, onComment, onChompKeep, defaultQuote)
+        return plainString(item, ctx, onComment, onChompKeep)
       default:
         return null
     }

--- a/src/tags/options.js
+++ b/src/tags/options.js
@@ -13,7 +13,7 @@ export const nullOptions = { nullStr: 'null' }
 
 export const strOptions = {
   defaultType: Type.PLAIN,
-  defaultQuote: Type.QUOTE_DOUBLE,
+  defaultQuoteSingle: false,
   doubleQuoted: {
     jsonEncoding: false,
     minMultiLineLength: 40

--- a/src/tags/options.js
+++ b/src/tags/options.js
@@ -13,6 +13,7 @@ export const nullOptions = { nullStr: 'null' }
 
 export const strOptions = {
   defaultType: Type.PLAIN,
+  defaultQuote: Type.QUOTE_DOUBLE,
   doubleQuoted: {
     jsonEncoding: false,
     minMultiLineLength: 40

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -625,10 +625,10 @@ describe('indentSeq: false', () => {
 describe('default quote option', () => {
   let origDefaultQuoteOption
   beforeAll(() => {
-    origDefaultQuoteOption = YAML.scalarOptions.str.defaultQuote
+    origDefaultQuoteOption = YAML.scalarOptions.str.defaultQuoteSingle
   })
   afterAll(() => {
-    YAML.scalarOptions.str.defaultQuote = origDefaultQuoteOption
+    YAML.scalarOptions.str.defaultQuoteSingle = origDefaultQuoteOption
   })
 
   const testSingleQuote = () => {
@@ -658,19 +658,19 @@ describe('default quote option', () => {
   }
 
   test('default', () => {
-    YAML.scalarOptions.str.defaultQuote = origDefaultQuoteOption
+    YAML.scalarOptions.str.defaultQuoteSingle = origDefaultQuoteOption
     testPlainStyle()
     testForcedQuotes()
     testDoubleQuote()
   })
   test("'", () => {
-    YAML.scalarOptions.str.defaultQuote = Type.QUOTE_SINGLE
+    YAML.scalarOptions.str.defaultQuoteSingle = true
     testPlainStyle()
     testForcedQuotes()
     testSingleQuote()
   })
   test('"', () => {
-    YAML.scalarOptions.str.defaultQuote = Type.QUOTE_DOUBLE
+    YAML.scalarOptions.str.defaultQuoteSingle = false
     testPlainStyle()
     testForcedQuotes()
     testDoubleQuote()

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -631,16 +631,14 @@ describe('default quote option', () => {
     YAML.scalarOptions.str.defaultQuoteSingle = origDefaultQuoteOption
   })
 
-  const testSingleQuote = () => {
-    const str = 'foo #bar',
-      expected = "'foo #bar'\n"
+  const testSingleQuote = str => {
+    const expected = `'${str}'\n`
     const actual = YAML.stringify(str)
     expect(actual).toBe(expected)
     expect(YAML.parse(actual)).toBe(str)
   }
-  const testDoubleQuote = () => {
-    const str = 'foo #bar',
-      expected = '"foo #bar"\n'
+  const testDoubleQuote = str => {
+    const expected = `"${str}"\n`
     const actual = YAML.stringify(str)
     expect(actual).toBe(expected)
     expect(YAML.parse(actual)).toBe(str)
@@ -661,19 +659,22 @@ describe('default quote option', () => {
     YAML.scalarOptions.str.defaultQuoteSingle = origDefaultQuoteOption
     testPlainStyle()
     testForcedQuotes()
-    testDoubleQuote()
+    testDoubleQuote('123')
+    testDoubleQuote('foo #bar')
   })
   test("'", () => {
     YAML.scalarOptions.str.defaultQuoteSingle = true
     testPlainStyle()
     testForcedQuotes()
-    testSingleQuote()
+    testDoubleQuote('123') // number-as-string is double-quoted
+    testSingleQuote('foo #bar')
   })
   test('"', () => {
     YAML.scalarOptions.str.defaultQuoteSingle = false
     testPlainStyle()
     testForcedQuotes()
-    testDoubleQuote()
+    testDoubleQuote('123')
+    testDoubleQuote('foo #bar')
   })
 })
 

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -622,6 +622,61 @@ describe('indentSeq: false', () => {
   })
 })
 
+describe('default quote option', () => {
+  let origDefaultQuoteOption
+  beforeAll(() => {
+    origDefaultQuoteOption = YAML.scalarOptions.str.defaultQuote
+  })
+  afterAll(() => {
+    YAML.scalarOptions.str.defaultQuote = origDefaultQuoteOption
+  })
+
+  const testSingleQuote = () => {
+    const str = 'foo #bar',
+      expected = "'foo #bar'\n"
+    const actual = YAML.stringify(str)
+    expect(actual).toBe(expected)
+    expect(YAML.parse(actual)).toBe(str)
+  }
+  const testDoubleQuote = () => {
+    const str = 'foo #bar',
+      expected = '"foo #bar"\n'
+    const actual = YAML.stringify(str)
+    expect(actual).toBe(expected)
+    expect(YAML.parse(actual)).toBe(str)
+  }
+
+  const testPlainStyle = () => {
+    const str = YAML.stringify('foo bar')
+    expect(str).toBe('foo bar\n')
+  }
+  const testForcedQuotes = () => {
+    let str = YAML.stringify('foo: "bar"')
+    expect(str).toBe(`'foo: "bar"'\n`)
+    str = YAML.stringify("foo: 'bar'")
+    expect(str).toBe(`"foo: 'bar'"\n`)
+  }
+
+  test('default', () => {
+    YAML.scalarOptions.str.defaultQuote = origDefaultQuoteOption
+    testPlainStyle()
+    testForcedQuotes()
+    testDoubleQuote()
+  })
+  test("'", () => {
+    YAML.scalarOptions.str.defaultQuote = Type.QUOTE_SINGLE
+    testPlainStyle()
+    testForcedQuotes()
+    testSingleQuote()
+  })
+  test('"', () => {
+    YAML.scalarOptions.str.defaultQuote = Type.QUOTE_DOUBLE
+    testPlainStyle()
+    testForcedQuotes()
+    testDoubleQuote()
+  })
+})
+
 describe('Document markers in top-level scalars', () => {
   let origDoubleQuotedOptions
   beforeAll(() => {


### PR DESCRIPTION
We use this library to update files, which are also updated by another (YamlDotNet) library, and we have quoting style not in sync, which generates useless changes. I added an option to choose the default quoting style, and also tried to avoid escaped single quotes within string content.