### PR TITLE
Ensure @node/types is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@rollup/plugin-replace": "^2.3.4",
     "@rollup/plugin-typescript": "^8.1.1",
     "@types/jest": "^26.0.20",
-    "@types/node": "14.14.22",
+    "@types/node": "*",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "babel-jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@rollup/plugin-replace": "^2.3.4",
     "@rollup/plugin-typescript": "^8.1.1",
     "@types/jest": "^26.0.20",
+    "@types/node": "14.14.22",
     "@typescript-eslint/eslint-plugin": "^4.15.2",
     "@typescript-eslint/parser": "^4.15.2",
     "babel-jest": "^26.6.3",


### PR DESCRIPTION
I cloned this and used PNPM instead of NPM and it doesn't find `@node/types` because it's not a devDependency.

(I assume it's installed as a dependency of something else, but PNPM isn't as lax as NPM when it installs things. )

- adds `@node/types`