### PR TITLE
Add a new createNode option aliasDuplicateObjects

### DIFF
--- a/docs/03_options.md
+++ b/docs/03_options.md
@@ -99,12 +99,13 @@ Multiple merge keys may be used on the same map, with earlier values taking prec
 
 Used by: `stringify()`, `new Document()`, `doc.createNode()`, and `doc.createPair()`
 
-| Name          | Type      | Default | Description                                                                                                                                      |
-| ------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| anchorPrefix  | `string`  | `'a'`   | Default prefix for anchors, resulting in anchors `a1`, `a2`, ... by default.                                                                     |
-| flow          | `boolean` | `false` | Force the top-level collection node to use flow style.                                                                                           |
-| keepUndefined | `boolean` | `false` | Keep `undefined` object values when creating mappings and return a Scalar node when stringifying `undefined`.                                    |
-| tag           | `string`  |         | Specify the top-level collection type, e.g. `"!!omap"`. Note that this requires the corresponding tag to be available in this document's schema. |
+| Name                  | Type      | Default | Description                                                                                                                                      |
+| --------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| aliasDuplicateObjects | `boolean` | `true`  | During node construction, use anchors and aliases to keep strictly equal non-null objects as equivalent in YAML.                                 |
+| anchorPrefix          | `string`  | `'a'`   | Default prefix for anchors, resulting in anchors `a1`, `a2`, ... by default.                                                                     |
+| flow                  | `boolean` | `false` | Force the top-level collection node to use flow style.                                                                                           |
+| keepUndefined         | `boolean` | `false` | Keep `undefined` object values when creating mappings and return a Scalar node when stringifying `undefined`.                                    |
+| tag                   | `string`  |         | Specify the top-level collection type, e.g. `"!!omap"`. Note that this requires the corresponding tag to be available in this document's schema. |
 
 ## ToJS Options
 

--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -182,12 +182,20 @@ export class Document<T = unknown> {
       replacer = undefined
     }
 
-    const { anchorPrefix, flow, keepUndefined, onTagObj, tag } = options || {}
+    const {
+      aliasDuplicateObjects,
+      anchorPrefix,
+      flow,
+      keepUndefined,
+      onTagObj,
+      tag
+    } = options || {}
     const { onAnchor, setAnchors, sourceObjects } = createNodeAnchors(
       this,
       anchorPrefix || 'a'
     )
     const ctx: CreateNodeContext = {
+      aliasDuplicateObjects: aliasDuplicateObjects ?? true,
       keepUndefined: keepUndefined ?? false,
       onAnchor,
       onTagObj,

--- a/src/doc/createNode.ts
+++ b/src/doc/createNode.ts
@@ -9,7 +9,8 @@ import type { Replacer } from './Document.js'
 const defaultTagPrefix = 'tag:yaml.org,2002:'
 
 export interface CreateNodeContext {
-  keepUndefined?: boolean
+  aliasDuplicateObjects: boolean
+  keepUndefined: boolean
   onAnchor(source: unknown): string
   onTagObj?: (tagObj: ScalarTag | CollectionTag) => void
   sourceObjects: Map<unknown, { anchor: string | null; node: Node | null }>
@@ -52,12 +53,13 @@ export function createNode(
     value = value.valueOf()
   }
 
-  const { onAnchor, onTagObj, schema, sourceObjects } = ctx
+  const { aliasDuplicateObjects, onAnchor, onTagObj, schema, sourceObjects } =
+    ctx
 
   // Detect duplicate references to the same object & use Alias nodes for all
   // after first. The `ref` wrapper allows for circular references to resolve.
   let ref: { anchor: string | null; node: Node | null } | undefined = undefined
-  if (value && typeof value === 'object') {
+  if (aliasDuplicateObjects && value && typeof value === 'object') {
     ref = sourceObjects.get(value)
     if (ref) {
       if (!ref.anchor) ref.anchor = onAnchor(value)

--- a/src/nodes/Collection.ts
+++ b/src/nodes/Collection.ts
@@ -26,6 +26,8 @@ export function collectionFromPath(
     }
   }
   return createNode(v, undefined, {
+    aliasDuplicateObjects: true,
+    keepUndefined: false,
     onAnchor() {
       throw new Error('Repeated objects are not supported here')
     },

--- a/src/nodes/Collection.ts
+++ b/src/nodes/Collection.ts
@@ -15,21 +15,14 @@ export function collectionFromPath(
       a[k] = v
       v = a
     } else {
-      const o = {}
-      Object.defineProperty(o, typeof k === 'symbol' ? k : String(k), {
-        value: v,
-        writable: true,
-        enumerable: true,
-        configurable: true
-      })
-      v = o
+      v = new Map<unknown, unknown>([[k, v]])
     }
   }
   return createNode(v, undefined, {
-    aliasDuplicateObjects: true,
+    aliasDuplicateObjects: false,
     keepUndefined: false,
-    onAnchor() {
-      throw new Error('Repeated objects are not supported here')
+    onAnchor: () => {
+      throw new Error('This should not happen, please report a bug.')
     },
     schema,
     sourceObjects: new Map()

--- a/src/options.ts
+++ b/src/options.ts
@@ -120,6 +120,14 @@ export type SchemaOptions = {
 
 export type CreateNodeOptions = {
   /**
+   * During node construction, use anchors and aliases to keep strictly equal
+   * non-null objects as equivalent in YAML.
+   *
+   * Default: `true`
+   */
+  aliasDuplicateObjects?: boolean
+
+  /**
    * Default prefix for anchors.
    *
    * Default: `'a'`, resulting in anchors `a1`, `a2`, etc.

--- a/tests/doc/collection-access.js
+++ b/tests/doc/collection-access.js
@@ -520,4 +520,37 @@ describe('Document', () => {
     doc.setIn(['c', '__proto__'], 9)
     expect(String(doc)).toBe('a: 1\nb:\n  - 2\n  - 3\nc:\n  __proto__: 9\n')
   })
+
+  test('setIn with object key', () => {
+    doc.contents = null
+    const foo = { foo: 'FOO' }
+    doc.setIn([foo], 'BAR')
+    expect(doc.contents.items).toMatchObject([
+      {
+        key: { items: [{ key: { value: 'foo' }, value: { value: 'FOO' } }] },
+        value: { value: 'BAR' }
+      }
+    ])
+  })
+
+  test('setIn with repeated object key', () => {
+    doc.contents = null
+    const foo = { foo: 'FOO' }
+    doc.setIn([foo, foo], 'BAR')
+    expect(doc.contents.items).toMatchObject([
+      {
+        key: { items: [{ key: { value: 'foo' }, value: { value: 'FOO' } }] },
+        value: {
+          items: [
+            {
+              key: {
+                items: [{ key: { value: 'foo' }, value: { value: 'FOO' } }]
+              },
+              value: { value: 'BAR' }
+            }
+          ]
+        }
+      }
+    ])
+  })
 })

--- a/tests/doc/createNode.js
+++ b/tests/doc/createNode.js
@@ -297,6 +297,31 @@ describe('toJSON()', () => {
   })
 })
 
+describe('strictly equal objects', () => {
+  test('createNode([foo, foo])', () => {
+    const foo = { foo: 'FOO' }
+    const s = doc.createNode([foo, foo])
+    expect(s).toBeInstanceOf(YAMLSeq)
+    expect(s.items).toMatchObject([
+      {
+        anchor: 'a1',
+        items: [{ key: { value: 'foo' }, value: { value: 'FOO' } }]
+      },
+      { source: 'a1' }
+    ])
+  })
+
+  test('createNode([foo, foo], { aliasDuplicateObjects: false })', () => {
+    const foo = { foo: 'FOO' }
+    const s = doc.createNode([foo, foo], { aliasDuplicateObjects: false })
+    expect(s).toBeInstanceOf(YAMLSeq)
+    expect(s.items).toMatchObject([
+      { items: [{ key: { value: 'foo' }, value: { value: 'FOO' } }] },
+      { items: [{ key: { value: 'foo' }, value: { value: 'FOO' } }] }
+    ])
+  })
+})
+
 describe('circular references', () => {
   test('parent at root', () => {
     const map = { foo: 'bar' }


### PR DESCRIPTION
Fixes #296, originally reported in #211

This adds an option `aliasDuplicateObjects` (default `true`) that does this:

```js
const foo = { foo: 'FOO' }

const doc1 = new YAML.Document([foo, foo])
const doc2 = new YAML.Document([foo, foo], { aliasDuplicateObjects: false })

`${doc1}
---
${doc2}`
```

```yaml
- &a1
  foo: FOO
- *a1

---
- foo: FOO
- foo: FOO
```

Ping @ChocolateLoverRaj, @ushuz, @dudif91. This would presumably work for you?