### PR TITLE
Add option setOrigRanges for parsing docs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,6 +118,13 @@ export interface Options extends Schema.Options {
    */
   keepCstNodes?: boolean
   /**
+   * Set original ranges (support \r\n line endings) for included cstNodes
+   * Only has an effect if `keepCstNodes` is enabled
+   *
+   * Default: `false`
+   */
+  setOrigRanges?: boolean
+  /**
    * Store the original node type when parsing documents.
    *
    * Default: `true`

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,9 @@ export { Document, parseCST }
 export function parseAllDocuments(src, options) {
   const stream = []
   let prev
-  for (const cstDoc of parseCST(src)) {
+  const cst = parseCST(src)
+  if (options && options.setOrigRanges) cst.setOrigRanges()
+  for (const cstDoc of cst) {
     const doc = new Document(undefined, null, options)
     doc.parse(cstDoc, prev)
     stream.push(doc)
@@ -22,6 +24,7 @@ export function parseAllDocuments(src, options) {
 
 export function parseDocument(src, options) {
   const cst = parseCST(src)
+  if (options && options.setOrigRanges) cst.setOrigRanges()
   const doc = new Document(cst[0], null, options)
   if (
     cst.length > 1 &&


### PR DESCRIPTION
This pull request adds the following parameter to the document parser:

    setOrigRanges?: boolean

It uses the same name as the corresponding function `setOrigRanges`, which sets original ranges on cstNodes for `\r\n` style line endings. Default is `false` and it obviously only has an effect when `keepCstNodes` is set to `true`, although it does get executed either way, just that the CST nodes get discarded when `keepCstNodes` is set to `false`.

I realize adding more options should always be considered carefully, but being able to set the original ranges when parsing a document was pretty useful for me.