### PR TITLE
Support for __proto__ as mapping key & anchor identifier

### DIFF
--- a/src/ast/Collection.js
+++ b/src/ast/Collection.js
@@ -8,9 +8,20 @@ export function collectionFromPath(schema, path, value) {
   let v = value
   for (let i = path.length - 1; i >= 0; --i) {
     const k = path[i]
-    const o = Number.isInteger(k) && k >= 0 ? [] : {}
-    o[k] = v
-    v = o
+    if (Number.isInteger(k) && k >= 0) {
+      const a = []
+      a[k] = v
+      v = a
+    } else {
+      const o = {}
+      Object.defineProperty(o, k, {
+        value: v,
+        writable: true,
+        enumerable: true,
+        configurable: true
+      })
+      v = o
+    }
   }
   return createNode(v, null, {
     onAlias() {

--- a/src/ast/Merge.js
+++ b/src/ast/Merge.js
@@ -39,8 +39,13 @@ export class Merge extends Pair {
           if (!map.has(key)) map.set(key, value)
         } else if (map instanceof Set) {
           map.add(key)
-        } else {
-          if (!Object.prototype.hasOwnProperty.call(map, key)) map[key] = value
+        } else if (!Object.prototype.hasOwnProperty.call(map, key)) {
+          Object.defineProperty(map, key, {
+            value,
+            writable: true,
+            enumerable: true,
+            configurable: true
+          })
         }
       }
     }

--- a/src/ast/Pair.js
+++ b/src/ast/Pair.js
@@ -65,7 +65,15 @@ export class Pair extends Node {
       map.add(key)
     } else {
       const stringKey = stringifyKey(this.key, key, ctx)
-      map[stringKey] = toJSON(this.value, stringKey, ctx)
+      const value = toJSON(this.value, stringKey, ctx)
+      if (stringKey in map)
+        Object.defineProperty(map, stringKey, {
+          value,
+          writable: true,
+          enumerable: true,
+          configurable: true
+        })
+      else map[stringKey] = value
     }
     return map
   }

--- a/src/ast/Pair.js
+++ b/src/ast/Pair.js
@@ -12,7 +12,7 @@ const stringifyKey = (key, jsKey, ctx) => {
   if (typeof jsKey !== 'object') return String(jsKey)
   if (key instanceof Node && ctx && ctx.doc)
     return key.toString({
-      anchors: {},
+      anchors: Object.create(null),
       doc: ctx.doc,
       indent: '',
       indentStep: ctx.indentStep,

--- a/src/doc/Anchors.js
+++ b/src/doc/Anchors.js
@@ -9,7 +9,7 @@ export class Anchors {
     )
   }
 
-  map = {}
+  map = Object.create(null)
 
   constructor(prefix) {
     this.prefix = prefix

--- a/src/doc/Document.js
+++ b/src/doc/Document.js
@@ -291,7 +291,7 @@ export class Document {
       lines.unshift(this.commentBefore.replace(/^/gm, '#'))
     }
     const ctx = {
-      anchors: {},
+      anchors: Object.create(null),
       doc: this,
       indent: '',
       indentStep: ' '.repeat(indentSize),

--- a/src/doc/createNode.js
+++ b/src/doc/createNode.js
@@ -33,7 +33,7 @@ export function createNode(value, tagName, ctx) {
 
   // Detect duplicate references to the same object & use Alias nodes for all
   // after first. The `obj` wrapper allows for circular references to resolve.
-  const obj = {}
+  const obj = { value: undefined, node: undefined }
   if (value && typeof value === 'object') {
     const prev = prevObjects.get(value)
     if (prev) return onAlias(prev)

--- a/tests/doc/collection-access.js
+++ b/tests/doc/collection-access.js
@@ -514,4 +514,11 @@ describe('Document', () => {
     doc.setIn(['c', 1], 9)
     expect(String(doc)).toBe('{ a: 1, b: [ 2, 3 ], c: [ null, 9 ] }\n')
   })
+
+  test('setIn with __proto__ as key', () => {
+    doc.setIn(['c', '__proto__'], 9)
+    expect(String(doc)).toBe(
+      'a: 1\nb:\n  - 2\n  - 3\nc:\n  __proto__: 9\n'
+    )
+  })
 })

--- a/tests/doc/parse.js
+++ b/tests/doc/parse.js
@@ -396,10 +396,7 @@ test('eemeli/yaml#38', () => {
   expect(YAML.parse(src)).toEqual({
     content: {
       arrayOfArray: [
-        [
-          { first: 'John', last: 'Black' },
-          { first: 'Brian', last: 'Green' }
-        ],
+        [{ first: 'John', last: 'Black' }, { first: 'Brian', last: 'Green' }],
         [{ first: 'Mark', last: 'Orange' }],
         [{ first: 'Adam', last: 'Grey' }]
       ]
@@ -607,8 +604,24 @@ test('Document.toJSON(null, onAnchor)', () => {
   const doc = YAML.parseDocument(src)
   const onAnchor = jest.fn()
   const res = doc.toJSON(null, onAnchor)
-  expect(onAnchor.mock.calls).toMatchObject([
-    [res.foo, 3],
-    ['foo', 1]
-  ])
+  expect(onAnchor.mock.calls).toMatchObject([[res.foo, 3], ['foo', 1]])
+})
+
+describe('__proto__ as mapping key', () => {
+  test('plain object', () => {
+    const src = '{ __proto__: [42] }'
+    const obj = YAML.parse(src)
+    expect(Array.isArray(obj)).toBe(false)
+    expect(obj.hasOwnProperty('__proto__')).toBe(true)
+    expect(obj).not.toHaveProperty('length')
+    expect(JSON.stringify(obj)).toBe('{"__proto__":[42]}')
+  })
+
+  test('with merge key', () => {
+    const src = '- &A { __proto__: [42] }\n- { <<: *A }\n'
+    const obj = YAML.parse(src, { merge: true })
+    expect(obj[0].hasOwnProperty('__proto__')).toBe(true)
+    expect(obj[1].hasOwnProperty('__proto__')).toBe(true)
+    expect(JSON.stringify(obj)).toBe('[{"__proto__":[42]},{"__proto__":[42]}]')
+  })
 })


### PR DESCRIPTION
JavaScript still supports the deprecated [`Object.prototype.__proto__`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) accessor for an object's prototype. This means that using `__proto__` as a mapping key or an anchor name does unexpected things. For example:
```js
const obj = YAML.parse('{ __proto__: [42] }') // Array {}
obj[0] // 42
obj.hasOwnProperty('__proto__') // false
JSON.stringify(obj) // '{}'
```

In other words, the value set for `__proto__` would be assigned as the prototype of the generated object, unless you enabled the `mapAsMap` option. Using it as an anchor just wouldn't work.

Just to be clear, this isn't about prototype pollution: no existing prototypes get modified at any point, they just get created unexpectedly.

This PR allows for `__proto__` as a mapping key or an anchor. The fixes should be robust enough that any other potential weirdnesses arising from inheriting from Object are averted as well.