### PR TITLE
Store the source string and outputs it in toString()/String().

### DIFF
--- a/src/resolve/resolveScalar.js
+++ b/src/resolve/resolveScalar.js
@@ -1,16 +1,10 @@
 import { Scalar } from '../ast/Scalar.js'
 
-// match custom string on null/bool
-function matchCustomTest(str, customTest) {
-  if (!customTest) return false
-  return customTest(str)
-}
-
 // falls back to string on no match
 export function resolveScalar(str, tags, scalarFallback) {
-  for (const { format, test, customTest, resolve } of tags) {
+  for (const { format, test, resolve } of tags) {
     if (test) {
-      const match = str.match(test) || matchCustomTest(str, customTest)
+      const match = str.match(test)
       if (match) {
         let res = resolve.apply(null, match)
         if (!(res instanceof Scalar)) res = new Scalar(res)

--- a/src/resolve/resolveScalar.js
+++ b/src/resolve/resolveScalar.js
@@ -1,10 +1,16 @@
 import { Scalar } from '../ast/Scalar.js'
 
+// match custom string on null/bool
+function matchCustomTest(str, customTest) {
+  if (!customTest) return false
+  return customTest(str)
+}
+
 // falls back to string on no match
 export function resolveScalar(str, tags, scalarFallback) {
-  for (const { format, test, resolve } of tags) {
+  for (const { format, test, customTest, resolve } of tags) {
     if (test) {
-      const match = str.match(test)
+      const match = str.match(test) || matchCustomTest(str, customTest)
       if (match) {
         let res = resolve.apply(null, match)
         if (!(res instanceof Scalar)) res = new Scalar(res)

--- a/src/tags/core.js
+++ b/src/tags/core.js
@@ -23,14 +23,10 @@ export const nullObj = {
     ctx.wrapScalars ? new Scalar(null) : null,
   default: true,
   tag: 'tag:yaml.org,2002:null',
-  sourceStr: null,
   test: /^(?:~|[Nn]ull|NULL)?$/,
-  customTest: str => {
-    return str === nullOptions.nullStr ? [str] : null
-  },
   resolve: str => {
     const node = new Scalar(null)
-    if(str) node.sourceStr = str
+    node.sourceStr = str
     return node
   },
   options: nullOptions,

--- a/src/tags/core.js
+++ b/src/tags/core.js
@@ -23,10 +23,18 @@ export const nullObj = {
     ctx.wrapScalars ? new Scalar(null) : null,
   default: true,
   tag: 'tag:yaml.org,2002:null',
+  sourceStr: null,
   test: /^(?:~|[Nn]ull|NULL)?$/,
-  resolve: () => null,
+  customTest: str => {
+    return str === nullOptions.nullStr ? [str] : null
+  },
+  resolve: str => {
+    const node = new Scalar(null)
+    if(str) node.sourceStr = str
+    return node
+  },
   options: nullOptions,
-  stringify: () => nullOptions.nullStr
+  stringify: ({ sourceStr }) => sourceStr ?? nullOptions.nullStr
 }
 
 export const boolObj = {

--- a/src/tags/yaml-1.1/index.js
+++ b/src/tags/yaml-1.1/index.js
@@ -54,10 +54,18 @@ export const yaml11 = failsafe.concat(
         ctx.wrapScalars ? new Scalar(null) : null,
       default: true,
       tag: 'tag:yaml.org,2002:null',
+      sourceStr: null,
       test: /^(?:~|[Nn]ull|NULL)?$/,
-      resolve: () => null,
+      customTest: str => {
+        return str === nullOptions.nullStr ? [str] : null
+      },
+      resolve: str => {
+        const node = new Scalar(null)
+        if(str) node.sourceStr = str
+        return node
+      },
       options: nullOptions,
-      stringify: () => nullOptions.nullStr
+      stringify: ({ sourceStr }) => sourceStr ?? nullOptions.nullStr
     },
     {
       identify: value => typeof value === 'boolean',

--- a/src/tags/yaml-1.1/index.js
+++ b/src/tags/yaml-1.1/index.js
@@ -54,14 +54,10 @@ export const yaml11 = failsafe.concat(
         ctx.wrapScalars ? new Scalar(null) : null,
       default: true,
       tag: 'tag:yaml.org,2002:null',
-      sourceStr: null,
       test: /^(?:~|[Nn]ull|NULL)?$/,
-      customTest: str => {
-        return str === nullOptions.nullStr ? [str] : null
-      },
       resolve: str => {
         const node = new Scalar(null)
-        if(str) node.sourceStr = str
+        node.sourceStr = str
         return node
       },
       options: nullOptions,

--- a/tests/doc/parse.js
+++ b/tests/doc/parse.js
@@ -75,6 +75,16 @@ describe('tags', () => {
   })
 })
 
+describe('custom string on node', () => {
+  test('custom null', () => {
+    YAML.scalarOptions.null.nullStr = 'None'
+    const doc = YAML.parse('a: null')
+    const str = YAML.stringify(doc, {simpleKeys: true})
+    expect(str).toBe('a: None\n')
+    expect(YAML.parse(str)).toEqual({a: null})
+  })
+})
+
 describe('number types', () => {
   describe('asBigInt: false', () => {
     test('Version 1.1', () => {

--- a/tests/doc/parse.js
+++ b/tests/doc/parse.js
@@ -76,11 +76,19 @@ describe('tags', () => {
 })
 
 describe('custom string on node', () => {
-  test('custom null', () => {
-    YAML.scalarOptions.null.nullStr = 'None'
+  test('tiled null', () => {
+    YAML.scalarOptions.null.nullStr = '~'
     const doc = YAML.parse('a: null')
     const str = YAML.stringify(doc, {simpleKeys: true})
-    expect(str).toBe('a: None\n')
+    expect(str).toBe('a: ~\n')
+    expect(YAML.parse(str)).toEqual({a: null})
+  })
+
+  test('empty string null', () => {
+    YAML.scalarOptions.null.nullStr = ''
+    const doc = YAML.parse('a: null')
+    const str = YAML.stringify(doc, {simpleKeys: true})
+    expect(str).toBe('a: \n')
     expect(YAML.parse(str)).toEqual({a: null})
   })
 })

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -445,12 +445,19 @@ test('eemeli/yaml#87', () => {
   expect(String(doc)).toBe('test:\n  a: test\n')
 })
 
+describe('scalar styles', () => {
+    test('null Scalar styles', () => {
+        const doc = YAML.parseDocument('[ null, Null, NULL, ~ ]')
+        expect(String(doc)).toBe('[ null, Null, NULL, ~ ]\n')
+    })
+})
+
 describe('simple keys', () => {
   test('key with null value', () => {
     const doc = YAML.parseDocument('~: ~')
-    expect(String(doc)).toBe('? null\n')
+    expect(String(doc)).toBe('? ~\n')
     doc.options.simpleKeys = true
-    expect(String(doc)).toBe('null: null\n')
+    expect(String(doc)).toBe('~: ~\n')
   })
 
   test('key with block scalar value', () => {

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -100,8 +100,11 @@ describe('json schema', () => {
     })
     expect(doc.errors).toHaveLength(2)
     doc.errors = []
-    expect(String(doc)).toBe(
-      '"empty": null\n"canonical": null\n"english": null\n? null\n: "null key"\n'
+    expect(String(doc)).toBe(`"empty": null
+"canonical": null
+"english": null
+? null
+: "null key"\n`
     )
   })
 })
@@ -178,9 +181,9 @@ english: null
       '': 'null key'
     })
     expect(String(doc)).toBe(`empty: null
-canonical: null
+canonical: ~
 english: null
-null: null key\n`)
+~: null key\n`)
   })
 
   describe('!!map', () => {
@@ -371,9 +374,9 @@ english: null
     expect(String(doc)).toBe(`%YAML 1.1
 ---
 empty: null
-canonical: null
+canonical: ~
 english: null
-null: null key\n`)
+~: null key\n`)
   })
 
   describe('!!timestamp', () => {


### PR DESCRIPTION
fix issue #170 .
+ Store the source string for null nodes.
+ Modify and supplement the test cases for `String()`.