### PR TITLE
Turn the Lexer, Parser & Composer into generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ const YAML = require('yaml')
 
 ### Parsing YAML
 
-- [`new Lexer(push)`](https://eemeli.org/yaml/#lexer)
-- [`new Parser(push, onNewLine?)`](https://eemeli.org/yaml/#parser)
+- [`new Lexer().lex(src)`](https://eemeli.org/yaml/#lexer)
+- [`new Parser(onNewLine?).parse(src)`](https://eemeli.org/yaml/#parser)
 - [`new Composer(push, options?)`](https://eemeli.org/yaml/#composer)
 
 ## YAML.parse

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ const YAML = require('yaml')
 
 - [`new Lexer().lex(src)`](https://eemeli.org/yaml/#lexer)
 - [`new Parser(onNewLine?).parse(src)`](https://eemeli.org/yaml/#parser)
-- [`new Composer(push, options?)`](https://eemeli.org/yaml/#composer)
+- [`new Composer(options?).compose(tokens)`](https://eemeli.org/yaml/#composer)
 
 ## YAML.parse
 

--- a/docs/01_intro.md
+++ b/docs/01_intro.md
@@ -96,6 +96,6 @@ import {
 import { Composer, Lexer, Parser } from 'yaml'
 ```
 
-- [`new Lexer(push)`](#lexer)
-- [`new Parser(push, onNewLine?)`](#parser)
+- [`new Lexer().lex(src)`](#lexer)
+- [`new Parser(onNewLine?).parse(src)`](#parser)
 - [`new Composer(push, options?)`](#composer)

--- a/docs/01_intro.md
+++ b/docs/01_intro.md
@@ -98,4 +98,4 @@ import { Composer, Lexer, Parser } from 'yaml'
 
 - [`new Lexer().lex(src)`](#lexer)
 - [`new Parser(onNewLine?).parse(src)`](#parser)
-- [`new Composer(push, options?)`](#composer)
+- [`new Composer(options?).compose(tokens)`](#composer)

--- a/docs/07_parsing_yaml.md
+++ b/docs/07_parsing_yaml.md
@@ -233,27 +233,29 @@ If `line === 0`, `addNewLine` has never been called or `offset` is before the fi
 import { Composer, Parser } from 'yaml'
 
 const src = 'foo: bar\nfee: [24, "42"]'
-const docs = []
-const composer = new Composer(doc => docs.push(doc))
-for (const token of new Parser().parse(src)) composer.next(token)
-composer.end()
+const tokens = new Parser().parse(src)
+const docs = new Composer().compose(tokens)
 
-docs.map(doc => doc.toJS())
+Array.from(docs, doc => doc.toJS())
 > [{ foo: 'bar', fee: [24, '42'] }]
 ```
 
-#### `new Composer(push: (doc: Document.Parsed) => void, options?: Options)`
+#### `new Composer(options?: ParseOptions & DocumentOptions & SchemaOptions)`
 
 Create a new Document composer.
 Does not include an internal Parser instance, so an external one will be needed.
-`options` will be used during composition, and passed to the `new Document` constructor; may include any of ParseOptions, DocumentOptions, and SchemaOptions.
+`options` will be used during composition, and passed to the `new Document` constructor.
 
-#### `composer.next(token: Token)`
+#### `composer.compose(tokens: Iterable<Token>, forceDoc?: boolean, endOffset?: number): Generator<Document.Parsed>`
+
+Compose tokens into documents.
+Convenience wrapper combining calls to `composer.next()` and `composer.end()`.
+
+#### `composer.next(token: Token): Generator<Document.Parsed>`
 
 Advance the composed by one CST token.
-Bound to the Composer instance, so may be used directly as a callback function.
 
-#### `composer.end(forceDoc?: boolean, offset?: number)`
+#### `composer.end(forceDoc?: boolean, offset?: number): Generator<Document.Parsed>`
 
 Always call at end of input to push out any remaining document.
 If `forceDoc` is true and the stream contains no document, still emit a final document including any comments and directives that would be applied to a subsequent document.

--- a/docs/07_parsing_yaml.md
+++ b/docs/07_parsing_yaml.md
@@ -28,10 +28,8 @@ Both the Lexer and Parser accept incomplete input, allowing for them and the Com
 ```js
 import { Lexer } from 'yaml'
 
-const tokens = []
-const lexer = new Lexer(tok => tokens.push(tok))
-lexer.lex('foo: bar\nfee:\n  [24,"42"]\n', false)
-console.dir(tokens)
+const tokens = new Lexer().lex('foo: bar\nfee:\n  [24,"42"]\n')
+console.dir(Array.from(tokens))
 > [
     '\x02', '\x1F', 'foo',  ':',
     ' ',    '\x1F', 'bar',  '\n',
@@ -41,12 +39,11 @@ console.dir(tokens)
   ]
 ```
 
-#### `new Lexer(push: (token: string) => void)`
+#### `new Lexer()`
 
-#### `lexer.lex(src: string, incomplete: boolean): void`
+#### `lexer.lex(src: string, incomplete?: boolean): Generator<string>`
 
 The API for the lexer is rather minimal, and offers no configuration.
-The constructor accepts a single callback as argument, defining a function that will be called once for each lexical token.
 If the input stream is chunked, the `lex()` method may be called separately for each chunk if the `incomplete` argument is `true`.
 At the end of input, `lex()` should be called a final time with `incomplete: false` to ensure that the remaining tokens are emitted.
 

--- a/src/compose/composer.ts
+++ b/src/compose/composer.ts
@@ -53,8 +53,7 @@ function parsePrelude(prelude: string[]) {
  * const options = { ... }
  * const docs: Document.Parsed[] = []
  * const composer = new Composer(doc => docs.push(doc), options)
- * const parser = new Parser(composer.next)
- * parser.parse(source)
+ * for (const doc of new Parser().parse(source)) composer.next(doc)
  * composer.end()
  * ```
  */

--- a/src/parse/parser.ts
+++ b/src/parse/parser.ts
@@ -148,9 +148,8 @@ function fixFlowSeqItems(fc: FlowCollection) {
  * const parser = new Parser(tok => cst.push(tok))
  * const src: string = ...
  *
- * // The following would be equivalent to `parser.parse(src, false)`
- * const lexer = new Lexer(parser.next)
- * lexer.lex(src, false)
+ * // The following would be equivalent to `parser.parse(src)`
+ * for (const lexeme of new Lexer().lex(src)) parser.next(lexeme)
  * parser.end()
  * ```
  */
@@ -206,7 +205,7 @@ export class Parser {
    */
   parse(source: string, incomplete = false) {
     if (this.onNewLine && this.offset === 0) this.onNewLine(0)
-    this.lexer.lex(source, incomplete)
+    for (const lexeme of this.lexer.lex(source, incomplete)) this.next(lexeme)
     if (!incomplete) this.end()
   }
 
@@ -261,7 +260,7 @@ export class Parser {
   }
 
   // Must be defined after `next()`
-  private lexer = new Lexer(this.next)
+  private lexer = new Lexer()
 
   /** Call at end of input to push out any remaining constructions */
   end() {

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -50,8 +50,8 @@ export function parseAllDocuments<T extends ParsedNode = ParsedNode>(
     doc => docs.push(doc as Document.Parsed<T>),
     options
   )
-  const parser = new Parser(composer.next, lineCounter?.addNewLine)
-  parser.parse(source)
+  const parser = new Parser(lineCounter?.addNewLine)
+  for (const token of parser.parse(source)) composer.next(token)
   composer.end()
 
   if (prettyErrors && lineCounter)
@@ -89,8 +89,8 @@ export function parseDocument<T extends ParsedNode = ParsedNode>(
       )
     }
   }, options)
-  const parser = new Parser(composer.next, lineCounter?.addNewLine)
-  parser.parse(source)
+  const parser = new Parser(lineCounter?.addNewLine)
+  for (const token of parser.parse(source)) composer.next(token)
   composer.end(true, source.length)
 
   if (prettyErrors && lineCounter) {

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -41,18 +41,12 @@ function parseOptions(options: ParseOptions | undefined) {
  */
 export function parseAllDocuments<T extends ParsedNode = ParsedNode>(
   source: string,
-  options?: ParseOptions & DocumentOptions & SchemaOptions
+  options: ParseOptions & DocumentOptions & SchemaOptions = {}
 ): Document.Parsed<T>[] | EmptyStream {
   const { lineCounter, prettyErrors } = parseOptions(options)
-
-  const docs: Document.Parsed<T>[] = []
-  const composer = new Composer(
-    doc => docs.push(doc as Document.Parsed<T>),
-    options
-  )
   const parser = new Parser(lineCounter?.addNewLine)
-  for (const token of parser.parse(source)) composer.next(token)
-  composer.end()
+  const composer = new Composer(options)
+  const docs = Array.from(composer.compose(parser.parse(source)))
 
   if (prettyErrors && lineCounter)
     for (const doc of docs) {
@@ -60,7 +54,7 @@ export function parseAllDocuments<T extends ParsedNode = ParsedNode>(
       doc.warnings.forEach(prettifyError(source, lineCounter))
     }
 
-  if (docs.length > 0) return docs
+  if (docs.length > 0) return docs as Document.Parsed<T>[]
   return Object.assign<
     Document.Parsed<T>[],
     { empty: true },
@@ -71,13 +65,19 @@ export function parseAllDocuments<T extends ParsedNode = ParsedNode>(
 /** Parse an input string into a single YAML.Document */
 export function parseDocument<T extends ParsedNode = ParsedNode>(
   source: string,
-  options?: ParseOptions & DocumentOptions & SchemaOptions
+  options: ParseOptions & DocumentOptions & SchemaOptions = {}
 ) {
   const { lineCounter, prettyErrors } = parseOptions(options)
+  const parser = new Parser(lineCounter?.addNewLine)
+  const composer = new Composer(options)
 
   // `doc` is always set by compose.end(true) at the very latest
   let doc: Document.Parsed<T> = null as any
-  const composer = new Composer(_doc => {
+  for (const _doc of composer.compose(
+    parser.parse(source),
+    true,
+    source.length
+  )) {
     if (!doc) doc = _doc as Document.Parsed<T>
     else if (doc.options.logLevel !== 'silent') {
       doc.errors.push(
@@ -87,11 +87,9 @@ export function parseDocument<T extends ParsedNode = ParsedNode>(
           'Source contains multiple documents; please use YAML.parseAllDocuments()'
         )
       )
+      break
     }
-  }, options)
-  const parser = new Parser(lineCounter?.addNewLine)
-  for (const token of parser.parse(source)) composer.next(token)
-  composer.end(true, source.length)
+  }
 
   if (prettyErrors && lineCounter) {
     doc.errors.forEach(prettifyError(source, lineCounter))

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -53,15 +53,16 @@ describe('Input in parts', () => {
 
       for (let i = 1; i < src.length - 1; ++i) {
         const res: Document.Parsed[] = []
-        const composer = new Composer(doc => res.push(doc), {
-          logLevel: 'error'
-        })
+        const composer = new Composer({ logLevel: 'error' })
         const parser = new Parser()
         const start = src.substring(0, i)
         const end = src.substring(i)
-        for (const token of parser.parse(start, true)) composer.next(token)
-        for (const token of parser.parse(end, false)) composer.next(token)
-        composer.end()
+        for (const token of [
+          ...parser.parse(start, true),
+          ...parser.parse(end, false)
+        ])
+          for (const doc of composer.next(token)) res.push(doc)
+        for (const doc of composer.end()) res.push(doc)
 
         try {
           expect(res.map(doc => doc.toJS())).toMatchObject(exp)

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -56,12 +56,11 @@ describe('Input in parts', () => {
         const composer = new Composer(doc => res.push(doc), {
           logLevel: 'error'
         })
-        const parser = new Parser(composer.next)
-
+        const parser = new Parser()
         const start = src.substring(0, i)
         const end = src.substring(i)
-        parser.parse(start, true)
-        parser.parse(end, false)
+        for (const token of parser.parse(start, true)) composer.next(token)
+        for (const token of parser.parse(end, false)) composer.next(token)
         composer.end()
 
         try {

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -6,8 +6,7 @@
     "paths": {
       "yaml": ["../src/index.ts"]
     },
-    "rootDir": "..",
-    "target": "ES3"
+    "rootDir": ".."
   },
   "include": ["**/*.ts"]
 }


### PR DESCRIPTION
In retrospect, this seems so obvious.

All of the parsing stages now provide generators, so that their output may be iterated, rather than needing to provide them with a callback function. As a convenience, a `compose()` method is also added:

```js
import { Composer, Parser } from 'yaml'

const src = 'foo: bar\nfee: [24, "42"]'
const tokens = new Parser().parse(src)
const docs = new Composer().compose(tokens)

Array.from(docs, doc => doc.toJS())
> [{ foo: 'bar', fee: [24, '42'] }]
```

This is a breaking change to the API provided for these classes in the preceding 2.0.0-4 release.