### PR TITLE
Add missing extension to Document.js import path

### DIFF
--- a/src/doc/Document.js
+++ b/src/doc/Document.js
@@ -8,7 +8,7 @@ import {
   isEmptyPath,
   toJS
 } from '../ast/index.js'
-import { Document as CSTDocument } from '../cst/Document'
+import { Document as CSTDocument } from '../cst/Document.js'
 import { defaultTagPrefix } from '../constants.js'
 import { YAMLError } from '../errors.js'
 import { defaultOptions, documentOptions } from '../options.js'


### PR DESCRIPTION
A quick grep yields this as the only import with a missing extension.
This change allows a successful import with Deno.