### PR TITLE
Add support for multi-linebreak-preservation

### DIFF
--- a/docs/05_content_nodes.md
+++ b/docs/05_content_nodes.md
@@ -13,6 +13,8 @@ class Node {
       // into this node (undefined for pairs or if not parsed)
   spaceBefore: ?boolean,
       // a blank line before this node and its commentBefore
+  spacesBefore: ?number,
+      // the number of blank lines before this node and its commentBefore
   tag: ?string,       // a fully qualified tag, if required
   toJSON(): any       // a plain JS or JSON representation of this node
 }
@@ -243,6 +245,7 @@ const doc = YAML.parseDocument('[ one, two, three ]')
 
 doc.contents.items[0].comment = ' item comment'
 doc.contents.items[1].spaceBefore = true
+doc.contents.items[1].spacesBefore = 1
 doc.comment = ' document end comment'
 
 doc.toString()

--- a/src/ast/Collection.js
+++ b/src/ast/Collection.js
@@ -146,8 +146,13 @@ export class Collection extends Node {
     const nodes = this.items.reduce((nodes, item, i) => {
       let comment
       if (item) {
-        if (!chompKeep && item.spaceBefore)
+        if (!chompKeep && item.spacesBefore) {
+          for (let count = 0; count < item.spacesBefore; count++) {
+            nodes.push({ type: 'comment', str: '' })
+          }
+        } else if (!chompKeep && item.spaceBefore) {
           nodes.push({ type: 'comment', str: '' })
+        }
 
         if (item.commentBefore)
           item.commentBefore.match(/^.*$/gm).forEach(line => {

--- a/src/ast/Pair.js
+++ b/src/ast/Pair.js
@@ -141,7 +141,11 @@ export class Pair extends Node {
     let vcb = ''
     let valueComment = null
     if (value instanceof Node) {
-      if (value.spaceBefore) vcb = '\n'
+      if (value.spacesBefore) {
+        vcb = '\n'.repeat(value.spacesBefore)
+      } else if (value.spaceBefore) {
+        vcb = '\n'
+      }
       if (value.commentBefore) {
         const cs = value.commentBefore.replace(/^/gm, `${ctx.indent}#`)
         vcb += `\n${cs}`

--- a/src/doc/parseContents.js
+++ b/src/doc/parseContents.js
@@ -7,6 +7,7 @@ export function parseContents(doc, contents) {
   const comments = { before: [], after: [] }
   let body = undefined
   let spaceBefore = false
+  let spacesBefore = 0
   for (const node of contents) {
     if (node.valueRange) {
       if (body !== undefined) {
@@ -20,12 +21,17 @@ export function parseContents(doc, contents) {
         res.spaceBefore = true
         spaceBefore = false
       }
+      if (spacesBefore) {
+        res.spacesBefore = spacesBefore
+        spacesBefore = 0
+      }
       body = res
     } else if (node.comment !== null) {
       const cc = body === undefined ? comments.before : comments.after
       cc.push(node.comment)
     } else if (node.type === Type.BLANK_LINE) {
       spaceBefore = true
+      spacesBefore += 1
       if (
         body === undefined &&
         comments.before.length > 0 &&

--- a/src/resolve/collection-utils.js
+++ b/src/resolve/collection-utils.js
@@ -66,7 +66,10 @@ export function resolveComments(collection, comments) {
     } else {
       if (afterKey && item.value) item = item.value
       if (comment === undefined) {
-        if (afterKey || !item.commentBefore) item.spaceBefore = true
+        if (afterKey || !item.commentBefore) {
+          item.spaceBefore = true
+          item.spacesBefore = item.spacesBefore ? item.spacesBefore + 1 : 1
+        }
       } else {
         if (item.commentBefore) item.commentBefore += '\n' + comment
         else item.commentBefore = comment

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -787,6 +787,7 @@ a:
   c: 2
   #1
 
+
 #2
 d: 1\n`
     const doc = YAML.parseDocument(src)
@@ -804,7 +805,7 @@ d: 1\n`
         },
         {
           spaceBefore: true,
-          spacesBefore: 1,
+          spacesBefore: 2,
           commentBefore: '2',
           key: { value: 'd' },
           value: { value: 1 }

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -371,6 +371,7 @@ describe('stringify comments', () => {
       doc.contents.items[1].commentBefore = 'c1'
       doc.contents.items[1].comment = 'c2'
       doc.contents.items[1].value.spaceBefore = true
+      doc.contents.items[1].value.spacesBefore = 1
       doc.contents.comment = 'c3'
       expect(String(doc)).toBe(`#c0
 key1: value 1
@@ -388,6 +389,7 @@ key2: #c2
       doc.contents.items[1].commentBefore = '\nc2\n\nc3'
       doc.contents.items[1].comment = 'c4\nc5'
       doc.contents.items[1].value.spaceBefore = true
+      doc.contents.items[1].value.spacesBefore = 1
       doc.contents.items[1].value.commentBefore = 'c6'
       doc.contents.comment = 'c7\nc8'
       expect(String(doc)).toBe(
@@ -481,19 +483,20 @@ describe('blank lines', () => {
     const doc = YAML.parseDocument('str\n')
     doc.directivesEndMarker = true
     doc.contents.spaceBefore = true
+    doc.contents.spacesBefore = 1
     expect(String(doc)).toBe('---\n\nstr\n')
   })
 
   test('between seq items', () => {
-    const src = '- a\n\n- b\n\n\n- c\n'
+    const src = '- a\n\n- b\n\n\n\n- c\n'
     const doc = YAML.parseDocument(src)
-    expect(String(doc)).toBe('- a\n\n- b\n\n- c\n')
+    expect(String(doc)).toBe('- a\n\n- b\n\n\n\n- c\n')
   })
 
   test('between seq items with leading comments', () => {
     const src = '#A\n- a\n\n#B\n- b\n\n\n#C\n\n- c\n'
     const doc = YAML.parseDocument(src)
-    expect(String(doc)).toBe('#A\n- a\n\n#B\n- b\n\n#C\n- c\n')
+    expect(String(doc)).toBe('#A\n- a\n\n#B\n- b\n\n\n#C\n- c\n')
   })
 
   describe('not after block scalar with keep chomping', () => {
@@ -508,6 +511,8 @@ describe('blank lines', () => {
         expect(String(doc)).toBe(src)
         expect(doc.contents.items[1]).not.toHaveProperty('spaceBefore', true)
         doc.contents.items[1].spaceBefore = true
+        expect(doc.contents.items[1]).not.toHaveProperty('spacesBefore', true)
+        doc.contents.items[1].spacesBefore = 1
         expect(String(doc)).toBe(src)
       })
     }
@@ -530,11 +535,11 @@ describe('blank lines', () => {
       items: [
         {
           key: { value: 'a' },
-          value: { value: 1, spaceBefore: true }
+          value: { value: 1, spaceBefore: true, spacesBefore: 1 }
         },
         {
           key: { value: 'b' },
-          value: { value: 2, commentBefore: 'c', spaceBefore: true }
+          value: { value: 2, commentBefore: 'c', spaceBefore: true, spacesBefore: 1 }
         }
       ]
     })
@@ -564,9 +569,9 @@ describe('blank lines', () => {
       expect(doc.contents).toMatchObject({
         items: [
           { value: 1 },
-          { value: 2, spaceBefore: true },
+          { value: 2, spaceBefore: true, spacesBefore: 1 },
           { value: 3 },
-          { value: 4, spaceBefore: true }
+          { value: 4, spaceBefore: true, spacesBefore: 1 }
         ]
       })
       expect(String(doc)).toBe('[\n  1,\n\n  2,\n  3,\n\n  4\n]\n')
@@ -577,8 +582,8 @@ describe('blank lines', () => {
       const doc = YAML.parseDocument(src)
       expect(doc.contents).toMatchObject({
         items: [
-          { key: { value: 'a' }, value: { value: 1 }, spaceBefore: true },
-          { key: { value: 'b' }, value: { value: 2 }, spaceBefore: true }
+          { key: { value: 'a' }, value: { value: 1 }, spaceBefore: true, spacesBefore: 1 },
+          { key: { value: 'b' }, value: { value: 2 }, spaceBefore: true, spacesBefore: 1 }
         ]
       })
     })
@@ -594,7 +599,7 @@ describe('blank lines', () => {
           },
           {
             key: { value: 'b' },
-            value: { value: 2, commentBefore: 'd', spaceBefore: true }
+            value: { value: 2, commentBefore: 'd', spaceBefore: true, spacesBefore: 1 }
           }
         ]
       })
@@ -717,7 +722,7 @@ describe('collection end comments', () => {
     expect(doc.contents).toMatchObject({
       items: [
         { items: [{ value: 'a' }, { value: 'b' }], comment: '1' },
-        { spaceBefore: true, commentBefore: '2', value: 'd' }
+        { spaceBefore: true, spacesBefore: 1, commentBefore: '2', value: 'd' }
       ]
     })
     expect(String(doc)).toBe(src)
@@ -741,7 +746,7 @@ describe('collection end comments', () => {
           ],
           comment: '1'
         },
-        { spaceBefore: true, commentBefore: '2', value: 'd' }
+        { spaceBefore: true, spacesBefore: 1, commentBefore: '2', value: 'd' }
       ]
     })
     expect(String(doc)).toBe(src)
@@ -765,6 +770,7 @@ d: 1\n`
         },
         {
           spaceBefore: true,
+          spacesBefore: 1,
           commentBefore: '2',
           key: { value: 'd' },
           value: { value: 1 }
@@ -798,6 +804,7 @@ d: 1\n`
         },
         {
           spaceBefore: true,
+          spacesBefore: 1,
           commentBefore: '2',
           key: { value: 'd' },
           value: { value: 1 }
@@ -813,6 +820,8 @@ a:
   #1
   - b:
       - c
+
+
 
   #2
   - e\n`
@@ -832,7 +841,7 @@ a:
                   }
                 ]
               },
-              { spaceBefore: true, commentBefore: '2', value: 'e' }
+              { spaceBefore: true, spacesBefore: 3, commentBefore: '2', value: 'e' }
             ]
           }
         }

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -716,13 +716,14 @@ describe('collection end comments', () => {
   - b
   #1
 
+
 #2
 - d\n`
     const doc = YAML.parseDocument(src)
     expect(doc.contents).toMatchObject({
       items: [
         { items: [{ value: 'a' }, { value: 'b' }], comment: '1' },
-        { spaceBefore: true, spacesBefore: 1, commentBefore: '2', value: 'd' }
+        { spaceBefore: true, spacesBefore: 2, commentBefore: '2', value: 'd' }
       ]
     })
     expect(String(doc)).toBe(src)

--- a/types.d.ts
+++ b/types.d.ts
@@ -187,6 +187,8 @@ export class Node {
   range?: [number, number] | null
   /** A blank line before this node and its commentBefore */
   spaceBefore?: boolean
+  /** The number of blank lines before this node and its commentBefore */
+  spacesBefore?: number
   /** A fully qualified tag, if required */
   tag?: string
   /** A plain JS representation of this node */


### PR DESCRIPTION
This is a solution for https://github.com/eemeli/yaml/issues/207.
I already tested it successfully on the following feature-branch of `attranslate`: https://github.com/fkirc/attranslate/pull/64
This API-proposal isn't really clean, but I do not dare to make any breaking changes as an external contributor.
