### PR TITLE
Dump the simple key which is over 1024 properly

### DIFF
--- a/src/ast/Pair.js
+++ b/src/ast/Pair.js
@@ -96,6 +96,10 @@ export class Pair extends Node {
         const msg = 'With simple keys, collection cannot be used as a key value'
         throw new Error(msg)
       }
+      if (key instanceof Scalar && key.value?.length > 1024) {
+        const msg = 'With simple keys, single line scalar must not span more than 1024 characters'
+        throw new Error(msg)
+      }
     }
     const explicitKey =
       !simpleKeys &&
@@ -103,7 +107,8 @@ export class Pair extends Node {
         keyComment ||
         key instanceof Collection ||
         key.type === Type.BLOCK_FOLDED ||
-        key.type === Type.BLOCK_LITERAL)
+        key.type === Type.BLOCK_LITERAL ||
+        (key instanceof Scalar && key.value?.length > 1024))
     const { allNullValues, doc, indent, indentStep, stringify } = ctx
     ctx = Object.assign({}, ctx, {
       implicitKey: !explicitKey && (simpleKeys || !allNullValues),

--- a/src/ast/Pair.js
+++ b/src/ast/Pair.js
@@ -96,19 +96,14 @@ export class Pair extends Node {
         const msg = 'With simple keys, collection cannot be used as a key value'
         throw new Error(msg)
       }
-      if (key instanceof Scalar && key.value?.length > 1024) {
-        const msg = 'With simple keys, single line scalar must not span more than 1024 characters'
-        throw new Error(msg)
-      }
     }
-    const explicitKey =
+    let explicitKey =
       !simpleKeys &&
       (!key ||
         keyComment ||
         key instanceof Collection ||
         key.type === Type.BLOCK_FOLDED ||
-        key.type === Type.BLOCK_LITERAL ||
-        (key instanceof Scalar && key.value?.length > 1024))
+        key.type === Type.BLOCK_LITERAL)
     const { allNullValues, doc, indent, indentStep, stringify } = ctx
     ctx = Object.assign({}, ctx, {
       implicitKey: !explicitKey && (simpleKeys || !allNullValues),
@@ -128,6 +123,14 @@ export class Pair extends Node {
         if (onComment) onComment()
       } else if (chompKeep && !keyComment && onChompKeep) onChompKeep()
       return ctx.inFlow ? str : `? ${str}`
+    }
+    if (!explicitKey && str.length > 1024) {
+      if (!simpleKeys) {
+        explicitKey = true
+      } else {
+        const msg = 'With simple keys, single line scalar must not span more than 1024 characters'
+        throw new Error(msg)
+      }
     }
     str = explicitKey ? `? ${str}\n${indent}:` : `${str}:`
     if (this.comment) {

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -479,6 +479,18 @@ describe('simple keys', () => {
       /With simple keys, collection cannot be used as a key value/
     )
   })
+
+  test('key value lingth > 1024', () => {
+    let str = `
+    ? ${new Array(1026).join('a')}
+    : longkey`
+    const doc = YAML.parseDocument(str)
+    expect(String(doc)).toBe(`? ${new Array(1026).join('a')}\n: longkey\n`)
+    doc.options.simpleKeys = true
+    expect(() => String(doc)).toThrow(
+      /With simple keys, single line scalar must not span more than 1024 characters/
+    )
+  })
 })
 
 test('eemeli/yaml#128: YAML node inside object', () => {


### PR DESCRIPTION
the single line scalar which is simple key  not span more than 1024 Unicode characters on `String()`/`stringify()` 