### PR TITLE
Replace error.offset with error.pos: [number, number]

### DIFF
--- a/src/compose/resolve-block-map.ts
+++ b/src/compose/resolve-block-map.ts
@@ -1,6 +1,6 @@
 import { Pair } from '../nodes/Pair.js'
 import { YAMLMap } from '../nodes/YAMLMap.js'
-import type { BlockMap } from '../parse/cst.js'
+import type { BlockMap, Token } from '../parse/cst.js'
 import type { ComposeContext, ComposeNode } from './compose-node.js'
 import type { ComposeErrorHandler } from './composer.js'
 import { resolveProps } from './resolve-props.js'
@@ -38,7 +38,7 @@ export function resolveBlockMap(
         else if ('indent' in key && key.indent !== bm.indent)
           onError(offset, 'BAD_INDENT', startColMsg)
       }
-      if (!keyProps.anchor && !keyProps.tagName && !sep) {
+      if (!keyProps.anchor && !keyProps.tag && !sep) {
         // TODO: assert being at last item?
         if (keyProps.comment) {
           if (map.comment) map.comment += '\n' + keyProps.comment
@@ -50,7 +50,7 @@ export function resolveBlockMap(
       onError(offset, 'BAD_INDENT', startColMsg)
     if (implicitKey && containsNewline(key))
       onError(
-        keyProps.start,
+        key as Token, // checked by containsNewline()
         'MULTILINE_IMPLICIT_KEY',
         'Implicit keys need to be on a single line'
       )
@@ -84,7 +84,7 @@ export function resolveBlockMap(
           keyProps.start < valueProps.found.offset - 1024
         )
           onError(
-            offset,
+            keyNode.range,
             'KEY_OVER_1024_CHARS',
             'The : indicator must be at most 1024 chars after the start of an implicit block mapping key'
           )
@@ -99,7 +99,7 @@ export function resolveBlockMap(
       // key with no value
       if (implicitKey)
         onError(
-          keyStart,
+          keyNode.range,
           'MISSING_CHAR',
           'Implicit map keys need to be followed by map values'
         )

--- a/src/compose/resolve-block-scalar.ts
+++ b/src/compose/resolve-block-scalar.ts
@@ -127,7 +127,7 @@ function parseBlockScalarHeader(
 ) {
   /* istanbul ignore if should not happen */
   if (props[0].type !== 'block-scalar-header') {
-    onError(offset, 'IMPOSSIBLE', 'Block scalar header not found')
+    onError(props[0], 'IMPOSSIBLE', 'Block scalar header not found')
     return null
   }
   const { source } = props[0]
@@ -166,19 +166,19 @@ function parseBlockScalarHeader(
         if (strict && !hasSpace) {
           const message =
             'Comments must be separated from other tokens by white space characters'
-          onError(offset + length, 'COMMENT_SPACE', message)
+          onError(token, 'COMMENT_SPACE', message)
         }
         length += token.source.length
         comment = token.source.substring(1)
         break
       case 'error':
-        onError(offset + length, 'UNEXPECTED_TOKEN', token.message)
+        onError(token, 'UNEXPECTED_TOKEN', token.message)
         length += token.source.length
         break
       /* istanbul ignore next should not happen */
       default: {
         const message = `Unexpected token in block scalar header: ${token.type}`
-        onError(offset + length, 'UNEXPECTED_TOKEN', message)
+        onError(token, 'UNEXPECTED_TOKEN', message)
         const ts = (token as any).source
         if (ts && typeof ts === 'string') length += ts.length
       }

--- a/src/compose/resolve-block-seq.ts
+++ b/src/compose/resolve-block-seq.ts
@@ -22,7 +22,7 @@ export function resolveBlockSeq(
     })
     offset = props.end
     if (!props.found) {
-      if (props.anchor || props.tagName || value) {
+      if (props.anchor || props.tag || value) {
         if (value && value.type === 'block-seq')
           onError(
             offset,

--- a/src/compose/resolve-end.ts
+++ b/src/compose/resolve-end.ts
@@ -11,7 +11,8 @@ export function resolveEnd(
   if (end) {
     let hasSpace = false
     let sep = ''
-    for (const { source, type } of end) {
+    for (const token of end) {
+      const { source, type } = token
       switch (type) {
         case 'space':
           hasSpace = true
@@ -19,7 +20,7 @@ export function resolveEnd(
         case 'comment': {
           if (reqSpace && !hasSpace)
             onError(
-              offset,
+              token,
               'COMMENT_SPACE',
               'Comments must be separated from other tokens by white space characters'
             )
@@ -34,7 +35,7 @@ export function resolveEnd(
           hasSpace = true
           break
         default:
-          onError(offset, 'UNEXPECTED_TOKEN', `Unexpected ${type} at node end`)
+          onError(token, 'UNEXPECTED_TOKEN', `Unexpected ${type} at node end`)
       }
       offset += source.length
     }

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -82,7 +82,7 @@ export function parseDocument<T extends ParsedNode = ParsedNode>(
     else if (doc.options.logLevel !== 'silent') {
       doc.errors.push(
         new YAMLParseError(
-          _doc.range[0],
+          _doc.range.slice(0, 2) as [number, number],
           'MULTIPLE_DOCS',
           'Source contains multiple documents; please use YAML.parseAllDocuments()'
         )

--- a/src/test-events.ts
+++ b/src/test-events.ts
@@ -50,14 +50,13 @@ export function testEvents(src: string) {
       // eslint-disable-next-line no-sparse-arrays
       const [rootStart, , rootEnd] = doc.range || [0, , 0]
       const error = doc.errors[0]
-      if (error && (!error.offset || error.offset < rootStart))
-        throw new Error()
+      if (error && (!error.pos || error.pos[0] < rootStart)) throw new Error()
       let docStart = '+DOC'
       if (doc.directives.marker) docStart += ' ---'
       else if (doc.contents && doc.contents.range[2] === doc.contents.range[0])
         continue
       events.push(docStart)
-      addEvents(events, doc, error?.offset ?? -1, root)
+      addEvents(events, doc, error?.pos[0] ?? -1, root)
 
       let docEnd = '-DOC'
       if (rootEnd) {

--- a/tests/line-counter.ts
+++ b/tests/line-counter.ts
@@ -3,7 +3,7 @@ import { LineCounter, parseDocument } from 'yaml'
 test('Parse error, no newlines', () => {
   const lineCounter = new LineCounter()
   const doc = parseDocument('foo: bar: baz', { lineCounter })
-  expect(doc.errors).toMatchObject([{ offset: 5 }])
+  expect(doc.errors).toMatchObject([{ pos: [5, 6] }])
   expect(lineCounter.lineStarts).toMatchObject([0])
   expect(lineCounter.linePos(5)).toMatchObject({ line: 1, col: 6 })
 })
@@ -11,9 +11,10 @@ test('Parse error, no newlines', () => {
 test('Parse error with newlines', () => {
   const lineCounter = new LineCounter()
   const doc = parseDocument('foo:\n  bar: - baz\n', { lineCounter })
-  expect(doc.errors).toMatchObject([{ offset: 14 }])
+  expect(doc.errors).toMatchObject([{ pos: [14, 17] }])
   expect(lineCounter.lineStarts).toMatchObject([0, 5, 18])
   expect(lineCounter.linePos(14)).toMatchObject({ line: 2, col: 10 })
+  expect(lineCounter.linePos(17)).toMatchObject({ line: 2, col: 13 })
 })
 
 test('block scalar', () => {


### PR DESCRIPTION
Fixes #254

**BREAKING CHANGE**: In addition to dropping `error.offset`, the shape of `error.linePos` is changed to a matching tuple of `{ line, col }` values.

Also, the first parts of anchor & tag resolution are moved down from `resolveProps()`, to allow the remaining parts of tag resolution to blame the tag when they fail.

For many errors, it's still impossible or unwieldy to determine their full position range, so their ranges get assigned as `[n, n+1]`.