### PR TITLE
Drop 'yaml/parse-cst' endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ npm test # just to be sure
   - **`tests/cst/`** - Tests for the CST parser
   - **`tests/doc/`** - Tests for the AST level of the library
   - **`tests/yaml-test-suite/`** - Git submodule of a custom fork of the [YAML Test Suite](https://github.com/yaml/yaml-test-suite)
-- **`{index,parse-cst,types,util}.js`** - The library's published API; see the documentation site for more details. Not transpiled, so written as backwards-compatible CommonJS.
+- **`{index,types,util}.js`** - The library's published API; see the documentation site for more details. Not transpiled, so written as backwards-compatible CommonJS.
 
 ## Contributing Code
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,6 @@ import { Pair, YAMLMap, YAMLSeq } from 'yaml/types'
 
 ### CST Parser
 
-```js
-import parseCST from 'yaml/parse-cst'
-```
-
-- [`parseCST(str): CSTDocument[]`](https://eemeli.org/yaml/#parsecst)
 - [`YAML.parseCST(str): CSTDocument[]`](https://eemeli.org/yaml/#parsecst)
 
 ## YAML.parse

--- a/browser/parse-cst.js
+++ b/browser/parse-cst.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/parse-cst').parse

--- a/cst.d.ts
+++ b/cst.d.ts
@@ -1,11 +1,5 @@
 import { Type, YAMLSyntaxError } from './util'
 
-export default function parseCST(str: string): ParsedCST
-
-export interface ParsedCST extends Array<CST.Document> {
-  setOrigRanges(): boolean
-}
-
 export namespace CST {
   interface Range {
     start: number

--- a/docs/01_intro.md
+++ b/docs/01_intro.md
@@ -59,9 +59,4 @@ import { Pair, YAMLMap, YAMLSeq } from 'yaml/types'
 
 <h3>CST Parser</h3>
 
-```js
-import parseCST from 'yaml/parse-cst'
-```
-
-- [`parseCST(str): CSTDocument[]`](#parsecst)
 - [`YAML.parseCST(str): CSTDocument[]`](#parsecst)

--- a/docs/07_cst_parser.md
+++ b/docs/07_cst_parser.md
@@ -6,9 +6,9 @@ For ease of implementation and to provide better error handling and reporting, t
 
 <!-- prettier-ignore -->
 ```js
-import parseCST from 'yaml/parse-cst'
+import YAML from 'yaml'
 
-const cst = parseCST(`
+const cst = YAML.parseCST(`
 sequence: [ one, two, ]
 mapping: { sky: blue, sea: green }
 ---
@@ -32,13 +32,13 @@ cst[1]            // second document, containing a sequence
   .strValue       // 'Block scalar\n'
 ```
 
-#### `parseCST(string): CSTDocument[]`
-
 #### `YAML.parseCST(string): CSTDocument[]`
 
 The CST parser will not produce a CST that is necessarily valid YAML, and in particular its representation of collections of items is expected to undergo further processing and validation. The parser should never throw errors, but may include them as a value of the relevant node. On the other hand, if you feed it garbage, you'll likely get a garbage CST as well.
 
-The public API of the CST layer is a single function which returns an array of parsed CST documents. The array and its contained nodes override the default `toString` method, each returning a YAML string representation of its contents. The same function is exported as a part of the default `YAML` object, as well as seprately at `yaml/parse-cst`. It has no dependency on the rest of the library, so importing only `parseCST` should add about 9kB to your gzipped bundle size, when the whole library will add about 27kB.
+The public API of the CST layer is a single function which returns an array of parsed CST documents.
+The array and its contained nodes override the default `toString` method, each returning a YAML string representation of its contents.
+The `parseCST` function has no dependency on the rest of the library, so importing only it should add about 9kB to your gzipped bundle size, when the whole library will add about 27kB.
 
 Care should be taken when modifying the CST, as no error checks are included to verify that the resulting YAML is valid, or that e.g. indentation levels aren't broken. In other words, this is an engineering tool and you may hurt yourself. If you're looking to generate a brand new YAML document, see the section on [Creating Documents](#creating-documents).
 
@@ -84,10 +84,10 @@ While the YAML spec considers e.g. block collections within a flow collection to
 <h3 style="clear:both">Dealing with CRLF line terminators</h3>
 
 ```js
-import parseCST from 'yaml/parse-cst'
+import YAML from 'yaml'
 
 const src = '- foo\r\n- bar\r\n'
-const cst = parseCST(src)
+const cst = YAML.parseCST(src)
 cst.setOrigRanges() // true
 const { range, valueRange } = cst[0].contents[0].items[1].node
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { CST } from './parse-cst'
+import { CST } from './cst'
 import {
   AST,
   Alias,
@@ -14,7 +14,12 @@ import {
 import { Type, YAMLError, YAMLWarning } from './util'
 
 export { AST, CST }
-export { default as parseCST } from './parse-cst'
+
+export function parseCST(str: string): ParsedCST
+
+export interface ParsedCST extends Array<CST.Document> {
+  setOrigRanges(): boolean
+}
 
 /**
  * `yaml` defines document-specific options in three places: as an argument of

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,6 @@ switch (process.env.npm_lifecycle_event) {
     process.env.TRACE_LEVEL = 'log'
     moduleNameMapper = {
       '^\\./dist$': '<rootDir>/src/index.js',
-      '^\\./dist/parse-cst(\\.js)?$': '<rootDir>/src/cst/parse.js',
       '^\\./dist/types(\\.js)?$': '<rootDir>/src/types.js',
       '^\\./dist/(.+)$': '<rootDir>/src/$1',
       '^\\.\\./dist/test-events.js$': '<rootDir>/src/test-events.js'

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "main": "./index.js",
   "browser": {
     "./index.js": "./browser/index.js",
-    "./parse-cst.js": "./browser/parse-cst.js",
     "./types.js": "./browser/types.js",
     "./types.mjs": "./browser/types.js",
     "./util.js": "./browser/util.js",
@@ -33,7 +32,6 @@
   "exports": {
     ".": "./index.js",
     "./package.json": "./package.json",
-    "./parse-cst": "./parse-cst.js",
     "./types": [
       {
         "import": "./types.mjs"

--- a/parse-cst.js
+++ b/parse-cst.js
@@ -1,1 +1,0 @@
-module.exports = require('./dist/parse-cst').parse

--- a/rollup.browser-config.js
+++ b/rollup.browser-config.js
@@ -3,7 +3,6 @@ import babel from '@rollup/plugin-babel'
 export default {
   input: {
     index: 'src/index.js',
-    'parse-cst': 'src/cst/parse.js',
     types: 'src/types.js',
     util: 'src/util.js'
   },

--- a/rollup.node-config.js
+++ b/rollup.node-config.js
@@ -3,7 +3,6 @@ import babel from '@rollup/plugin-babel'
 export default {
   input: {
     index: 'src/index.js',
-    'parse-cst': 'src/cst/parse.js',
     'test-events': 'src/test-events.js',
     types: 'src/types.js',
     util: 'src/util.js'

--- a/src/cst/parse.js
+++ b/src/cst/parse.js
@@ -1,5 +1,3 @@
-// Published as 'yaml/parse-cst'
-
 import { Document } from './Document.js'
 import { ParseContext } from './ParseContext.js'
 

--- a/tests/cst/corner-cases.js
+++ b/tests/cst/corner-cases.js
@@ -1,5 +1,6 @@
 import { source } from 'common-tags'
-import parse from '../../parse-cst.js'
+import * as YAML from '../../index.js'
+const parse = YAML.parseCST
 
 describe('folded block with chomp: keep', () => {
   test('nl + nl', () => {

--- a/tests/cst/parse.js
+++ b/tests/cst/parse.js
@@ -1,4 +1,5 @@
-import parse from '../../parse-cst.js'
+import * as YAML from '../../index.js'
+const parse = YAML.parseCST
 
 test('return value', () => {
   const src = '---\n- foo\n- bar\n'

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,5 @@
 import { Document, scalarOptions } from './index'
-import { CST } from './parse-cst'
+import { CST } from './cst'
 import { Type } from './util'
 
 export const binaryOptions: scalarOptions.Binary

--- a/util.d.ts
+++ b/util.d.ts
@@ -1,4 +1,4 @@
-import { CST } from './parse-cst'
+import { CST } from './cst'
 import { Pair, Scalar, Schema } from './types'
 
 export function findPair(items: any[], key: Scalar | any): Pair | undefined


### PR DESCRIPTION
### BREAKING CHANGE
Users will need to update their code:

```diff
-import parseCST from 'yaml/parse-cst'
+import YAML from 'yaml'
+const parseCST = YAML.parseCST
```

This simplifies the public API of the library, but should not adversely affect users. Providing a separate endpoint has previously made it simpler for browser bundlers to treeshake the library for users that only use the CST parser, but the updated exports should now allow for that to happen even with a single export. Especially once #208 is resolved, as it should now be possible to provide ES-only exports for browsers.

This is also related to #203, which will change the output & API of `YAML.parseCST` rather thoroughly.