### PR TITLE
Fix the object null property-read bug when stringify the null node.

### DIFF
--- a/src/doc/createNode.js
+++ b/src/doc/createNode.js
@@ -22,7 +22,7 @@ export function createNode(value, tagName, ctx) {
   let tagObj = findTagObject(value, tagName, tags)
   if (!tagObj) {
     if (typeof value.toJSON === 'function') value = value.toJSON()
-    if (typeof value !== 'object')
+    if (!value || typeof value !== 'object')
       return wrapScalars ? new Scalar(value) : value
     tagObj = value instanceof Map ? map : value[Symbol.iterator] ? seq : map
   }

--- a/tests/doc/stringify.js
+++ b/tests/doc/stringify.js
@@ -988,3 +988,10 @@ describe('YAML.stringify options as scalar', () => {
     )
   })
 })
+
+describe('YAML.stringify on ast Document', () => {
+  test('null document', () => {
+    const doc = YAML.parseDocument('null')
+    expect(YAML.stringify(doc)).toBe('null\n')
+  })
+})


### PR DESCRIPTION
When we run
```js
a = YAML.parseDocument("null")
console.log(YAML.stringify(a))
```
Get an exception：
```
   tagObj = value instanceof Map ? map : value[Symbol.iterator] ? seq : map;
                                               ^

TypeError: object null is not iterable (cannot read property Symbol(Symbol.iterator))
    at Object.createNode (c:\Users\l00498592\Desktop\workdata\yaml-master\dist\resolveSeq-6b2dc4ac.js:81:48)
    at Document.createNode (c:\Users\l00498592\Desktop\workdata\yaml-master\dist\Document-88366d37.js:542:29)
    at new Document (c:\Users\l00498592\Desktop\workdata\yaml-master\dist\Document-88366d37.js:509:28)
    at Object.stringify (c:\Users\l00498592\Desktop\workdata\yaml-master\dist\index.js:62:10)
    at Object.<anonymous> (c:\Users\l00498592\Desktop\workdata\yaml-master\test.js:74:18)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
    at Module.load (internal/modules/cjs/loader.js:985:32)
    at Function.Module._load (internal/modules/cjs/loader.js:878:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
```