### PR TITLE
Fix empty lines & trailing comments

### DIFF
--- a/src/compose/composer.ts
+++ b/src/compose/composer.ts
@@ -42,7 +42,7 @@ function parsePrelude(prelude: string[]) {
       case '#':
         comment +=
           (comment === '' ? '' : afterEmptyLine ? '\n\n' : '\n') +
-          source.substring(1)
+          (source.substring(1) || ' ')
         atComment = true
         afterEmptyLine = false
         break

--- a/src/compose/resolve-end.ts
+++ b/src/compose/resolve-end.ts
@@ -24,7 +24,7 @@ export function resolveEnd(
               'COMMENT_SPACE',
               'Comments must be separated from other tokens by white space characters'
             )
-          const cb = source.substring(1)
+          const cb = source.substring(1) || ' '
           if (!comment) comment = cb
           else comment += sep + cb
           sep = ''

--- a/src/compose/resolve-props.ts
+++ b/src/compose/resolve-props.ts
@@ -48,7 +48,7 @@ export function resolveProps(
             'COMMENT_SPACE',
             'Comments must be separated from other tokens by white space characters'
           )
-        const cb = token.source.substring(1)
+        const cb = token.source.substring(1) || ' '
         if (!comment) comment = cb
         else comment += commentSep + cb
         commentSep = ''

--- a/src/compose/resolve-props.ts
+++ b/src/compose/resolve-props.ts
@@ -52,14 +52,17 @@ export function resolveProps(
         if (!comment) comment = cb
         else comment += commentSep + cb
         commentSep = ''
+        atNewline = false
         break
       }
       case 'newline':
-        if (atNewline && !comment) spaceBefore = true
+        if (atNewline) {
+          if (comment) comment += token.source
+          else spaceBefore = true
+        } else commentSep += token.source
         atNewline = true
         hasNewline = true
         hasSpace = true
-        commentSep += token.source
         break
       case 'anchor':
         if (anchor)

--- a/src/parse/parser.ts
+++ b/src/parse/parser.ts
@@ -33,13 +33,17 @@ function includesNonEmpty(list: SourceToken[]) {
   return false
 }
 
-function atFirstEmptyLineAfterComments(start: SourceToken[]) {
+function atFirstEmptyLineAfterIndentedComments(
+  start: SourceToken[],
+  indent: number
+) {
   let hasComment = false
   for (let i = 0; i < start.length; ++i) {
     switch (start[i].type) {
       case 'space':
         break
       case 'comment':
+        if (!hasComment && start[i].indent <= indent) return false
         hasComment = true
         break
       case 'newline':
@@ -521,7 +525,10 @@ export class Parser {
     switch (this.type) {
       case 'newline':
         this.onKeyLine = false
-        if (!it.sep && atFirstEmptyLineAfterComments(it.start)) {
+        if (
+          !it.sep &&
+          atFirstEmptyLineAfterIndentedComments(it.start, map.indent)
+        ) {
           const prev = map.items[map.items.length - 2]
           const end = (prev?.value as { end: SourceToken[] })?.end
           if (Array.isArray(end)) {
@@ -643,7 +650,10 @@ export class Parser {
     const it = seq.items[seq.items.length - 1]
     switch (this.type) {
       case 'newline':
-        if (!it.value && atFirstEmptyLineAfterComments(it.start)) {
+        if (
+          !it.value &&
+          atFirstEmptyLineAfterIndentedComments(it.start, seq.indent)
+        ) {
           const prev = seq.items[seq.items.length - 2]
           const end = (prev?.value as { end: SourceToken[] })?.end
           if (Array.isArray(end)) {

--- a/src/stringify/stringifyCollection.ts
+++ b/src/stringify/stringifyCollection.ts
@@ -1,7 +1,7 @@
 import { Collection } from '../nodes/Collection.js'
-import { addComment } from '../stringify/addComment.js'
-import { stringify, StringifyContext } from '../stringify/stringify.js'
 import { isNode, isPair } from '../nodes/Node.js'
+import { stringify, StringifyContext } from './stringify.js'
+import { addComment, stringifyComment } from './stringifyComment.js'
 
 type StringifyNode = { comment: boolean; str: string }
 
@@ -38,7 +38,7 @@ export function stringifyCollection(
       if (item.commentBefore) {
         // This match will always succeed on a non-empty string
         for (const line of item.commentBefore.match(/^.*$/gm) as string[])
-          nodes.push({ comment: true, str: `#${line}` })
+          nodes.push({ comment: true, str: line ? `#${line}` : '' })
       }
       if (item.comment) {
         comment = item.comment
@@ -51,7 +51,7 @@ export function stringifyCollection(
         if (ik.commentBefore) {
           // This match will always succeed on a non-empty string
           for (const line of ik.commentBefore.match(/^.*$/gm) as string[])
-            nodes.push({ comment: true, str: `#${line}` })
+            nodes.push({ comment: true, str: line ? `#${line}` : '' })
         }
         if (ik.comment) singleLineOutput = false
       }
@@ -113,7 +113,7 @@ export function stringifyCollection(
     for (const s of strings) str += s ? `\n${indent}${s}` : '\n'
   }
   if (comment) {
-    str += '\n' + comment.replace(/^/gm, `${indent}#`)
+    str += '\n' + stringifyComment(comment, indent)
     if (onComment) onComment()
   } else if (chompKeep && onChompKeep) onChompKeep()
   return str

--- a/src/stringify/stringifyCollection.ts
+++ b/src/stringify/stringifyCollection.ts
@@ -35,9 +35,12 @@ export function stringifyCollection(
     let comment: string | null = null
     if (isNode(item)) {
       if (!chompKeep && item.spaceBefore) nodes.push({ comment: true, str: '' })
-      if (item.commentBefore) {
+      let cb = item.commentBefore
+      if (cb && chompKeep) cb = cb.replace(/^\n+/, '')
+      if (cb) {
+        if (/^\n+$/.test(cb)) cb = cb.substring(1)
         // This match will always succeed on a non-empty string
-        for (const line of item.commentBefore.match(/^.*$/gm) as string[]) {
+        for (const line of cb.match(/^.*$/gm) as string[]) {
           const str = line === ' ' ? '#' : line ? `#${line}` : ''
           nodes.push({ comment: true, str })
         }
@@ -50,9 +53,12 @@ export function stringifyCollection(
       const ik = isNode(item.key) ? item.key : null
       if (ik) {
         if (!chompKeep && ik.spaceBefore) nodes.push({ comment: true, str: '' })
-        if (ik.commentBefore) {
+        let cb = ik.commentBefore
+        if (cb && chompKeep) cb = cb.replace(/^\n+/, '')
+        if (cb) {
+          if (/^\n+$/.test(cb)) cb = cb.substring(1)
           // This match will always succeed on a non-empty string
-          for (const line of ik.commentBefore.match(/^.*$/gm) as string[]) {
+          for (const line of cb.match(/^.*$/gm) as string[]) {
             const str = line === ' ' ? '#' : line ? `#${line}` : ''
             nodes.push({ comment: true, str })
           }

--- a/src/stringify/stringifyCollection.ts
+++ b/src/stringify/stringifyCollection.ts
@@ -37,8 +37,10 @@ export function stringifyCollection(
       if (!chompKeep && item.spaceBefore) nodes.push({ comment: true, str: '' })
       if (item.commentBefore) {
         // This match will always succeed on a non-empty string
-        for (const line of item.commentBefore.match(/^.*$/gm) as string[])
-          nodes.push({ comment: true, str: line ? `#${line}` : '' })
+        for (const line of item.commentBefore.match(/^.*$/gm) as string[]) {
+          const str = line === ' ' ? '#' : line ? `#${line}` : ''
+          nodes.push({ comment: true, str })
+        }
       }
       if (item.comment) {
         comment = item.comment
@@ -50,8 +52,10 @@ export function stringifyCollection(
         if (!chompKeep && ik.spaceBefore) nodes.push({ comment: true, str: '' })
         if (ik.commentBefore) {
           // This match will always succeed on a non-empty string
-          for (const line of ik.commentBefore.match(/^.*$/gm) as string[])
-            nodes.push({ comment: true, str: line ? `#${line}` : '' })
+          for (const line of ik.commentBefore.match(/^.*$/gm) as string[]) {
+            const str = line === ' ' ? '#' : line ? `#${line}` : ''
+            nodes.push({ comment: true, str })
+          }
         }
         if (ik.comment) singleLineOutput = false
       }

--- a/src/stringify/stringifyComment.ts
+++ b/src/stringify/stringifyComment.ts
@@ -1,10 +1,13 @@
+export const stringifyComment = (comment: string, indent: string) =>
+  comment.replace(/^(?!$)/gm, `${indent}#`)
+
 export function addCommentBefore(
   str: string,
   indent: string,
   comment?: string | null
 ) {
   if (!comment) return str
-  const cc = comment.replace(/[\s\S]^/gm, `$&${indent}#`)
+  const cc = comment.replace(/[\s\S]^(?!$)/gm, `$&${indent}#`)
   return `#${cc}\n${indent}${str}`
 }
 
@@ -16,7 +19,7 @@ export function addComment(
   return !comment
     ? str
     : comment.includes('\n')
-    ? `${str}\n` + comment.replace(/^/gm, `${indent || ''}#`)
+    ? `${str}\n` + stringifyComment(comment, indent)
     : str.endsWith(' ')
     ? `${str}#${comment}`
     : `${str} #${comment}`

--- a/src/stringify/stringifyComment.ts
+++ b/src/stringify/stringifyComment.ts
@@ -1,5 +1,5 @@
 export const stringifyComment = (comment: string, indent: string) =>
-  comment.replace(/^(?!$)/gm, `${indent}#`)
+  comment.replace(/^(?!$)(?: $)?/gm, `${indent}#`)
 
 export function addCommentBefore(
   str: string,
@@ -7,7 +7,7 @@ export function addCommentBefore(
   comment?: string | null
 ) {
   if (!comment) return str
-  const cc = comment.replace(/[\s\S]^(?!$)/gm, `$&${indent}#`)
+  const cc = comment.replace(/([\s\S])^(?!$)(?: $)?/gm, `$1${indent}#`)
   return `#${cc}\n${indent}${str}`
 }
 

--- a/src/stringify/stringifyComment.ts
+++ b/src/stringify/stringifyComment.ts
@@ -1,15 +1,7 @@
 export const stringifyComment = (comment: string, indent: string) =>
-  comment.replace(/^(?!$)(?: $)?/gm, `${indent}#`)
-
-export function addCommentBefore(
-  str: string,
-  indent: string,
-  comment?: string | null
-) {
-  if (!comment) return str
-  const cc = comment.replace(/([\s\S])^(?!$)(?: $)?/gm, `$1${indent}#`)
-  return `#${cc}\n${indent}${str}`
-}
+  /^\n+$/.test(comment)
+    ? comment.substring(1)
+    : comment.replace(/^(?!$)(?: $)?/gm, `${indent}#`)
 
 export function addComment(
   str: string,

--- a/src/stringify/stringifyDocument.ts
+++ b/src/stringify/stringifyDocument.ts
@@ -1,12 +1,12 @@
 import { Document } from '../doc/Document.js'
 import { isNode } from '../nodes/Node.js'
 import { ToStringOptions } from '../options.js'
-import { addComment } from './addComment.js'
 import {
   createStringifyContext,
   stringify,
   StringifyContext
 } from './stringify.js'
+import { addComment, stringifyComment } from './stringifyComment.js'
 
 export function stringifyDocument(
   doc: Readonly<Document>,
@@ -24,7 +24,7 @@ export function stringifyDocument(
   if (hasDirectives) lines.push('---')
   if (doc.commentBefore) {
     if (lines.length !== 1) lines.unshift('')
-    lines.unshift(doc.commentBefore.replace(/^/gm, '#'))
+    lines.unshift(stringifyComment(doc.commentBefore, ''))
   }
 
   const ctx: StringifyContext = createStringifyContext(doc, options)
@@ -34,7 +34,7 @@ export function stringifyDocument(
     if (isNode(doc.contents)) {
       if (doc.contents.spaceBefore && hasDirectives) lines.push('')
       if (doc.contents.commentBefore)
-        lines.push(doc.contents.commentBefore.replace(/^/gm, '#'))
+        lines.push(stringifyComment(doc.contents.commentBefore, ''))
       // top-level block scalars need to be indented if followed by a comment
       ctx.forceBlockIndent = !!doc.comment
       contentComment = doc.contents.comment
@@ -61,7 +61,7 @@ export function stringifyDocument(
   if (doc.comment) {
     if ((!chompKeep || contentComment) && lines[lines.length - 1] !== '')
       lines.push('')
-    lines.push(doc.comment.replace(/^/gm, '#'))
+    lines.push(stringifyComment(doc.comment, ''))
   }
   return lines.join('\n') + '\n'
 }

--- a/src/stringify/stringifyDocument.ts
+++ b/src/stringify/stringifyDocument.ts
@@ -58,10 +58,12 @@ export function stringifyDocument(
   } else {
     lines.push(stringify(doc.contents, ctx))
   }
-  if (doc.comment) {
+  let dc = doc.comment
+  if (dc && chompKeep) dc = dc.replace(/^\n+/, '')
+  if (dc) {
     if ((!chompKeep || contentComment) && lines[lines.length - 1] !== '')
       lines.push('')
-    lines.push(stringifyComment(doc.comment, ''))
+    lines.push(stringifyComment(dc, ''))
   }
   return lines.join('\n') + '\n'
 }

--- a/src/stringify/stringifyPair.ts
+++ b/src/stringify/stringifyPair.ts
@@ -1,8 +1,8 @@
 import { isCollection, isNode, isScalar, isSeq } from '../nodes/Node.js'
 import type { Pair } from '../nodes/Pair.js'
 import { Scalar } from '../nodes/Scalar.js'
-import { addComment } from './addComment.js'
 import { stringify, StringifyContext } from './stringify.js'
+import { addComment, stringifyComment } from './stringifyComment.js'
 
 export function stringifyPair(
   { key, value }: Readonly<Pair>,
@@ -78,10 +78,8 @@ export function stringifyPair(
   let valueComment = null
   if (isNode(value)) {
     if (value.spaceBefore) vcb = '\n'
-    if (value.commentBefore) {
-      const cs = value.commentBefore.replace(/^/gm, `${ctx.indent}#`)
-      vcb += `\n${cs}`
-    }
+    if (value.commentBefore)
+      vcb += `\n${stringifyComment(value.commentBefore, ctx.indent)}`
     valueComment = value.comment
   } else if (value && typeof value === 'object') {
     value = doc.createNode(value)

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -80,7 +80,7 @@ describe('parse comments', () => {
       const src = source`
         #c0
         - value 1
-        #c1
+          #c1
 
         - value 2
 
@@ -93,7 +93,7 @@ describe('parse comments', () => {
             { commentBefore: 'c0', value: 'value 1', comment: 'c1' },
             { value: 'value 2' }
           ],
-          range: [4, 29, 29]
+          range: [4, 31, 31]
         },
         comment: 'c2'
       })
@@ -102,7 +102,7 @@ describe('parse comments', () => {
     test('multiline', () => {
       const src = source`
         - value 1
-        #c0
+          #c0
         #c1
 
         #c2
@@ -126,7 +126,7 @@ describe('parse comments', () => {
       const src = source`
         #c0
         key1: value 1
-        #c1
+          #c1
 
         key2: value 2
 
@@ -147,7 +147,7 @@ describe('parse comments', () => {
     test('multiline', () => {
       const src = source`
         key1: value 1
-        #c0
+          #c0
         #c1
 
         #c2

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -627,6 +627,8 @@ describe('blank lines', () => {
         expect(it).not.toHaveProperty('spaceBefore', true)
         it.spaceBefore = true
         expect(String(doc)).toBe(src)
+        it.commentBefore = '\n\n'
+        expect(String(doc)).toBe(src)
       })
     }
 
@@ -637,6 +639,8 @@ describe('blank lines', () => {
         comment: 'c',
         contents: { value: 'a\n\n' }
       })
+      expect(String(doc)).toBe(src)
+      doc.comment = '\n\nc'
       expect(String(doc)).toBe(src)
     })
   })
@@ -910,6 +914,48 @@ map:
 
         # c4
         - v2
+      `)
+    })
+  })
+
+  describe('newlines as comments', () => {
+    test('seq', () => {
+      const doc = YAML.parseDocument('- v1\n- v2\n')
+      const [v1, v2] = doc.contents.items
+      v1.commentBefore = '\n'
+      v1.comment = '\n'
+      v2.commentBefore = '\n'
+      v2.comment = '\n'
+      expect(doc.toString()).toBe(source`
+
+        - v1
+
+
+        - v2
+
+      `)
+    })
+
+    test('map', () => {
+      const doc = YAML.parseDocument('k1: v1\nk2: v2')
+      const [p1, p2] = doc.contents.items
+      p1.key.commentBefore = '\n'
+      p1.value.commentBefore = '\n'
+      p1.value.comment = '\n'
+      p2.key.commentBefore = '\n'
+      p2.value.commentBefore = '\n'
+      p2.value.comment = '\n'
+      expect(doc.toString()).toBe(source`
+
+        k1:
+
+          v1
+
+
+        k2:
+
+          v2
+
       `)
     })
   })

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -592,9 +592,30 @@ describe('blank lines', () => {
   })
 
   test('between seq items with leading comments', () => {
-    const src = '#A\n- a\n\n#B\n- b\n\n\n#C\n\n- c\n'
+    const src = source`
+      #A
+      - a
+
+      #B
+      - b
+
+
+      #C
+
+      - c
+    `
     const doc = YAML.parseDocument(src)
-    expect(String(doc)).toBe('#A\n- a\n\n#B\n- b\n\n#C\n- c\n')
+    expect(String(doc)).toBe(source`
+      #A
+      - a
+
+      #B
+      - b
+
+      #C
+
+      - c
+    `)
   })
 
   describe('not after block scalar with keep chomping', () => {
@@ -793,7 +814,7 @@ map:
       const doc = YAML.parseDocument(src)
       expect(doc.contents).toMatchObject({
         items: [
-          { value: { commentBefore: ' c1\n \n c2', comment: ' c3\n \n c4' } }
+          { value: { commentBefore: ' c1\n \n c2\n', comment: ' c3\n \n c4' } }
         ]
       })
       expect(doc.toString()).toBe(
@@ -802,6 +823,7 @@ map:
             # c1
             #·
             # c2
+
             value
             # c3
             #·
@@ -826,7 +848,7 @@ map:
       const doc = YAML.parseDocument(src)
       expect(doc.contents).toMatchObject({
         items: [
-          { value: { commentBefore: ' c1\n\n c2', comment: ' c3\n\n c4' } }
+          { value: { commentBefore: ' c1\n\n c2\n', comment: ' c3\n\n c4' } }
         ]
       })
       expect(doc.toString()).toBe(source`
@@ -834,6 +856,7 @@ map:
           # c1
 
           # c2
+
           value
           # c3
 

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -32,15 +32,13 @@ describe('parse comments', () => {
       `
       const doc = YAML.parseDocument(src)
       expect(doc.contents.commentBefore).toBe('comment\n \ncomment')
-      expect(String(doc)).toBe(
-        source`
-          ---
-          #comment
-          #·
-          #comment
-          string
-        `.replace(/·/g, ' ')
-      )
+      expect(String(doc)).toBe(source`
+        ---
+        #comment
+        #
+        #comment
+        string
+      `)
     })
 
     test('body end comments', () => {
@@ -393,20 +391,18 @@ describe('stringify comments', () => {
       doc.contents.items[0].commentBefore = 'c0\nc1'
       doc.contents.items[1].commentBefore = ' \nc2\n\nc3'
       doc.contents.comment = 'c4\nc5'
-      expect(String(doc)).toBe(
-        source`
+      expect(String(doc)).toBe( source`
         #c0
         #c1
         - value 1
-        #·
+        #
         #c2
 
         #c3
         - value 2
         #c4
         #c5
-      `.replace(/·/g, ' ')
-      )
+      `)
     })
 
     test('seq-in-map', () => {
@@ -461,12 +457,11 @@ describe('stringify comments', () => {
       doc.contents.items[1].value.spaceBefore = true
       doc.contents.items[1].value.commentBefore = 'c6'
       doc.contents.comment = 'c7\nc8'
-      expect(String(doc)).toBe(
-        source`
+      expect(String(doc)).toBe(source`
         #c0
         #c1
         key1: value 1
-        #·
+        #
         #c2
 
         #c3
@@ -478,8 +473,7 @@ describe('stringify comments', () => {
           value 2
         #c7
         #c8
-      `.replace(/·/g, ' ')
-      )
+      `)
     })
   })
 
@@ -763,19 +757,17 @@ map:
         commentBefore: ' c1\n \n c2',
         comment: ' c3\n \n c4'
       })
-      expect(doc.toString()).toBe(
-        source`
-          # c1
-          #·
-          # c2
+      expect(doc.toString()).toBe(source`
+        # c1
+        #
+        # c2
 
-          value
+        value
 
-          # c3
-          #·
-          # c4
-        `.replace(/·/g, ' ')
-      )
+        # c3
+        #
+        # c4
+      `)
     })
 
     test('document comments without #', () => {
@@ -817,19 +809,17 @@ map:
           { value: { commentBefore: ' c1\n \n c2\n', comment: ' c3\n \n c4' } }
         ]
       })
-      expect(doc.toString()).toBe(
-        source`
-          key:
-            # c1
-            #·
-            # c2
+      expect(doc.toString()).toBe(source`
+        key:
+          # c1
+          #
+          # c2
 
-            value
-            # c3
-            #·
-            # c4
-        `.replace(/·/g, ' ')
-      )
+          value
+          # c3
+          #
+          # c4
+      `)
     })
 
     test('map comments without #', () => {
@@ -882,18 +872,16 @@ map:
           { commentBefore: ' c4' }
         ]
       })
-      expect(doc.toString()).toBe(
-        source`
-          # c1
-          #·
-          # c2
-          - v1
-            # c3
-            #·
-          # c4
-          - v2
-        `.replace(/·/g, ' ')
-      )
+      expect(doc.toString()).toBe(source`
+        # c1
+        #
+        # c2
+        - v1
+          # c3
+          #
+        # c4
+        - v2
+      `)
     })
 
     test('seq comments without #', () => {

--- a/tests/doc/comments.js
+++ b/tests/doc/comments.js
@@ -959,6 +959,24 @@ map:
       `)
     })
   })
+
+  test('eemeli/yaml#277', () => {
+    const src = source`
+      environment:
+        ### SESSION START ###
+        A: "true"
+        B: "true"
+        ### SESSION END ###
+
+        ### ANOTHER SESSION START ###
+        C: "true"
+        D: "true"
+        ### ANOTHER SESSION END ###
+
+    `
+    const doc = YAML.parseDocument(src)
+    expect(doc.toString()).toBe(src)
+  })
 })
 
 describe('eemeli/yaml#18', () => {

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -32,10 +32,10 @@ aa: AA
 
 describe('Input in parts', () => {
   const cases = [
-    { title: 'LF line endings', src },
-    { title: 'CRLF line endings', src: src.replace(/\n/g, '\r\n') }
+    { title: 'LF line endings', src, nl: '\n' },
+    { title: 'CRLF line endings', src: src.replace(/\n/g, '\r\n'), nl: '\r\n' }
   ]
-  for (const { title, src } of cases)
+  for (const { title, src, nl } of cases)
     test(title, () => {
       const doc = parseDocument(src, { logLevel: 'error' })
       const exp = [doc.toJS()]
@@ -49,7 +49,7 @@ describe('Input in parts', () => {
         '{ hh }': ['HH', 'II\rII II']
       })
       const cb = [doc.commentBefore, doc.contents?.commentBefore]
-      expect(cb).toMatchObject(['c0\n\nc1', 'c2'])
+      expect(cb).toMatchObject(['c0\n\nc1', `c2${nl}${nl}`])
 
       for (let i = 1; i < src.length - 1; ++i) {
         const res: Document.Parsed[] = []


### PR DESCRIPTION
Fixes #244
Fixes #277 

I think I finally figured out a way to make comments and empty lines more usable. This hinges on refactoring the representation of completely empty lines vs. comment lines that terminate immediately after the `#`.

At the moment, empty lines in source are parsed into `spaceBefore` boolean values or completely dropped, and comments consisting of just a `#` are represented by an empty line in the `comment` or `commentBefore` value.

However, let's change that a bit. With this PR, an empty line in the source is represented by an empty line in the `comment` or `commentBefore` value, and a bare `#` is represented by a line consisting of a single space character. This relatively small change allows for any combination of comment and blank lines to be cleanly represented by a single string, with the cost of a comment consisting of a single space character being unrepresentable.

At least for now, an empty line before comments remains represented as the boolean `spaceBefore` property, but that property could be dropped entirely as it's equivalent to a `commentBefore` value of `'\n'`.

Simultaneously, the handling of trailing comments is simplified somewhat; they now need to be more indented than their parent collection to attach to the preceding rather than the following node.