### PR TITLE
Refactor Node range as [start, value-end, node-end]

### DIFF
--- a/docs/04_documents.md
+++ b/docs/04_documents.md
@@ -14,33 +14,30 @@ doc.contents
 // YAMLMap {
 //   items:
 //    [ Pair {
-//        key: Scalar { value: 'YAML', range: [ 0, 4 ] },
+//        key: Scalar { value: 'YAML', range: [ 0, 4, 4 ] },
 //        value:
 //         YAMLSeq {
 //           items:
 //            [ Scalar {
 //                value: 'A human-readable data serialization language',
-//                range: [ 10, 55 ] },
+//                range: [ 10, 54, 55 ] },
 //              Scalar {
 //                value: 'https://en.wikipedia.org/wiki/YAML',
-//                range: [ 59, 94 ] } ],
-//           tag: 'tag:yaml.org,2002:seq',
-//           range: [ 8, 94 ] } },
+//                range: [ 59, 93, 94 ] } ],
+//           range: [ 8, 94, 94 ] } },
 //      Pair {
-//        key: Scalar { value: 'yaml', range: [ 94, 98 ] },
+//        key: Scalar { value: 'yaml', range: [ 94, 98, 98 ] },
 //        value:
 //         YAMLSeq {
 //           items:
 //            [ Scalar {
 //                value: 'A complete JavaScript implementation',
-//                range: [ 104, 141 ] },
+//                range: [ 104, 140, 141 ] },
 //              Scalar {
 //                value: 'https://www.npmjs.com/package/yaml',
-//                range: [ 145, 180 ] } ],
-//           tag: 'tag:yaml.org,2002:seq',
-//           range: [ 102, 180 ] } } ],
-//   tag: 'tag:yaml.org,2002:map',
-//   range: [ 0, 180 ] }
+//                range: [ 145, 180, 180 ] } ],
+//           range: [ 102, 180, 180 ] } } ],
+//   range: [ 0, 180, 180 ] }
 ```
 
 #### `parseDocument(str, options = {}): Document`

--- a/docs/05_content_nodes.md
+++ b/docs/05_content_nodes.md
@@ -12,9 +12,9 @@ It is valid to have an anchor associated with a node even if it has no aliases.
 class NodeBase {
   comment?: string        // a comment on or immediately after this
   commentBefore?: string  // a comment before this
-  range?: [number, number]
-      // the [start, end] range of characters of the source parsed
-      // into this node (undefined for pairs or if not parsed)
+  range?: [number, number, number]
+      // The [start, value-end, node-end] character offsets for the part
+      // of the source parsed into this node (undefined if not parsed).
   spaceBefore?: boolean
       // a blank line before this node and its commentBefore
   tag?: string   // a fully qualified tag, if required

--- a/docs/07_parsing_yaml.md
+++ b/docs/07_parsing_yaml.md
@@ -308,7 +308,7 @@ const item = doc.value.items[0].value
   }
 
 YAML.resolveAsScalar(item)
-> { value: 'bar', type: 'QUOTE_DOUBLE', comment: 'comment', length: 14 }
+> { value: 'bar', type: 'QUOTE_DOUBLE', comment: 'comment', range: [5, 9, 19] }
 ```
 
 #### `CST.isCollection(token?: Token): boolean`

--- a/src/compose/compose-doc.ts
+++ b/src/compose/compose-doc.ts
@@ -52,8 +52,9 @@ export function composeDoc(
     ? composeNode(ctx, value, props, onError)
     : composeEmptyNode(ctx, props.end, start, null, props, onError)
 
-  const re = resolveEnd(end, doc.contents.range[1], false, onError)
+  const contentEnd = doc.contents.range[2]
+  const re = resolveEnd(end, contentEnd, false, onError)
   if (re.comment) doc.comment = re.comment
-  doc.range = [offset, re.offset]
+  doc.range = [offset, contentEnd, re.offset]
   return doc
 }

--- a/src/compose/compose-node.ts
+++ b/src/compose/compose-node.ts
@@ -102,8 +102,9 @@ function composeAlias(
   onError: ComposeErrorHandler
 ) {
   const alias = new Alias(source.substring(1))
-  const re = resolveEnd(end, offset + source.length, options.strict, onError)
-  alias.range = [offset, re.offset]
+  const valueEnd = offset + source.length
+  const re = resolveEnd(end, valueEnd, options.strict, onError)
+  alias.range = [offset, valueEnd, re.offset]
   if (re.comment) alias.comment = re.comment
   return alias as Alias.Parsed
 }

--- a/src/compose/compose-scalar.ts
+++ b/src/compose/compose-scalar.ts
@@ -14,8 +14,7 @@ export function composeScalar(
   tagName: string | null,
   onError: ComposeErrorHandler
 ) {
-  const { offset } = token
-  const { value, type, comment, length } =
+  const { value, type, comment, range } =
     token.type === 'block-scalar'
       ? resolveBlockScalar(token, ctx.options.strict, onError)
       : resolveFlowScalar(token, ctx.options.strict, onError)
@@ -28,15 +27,15 @@ export function composeScalar(
   try {
     const res = tag.resolve(
       value,
-      msg => onError(offset, 'TAG_RESOLVE_FAILED', msg),
+      msg => onError(token.offset, 'TAG_RESOLVE_FAILED', msg),
       ctx.options
     )
     scalar = isScalar(res) ? res : new Scalar(res)
   } catch (error) {
-    onError(offset, 'TAG_RESOLVE_FAILED', error.message)
+    onError(token.offset, 'TAG_RESOLVE_FAILED', error.message)
     scalar = new Scalar(value)
   }
-  scalar.range = [offset, offset + length]
+  scalar.range = range
   scalar.source = value
   if (type) scalar.type = type
   if (tagName) scalar.tag = tagName

--- a/src/compose/composer.ts
+++ b/src/compose/composer.ts
@@ -206,7 +206,7 @@ export class Composer {
           const dc = this.doc.comment
           this.doc.comment = dc ? `${dc}\n${end.comment}` : end.comment
         }
-        this.doc.range[1] = end.offset
+        this.doc.range[2] = end.offset
         break
       }
       default:
@@ -240,7 +240,7 @@ export class Composer {
           'MISSING_CHAR',
           'Missing directives-end indicator line'
         )
-      doc.range = [0, endOffset]
+      doc.range = [0, endOffset, endOffset]
       this.decorate(doc, false)
       yield doc
     }

--- a/src/compose/resolve-block-map.ts
+++ b/src/compose/resolve-block-map.ts
@@ -65,7 +65,7 @@ export function resolveBlockMap(
     const valueProps = resolveProps(sep || [], {
       ctx,
       indicator: 'map-value-ind',
-      offset: keyNode.range[1],
+      offset: keyNode.range[2],
       onError,
       startOnNewline: !key || key.type === 'block-scalar'
     })
@@ -93,7 +93,7 @@ export function resolveBlockMap(
       const valueNode = value
         ? composeNode(ctx, value, valueProps, onError)
         : composeEmptyNode(ctx, offset, sep, null, valueProps, onError)
-      offset = valueNode.range[1]
+      offset = valueNode.range[2]
       map.items.push(new Pair(keyNode, valueNode))
     } else {
       // key with no value
@@ -111,6 +111,6 @@ export function resolveBlockMap(
     }
   }
 
-  map.range = [bm.offset, offset]
+  map.range = [bm.offset, offset, offset]
   return map as YAMLMap.Parsed
 }

--- a/src/compose/resolve-block-seq.ts
+++ b/src/compose/resolve-block-seq.ts
@@ -40,9 +40,9 @@ export function resolveBlockSeq(
     const node = value
       ? composeNode(ctx, value, props, onError)
       : composeEmptyNode(ctx, offset, start, null, props, onError)
-    offset = node.range[1]
+    offset = node.range[2]
     seq.items.push(node)
   }
-  seq.range = [bs.offset, offset]
+  seq.range = [bs.offset, offset, offset]
   return seq as YAMLSeq.Parsed
 }

--- a/src/compose/resolve-flow-scalar.ts
+++ b/src/compose/resolve-flow-scalar.ts
@@ -1,3 +1,4 @@
+import { Range } from '../nodes/Node.js'
 import { Scalar } from '../nodes/Scalar.js'
 import type { FlowScalar } from '../parse/cst.js'
 import type { ComposeErrorHandler } from './composer.js'
@@ -11,7 +12,7 @@ export function resolveFlowScalar(
   value: string
   type: Scalar.PLAIN | Scalar.QUOTE_DOUBLE | Scalar.QUOTE_SINGLE | null
   comment: string
-  length: number
+  range: Range
 } {
   let _type: Scalar.PLAIN | Scalar.QUOTE_DOUBLE | Scalar.QUOTE_SINGLE
   let value: string
@@ -44,7 +45,7 @@ export function resolveFlowScalar(
         value: '',
         type: null,
         comment: '',
-        length: source.length
+        range: [offset, offset + source.length, offset + source.length]
       }
   }
 
@@ -53,7 +54,7 @@ export function resolveFlowScalar(
     value,
     type: _type,
     comment: re.comment,
-    length: source.length + re.offset
+    range: [offset, offset + source.length, offset + source.length + re.offset]
   }
 }
 

--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -7,7 +7,8 @@ import {
   isScalar,
   Node,
   NODE_TYPE,
-  ParsedNode
+  ParsedNode,
+  Range
 } from '../nodes/Node.js'
 import { Pair } from '../nodes/Pair.js'
 import type { Scalar } from '../nodes/Scalar.js'
@@ -35,9 +36,7 @@ export type Replacer = any[] | ((key: any, value: any) => unknown)
 
 export declare namespace Document {
   interface Parsed<T extends ParsedNode = ParsedNode> extends Document<T> {
-    range: [number, number]
-    /** The schema used with the document. */
-    schema: Schema
+    range: Range
   }
 }
 
@@ -64,6 +63,12 @@ export class Document<T = unknown> {
       'lineCounter' | 'directives' | 'version'
     >
   >
+
+  /**
+   * The [start, value-end, node-end] character offsets for the part of the
+   * source parsed into this document (undefined if not parsed).
+   */
+  declare range?: Range
 
   // TS can't figure out that setSchema() will set this, or throw
   /** The schema used with the document. Use `setSchema()` to change. */

--- a/src/nodes/Alias.ts
+++ b/src/nodes/Alias.ts
@@ -2,7 +2,15 @@ import { anchorIsValid } from '../doc/anchors'
 import type { Document } from '../doc/Document'
 import type { StringifyContext } from '../stringify/stringify.js'
 import { visit } from '../visit'
-import { ALIAS, isAlias, isCollection, isPair, Node, NodeBase } from './Node.js'
+import {
+  ALIAS,
+  isAlias,
+  isCollection,
+  isPair,
+  Node,
+  NodeBase,
+  Range
+} from './Node.js'
 import type { Scalar } from './Scalar'
 import type { ToJSContext } from './toJS.js'
 import type { YAMLMap } from './YAMLMap'
@@ -10,7 +18,7 @@ import type { YAMLSeq } from './YAMLSeq'
 
 export declare namespace Alias {
   interface Parsed extends Alias {
-    range: [number, number]
+    range: Range
   }
 }
 

--- a/src/nodes/Node.ts
+++ b/src/nodes/Node.ts
@@ -14,6 +14,8 @@ export type ParsedNode =
   | YAMLMap.Parsed
   | YAMLSeq.Parsed
 
+export type Range = [number, number, number]
+
 export const ALIAS = Symbol.for('yaml.alias')
 export const DOC = Symbol.for('yaml.document')
 export const MAP = Symbol.for('yaml.map')
@@ -75,10 +77,10 @@ export abstract class NodeBase {
   declare commentBefore?: string | null
 
   /**
-   * The [start, end] range of characters of the source parsed
-   * into this node (undefined for pairs or if not parsed)
+   * The [start, value-end, node-end] character offsets for the part of the
+   * source parsed into this node (undefined if not parsed).
    */
-  declare range?: [number, number] | null
+  declare range?: Range | null
 
   /** A blank line before this node and its commentBefore */
   declare spaceBefore?: boolean

--- a/src/nodes/Scalar.ts
+++ b/src/nodes/Scalar.ts
@@ -1,4 +1,4 @@
-import { NodeBase, SCALAR } from './Node.js'
+import { NodeBase, Range, SCALAR } from './Node.js'
 import { toJS, ToJSContext } from './toJS.js'
 
 export const isScalarValue = (value: unknown) =>
@@ -6,7 +6,7 @@ export const isScalarValue = (value: unknown) =>
 
 export declare namespace Scalar {
   interface Parsed extends Scalar {
-    range: [number, number]
+    range: Range
     source: string
   }
 

--- a/src/nodes/YAMLMap.ts
+++ b/src/nodes/YAMLMap.ts
@@ -3,7 +3,7 @@ import type { StringifyContext } from '../stringify/stringify.js'
 import { stringifyCollection } from '../stringify/stringifyCollection.js'
 import { addPairToJSMap } from './addPairToJSMap.js'
 import { Collection } from './Collection.js'
-import { isPair, isScalar, MAP, ParsedNode } from './Node.js'
+import { isPair, isScalar, MAP, ParsedNode, Range } from './Node.js'
 import { Pair } from './Pair.js'
 import { isScalarValue } from './Scalar.js'
 import type { ToJSContext } from './toJS.js'
@@ -28,7 +28,7 @@ export declare namespace YAMLMap {
     V extends ParsedNode | null = ParsedNode | null
   > extends YAMLMap<K, V> {
     items: Pair<K, V>[]
-    range: [number, number]
+    range: Range
   }
 }
 

--- a/src/nodes/YAMLSeq.ts
+++ b/src/nodes/YAMLSeq.ts
@@ -2,7 +2,7 @@ import type { Schema } from '../schema/Schema.js'
 import type { StringifyContext } from '../stringify/stringify.js'
 import { stringifyCollection } from '../stringify/stringifyCollection.js'
 import { Collection } from './Collection.js'
-import { isScalar, ParsedNode, SEQ } from './Node.js'
+import { isScalar, ParsedNode, Range, SEQ } from './Node.js'
 import type { Pair } from './Pair.js'
 import { isScalarValue } from './Scalar.js'
 import { toJS, ToJSContext } from './toJS.js'
@@ -12,7 +12,7 @@ export declare namespace YAMLSeq {
     T extends ParsedNode | Pair<ParsedNode, ParsedNode | null> = ParsedNode
   > extends YAMLSeq<T> {
     items: T[]
-    range: [number, number]
+    range: Range
   }
 }
 

--- a/src/parse/cst-scalar.ts
+++ b/src/parse/cst-scalar.ts
@@ -2,6 +2,7 @@ import type { ComposeErrorHandler } from '../compose/composer.js'
 import { resolveBlockScalar } from '../compose/resolve-block-scalar.js'
 import { resolveFlowScalar } from '../compose/resolve-flow-scalar.js'
 import { YAMLParseError } from '../errors.js'
+import { Range } from '../nodes/Node.js'
 import type { Scalar } from '../nodes/Scalar.js'
 import type { StringifyContext } from '../stringify/stringify.js'
 import { stringifyString } from '../stringify/stringifyString.js'
@@ -19,7 +20,7 @@ export function resolveAsScalar(
   value: string
   type: Scalar.Type | null
   comment: string
-  length: number
+  range: Range
 } | null {
   if (token) {
     if (!onError)

--- a/src/parse/cst-scalar.ts
+++ b/src/parse/cst-scalar.ts
@@ -80,7 +80,9 @@ export function createScalarToken(
       options: { lineWidth: -1 }
     } as StringifyContext
   )
-  const end = context.end ?? [{ type: 'newline', offset: -1, indent, source: '\n' }]
+  const end = context.end ?? [
+    { type: 'newline', offset: -1, indent, source: '\n' }
+  ]
   switch (source[0]) {
     case '|':
     case '>': {
@@ -186,7 +188,7 @@ function setBlockScalarValue(token: Token, source: string) {
     header.source = head
     token.source = body
   } else {
-    let offset = token.offset
+    const { offset } = token
     const indent = 'indent' in token ? token.indent : -1
     const props: Token[] = [
       { type: 'block-scalar-header', offset, indent, source: head }

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -21,7 +21,7 @@ export class Schema {
 
   // Used by createNode() and composeScalar()
   [MAP]: CollectionTag;
-  [SCALAR]: ScalarTag
+  [SCALAR]: ScalarTag;
   [SEQ]: CollectionTag
 
   constructor({

--- a/src/test-events.ts
+++ b/src/test-events.ts
@@ -47,13 +47,13 @@ export function testEvents(src: string) {
       const doc = docs[i]
       let root = doc.contents
       if (Array.isArray(root)) root = root[0]
-      const [rootStart, rootEnd] = doc.range || [0, 0]
+      const [rootStart, , rootEnd] = doc.range || [0, , 0]
       const error = doc.errors[0]
       if (error && (!error.offset || error.offset < rootStart))
         throw new Error()
       let docStart = '+DOC'
       if (doc.directives.marker) docStart += ' ---'
-      else if (doc.contents && doc.contents.range[1] === doc.contents.range[0])
+      else if (doc.contents && doc.contents.range[2] === doc.contents.range[0])
         continue
       events.push(docStart)
       addEvents(events, doc, error?.offset ?? -1, root)

--- a/src/test-events.ts
+++ b/src/test-events.ts
@@ -47,6 +47,7 @@ export function testEvents(src: string) {
       const doc = docs[i]
       let root = doc.contents
       if (Array.isArray(root)) root = root[0]
+      // eslint-disable-next-line no-sparse-arrays
       const [rootStart, , rootEnd] = doc.range || [0, , 0]
       const error = doc.errors[0]
       if (error && (!error.offset || error.offset < rootStart))

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -51,7 +51,7 @@ describe('parse comments', () => {
       expect(doc.contents.comment).toBe('c1')
       expect(doc.comment).toBe('c2')
       expect(doc.contents.value).toBe('value')
-      expect(doc.contents.range).toMatchObject([4, 14])
+      expect(doc.contents.range).toMatchObject([4, 9, 14])
     })
 
     test('"quoted"', () => {
@@ -61,7 +61,7 @@ describe('parse comments', () => {
       expect(doc.contents.comment).toBe('c1')
       expect(doc.comment).toBe('c2')
       expect(doc.contents.value).toBe('value')
-      expect(doc.contents.range).toMatchObject([4, 16])
+      expect(doc.contents.range).toMatchObject([4, 11, 16])
     })
 
     test('block', () => {
@@ -71,7 +71,7 @@ describe('parse comments', () => {
       expect(doc.contents.comment).toBe('c1')
       expect(doc.comment).toBe('c2')
       expect(doc.contents.value).toBe('value')
-      expect(doc.contents.range).toMatchObject([4, 18])
+      expect(doc.contents.range).toMatchObject([4, 18, 18])
     })
   })
 
@@ -93,7 +93,7 @@ describe('parse comments', () => {
             { commentBefore: 'c0', value: 'value 1', comment: 'c1' },
             { value: 'value 2' }
           ],
-          range: [4, 29]
+          range: [4, 29, 29]
         },
         comment: 'c2'
       })

--- a/tests/doc/parse.js
+++ b/tests/doc/parse.js
@@ -455,7 +455,7 @@ describe('empty(ish) nodes', () => {
   test('empty node position', () => {
     const doc = YAML.parseDocument('\r\na: # 123\r\n')
     const empty = doc.contents.items[0].value
-    expect(empty.range).toEqual([5, 5])
+    expect(empty.range).toEqual([5, 5, 5])
   })
 
   test('parse an empty string as null', () => {


### PR DESCRIPTION
Fixes #258 by adding a third value to the `range` tuple.

For block values, `value-end` and `node-end` are always the same as the previous end value. For flow collections and documents, `node-end` is the same as the previous `end` position, while `value-end` marks the end of the actual value.

@gorkem, would this work for your use case?