### PR TITLE
Directive cleanup

### DIFF
--- a/docs/04_documents.md
+++ b/docs/04_documents.md
@@ -73,17 +73,17 @@ If `value` is `undefined`, the document's `contents` is initialised as `null`.
 If defined, a `replacer` may filter or modify the initial document contents, following the same algorithm as the [JSON implementation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#The_replacer_parameter).
 See [Options](#options) for more information on the last argument.
 
-| Member        | Type                             | Description                                                                                                                                                         |
-| ------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| anchors       | [`Anchors`](#anchors)            | Anchors associated with the document's nodes; also provides alias & merge node creators.                                                                            |
-| commentBefore | `string?`                        | A comment at the very beginning of the document. If not empty, separated from the rest of the document by a blank line or the doc-start indicator when stringified. |
-| comment       | `string?`                        | A comment at the end of the document. If not empty, separated from the rest of the document by a blank line when stringified.                                       |
-| contents      | [`Node`](#content-nodes) `⎮ any` | The document contents.                                                                                                                                              |
-| directives    | `Directives`                     | Document directives `%YAML` and `%TAG`, as well as the doc-start marker `---`.                                                                                      |
-| errors        | `Error[]`                        | Errors encountered during parsing.                                                                                                                                  |
-| schema        | `Schema`                         | The schema used with the document.                                                                                                                                  |
-| version       | `string?`                        | The parsed version of the source document; if true-ish, stringified output will include a `%YAML` directive.                                                        |
-| warnings      | `Error[]`                        | Warnings encountered during parsing.                                                                                                                                |
+| Member        | Type                               | Description                                                                                                                                                         |
+| ------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| anchors       | [`Anchors`](#anchors)              | Anchors associated with the document's nodes; also provides alias & merge node creators.                                                                            |
+| commentBefore | `string?`                          | A comment at the very beginning of the document. If not empty, separated from the rest of the document by a blank line or the doc-start indicator when stringified. |
+| comment       | `string?`                          | A comment at the end of the document. If not empty, separated from the rest of the document by a blank line when stringified.                                       |
+| contents      | [`Node`](#content-nodes) `⎮ any`   | The document contents.                                                                                                                                              |
+| directives    | [`Directives`](#stream-directives) | Controls for the `%YAML` and `%TAG` directives, as well as the doc-start marker `---`.                                                                              |
+| errors        | `Error[]`                          | Errors encountered during parsing.                                                                                                                                  |
+| schema        | `Schema`                           | The schema used with the document.                                                                                                                                  |
+| version       | `string?`                          | The parsed version of the source document; if true-ish, stringified output will include a `%YAML` directive.                                                        |
+| warnings      | `Error[]`                          | Warnings encountered during parsing.                                                                                                                                |
 
 ```js
 import { Document } from 'yaml'
@@ -157,6 +157,29 @@ To stringify a document as YAML, use **`toString(options = {})`**.
 This will also be called by `String(doc)` (with no options).
 This method will throw if the `errors` array is not empty.
 See [Options](#options) for more information on the optional parameter.
+
+## Stream Directives
+
+<!-- prettier-ignore -->
+```js
+const doc = new Document()
+doc.directives
+> {
+    marker: null, // set true to force the doc-start marker
+    tags: { '!!': 'tag:yaml.org,2002:' }, // Record<handle, prefix>
+    yaml: { explicit: false, version: '1.2' }
+  }
+```
+
+A YAML document may be preceded by `%YAML` and `%TAG` directives; their state is accessible via the `directives` member of a `Document`.
+After parsing or other creation, the contents of `doc.directives` are mutable, and will influence the YAML string representation of the document.
+
+The contents of `doc.directives.tags` are used both for the `%TAG` directives and when stringifying tags within the document.
+Each of the handles must start and end with a `!` character; `!` is by default the local tag and `!!` is used for default tags.
+See the section on [custom tags](#writing-custom-tags) for more on this topic.
+
+`doc.contents.yaml` determines if an explicit `%YAML` directive should be included in the output, and what version it should use.
+If changing the version after the document's creation, you'll probably want to use `doc.setSchema()` as it will also update the schema accordingly.
 
 ## Working with Anchors
 

--- a/docs/04_documents.md
+++ b/docs/04_documents.md
@@ -82,7 +82,6 @@ See [Options](#options) for more information on the last argument.
 | directives    | `Directives`                     | Document directives `%YAML` and `%TAG`, as well as the doc-start marker `---`.                                                                                      |
 | errors        | `Error[]`                        | Errors encountered during parsing.                                                                                                                                  |
 | schema        | `Schema`                         | The schema used with the document.                                                                                                                                  |
-| tagPrefixes   | `Prefix[]`                       | Array of prefixes; each will have a string `handle` that starts and ends with `!` and a string `prefix` that the handle will be replaced by.                        |
 | version       | `string?`                        | The parsed version of the source document; if true-ish, stringified output will include a `%YAML` directive.                                                        |
 | warnings      | `Error[]`                        | Warnings encountered during parsing.                                                                                                                                |
 
@@ -115,7 +114,6 @@ During stringification, a document with a true-ish `version` value will include 
 | createNode(value,&nbsp;options?)           | `Node`   | Recursively wrap any input with appropriate `Node` containers. See [Creating Nodes](#creating-nodes) for more information.        |
 | createPair(key,&nbsp;value,&nbsp;options?) | `Pair`   | Recursively wrap `key` and `value` into a `Pair` object. See [Creating Nodes](#creating-nodes) for more information.              |
 | setSchema(version,&nbsp;options?)          | `void`   | Change the YAML version and schema used by the document. `version` must be either `'1.1'` or `'1.2'`; accepts all Schema options. |
-| setTagPrefix(handle,&nbsp;prefix)          | `void`   | Set `handle` as a shorthand string for the `prefix` tag namespace.                                                                |
 | toJS(options?)                             | `any`    | A plain JavaScript representation of the document `contents`.                                                                     |
 | toJSON()                                   | `any`    | A JSON representation of the document `contents`.                                                                                 |
 | toString(options?)                         | `string` | A YAML representation of the document.                                                                                            |
@@ -132,10 +130,6 @@ doc.getIn(['b', 1]) // 4
 
 In addition to the above, the document object also provides the same **accessor methods** as [collections](#collections), based on the top-level collection: `add`, `delete`, `get`, `has`, and `set`, along with their deeper variants `addIn`, `deleteIn`, `getIn`, `hasIn`, and `setIn`.
 For the `*In` methods using an empty `path` value (i.e. `null`, `undefined`, or `[]`) will refer to the document's top-level `contents`.
-
-To define a tag prefix to use when stringifying, use **`setTagPrefix(handle, prefix)`** rather than setting a value directly in `tagPrefixes`.
-This will guarantee that the `handle` is valid (by throwing an error), and will overwrite any previous definition for the `handle`.
-Use an empty `prefix` value to remove a prefix.
 
 #### `Document#toJS()`, `Document#toJSON()` and `Document#toString()`
 

--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -44,11 +44,6 @@ export declare namespace Document {
     /** The schema used with the document. */
     schema: Schema
   }
-
-  interface TagPrefix {
-    handle: string
-    prefix: string
-  }
 }
 
 export class Document<T = unknown> {
@@ -84,12 +79,6 @@ export class Document<T = unknown> {
   // TS can't figure out that setSchema() will set this, or throw
   /** The schema used with the document. Use `setSchema()` to change. */
   declare schema: Schema
-
-  /**
-   * Array of prefixes; each will have a string `handle` that
-   * starts and ends with `!` and a string `prefix` that the handle will be replaced by.
-   */
-  tagPrefixes: Document.TagPrefix[] = []
 
   /** Warnings encountered during parsing. */
   warnings: YAMLWarning[] = []
@@ -329,19 +318,6 @@ export class Document<T = unknown> {
       }
     }
     this.schema = new Schema(_options)
-  }
-
-  /** Set `handle` as a shorthand string for the `prefix` tag namespace. */
-  setTagPrefix(handle: string, prefix: string | null) {
-    if (handle[0] !== '!' || handle[handle.length - 1] !== '!')
-      throw new Error('Handle must start and end with !')
-    if (prefix) {
-      const prev = this.tagPrefixes.find(p => p.handle === handle)
-      if (prev) prev.prefix = prefix
-      else this.tagPrefixes.push({ handle, prefix })
-    } else {
-      this.tagPrefixes = this.tagPrefixes.filter(p => p.handle !== handle)
-    }
   }
 
   /** A plain JavaScript representation of the document `contents`. */

--- a/src/doc/directives.ts
+++ b/src/doc/directives.ts
@@ -33,7 +33,7 @@ export class Directives {
    * > settings as the previous document. If the document does specify any
    * > directives, all directives of previous documents, if any, are ignored.
    */
-  private atNextDocument = false
+  private atNextDocument?: boolean
 
   constructor(yaml?: Directives['yaml'], tags?: Directives['tags']) {
     this.yaml = Object.assign({}, Directives.defaultYaml, yaml)

--- a/tests/directives.ts
+++ b/tests/directives.ts
@@ -1,0 +1,40 @@
+import { parseDocument, Scalar } from 'yaml'
+import { source } from './_utils'
+
+describe('%TAG', () => {
+  test('parse', () => {
+    const doc = parseDocument(source`
+      %TAG ! !foo:
+      %TAG !bar! !bar:
+      ---
+      - !bar v1
+      - !bar!foo v2
+    `)
+    expect(doc.errors).toHaveLength(0)
+    expect(doc.directives.tags).toMatchObject({
+      '!!': 'tag:yaml.org,2002:',
+      '!': '!foo:',
+      '!bar!': '!bar:'
+    })
+    expect(doc.contents).toMatchObject({
+      items: [
+        { value: 'v1', tag: '!foo:bar' },
+        { value: 'v2', tag: '!bar:foo' }
+      ]
+    })
+  })
+
+  test('create & stringify', () => {
+    const doc = parseDocument('[ v1, v2 ]\n')
+    ;(doc.get(0, true) as Scalar).tag = '!foo:foo'
+    ;(doc.get(1, true) as Scalar).tag = '!bar:bar'
+    doc.directives.tags['!'] = '!foo:'
+    doc.directives.tags['!bar!'] = '!bar:'
+    expect(String(doc)).toBe(source`
+      %TAG ! !foo:
+      %TAG !bar! !bar:
+      ---
+      [ !foo v1, !bar!bar v2 ]
+    `)
+  })
+})


### PR DESCRIPTION
Drop the obsolete `doc.tagPrefix` & `doc.setTagPrefix()` which don't actually do anything anymore.

Improve directives tests & documentation.