### PR TITLE
Fix test config for Windows environments

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,10 +9,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [12.x, 14.x, 16.x]
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,8 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Checkout submodules
-        uses: textbook/git-checkout-submodule-action@master
+        with: { submodules: true }
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,6 +17,7 @@ jobs:
         node-version: [12.x, 14.x, 16.x]
 
     steps:
+      - run: git config --global core.autocrlf false
       - uses: actions/checkout@v2
         with: { submodules: true }
       - name: Use Node.js ${{ matrix.node-version }}

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -1,6 +1,6 @@
 let moduleNameMapper
 const transform = {
-  '/tests/.*\\.(js|ts)$': [
+  '[/\\\\]tests[/\\\\].*\\.(js|ts)$': [
     'babel-jest',
     { configFile: './config/babel.config.js' }
   ]
@@ -25,7 +25,7 @@ switch (process.env.npm_lifecycle_event) {
       '^yaml/util$': '<rootDir>/src/util.ts',
       '^yaml/test-events$': '<rootDir>/src/test-events.ts'
     }
-    transform['/src/.*\\.ts$'] = [
+    transform['[/\\\\]src[/\\\\].*\\.ts$'] = [
       'babel-jest',
       { configFile: './config/babel.config.js' }
     ]

--- a/tests/doc/parse.js
+++ b/tests/doc/parse.js
@@ -376,7 +376,8 @@ aliases:
         version: 2
       }
     })
-    expect(String(doc)).toBe(src)
+    const exp = src.replace(/\r\n/g, '\n') // To account for git core.autocrlf true on Windows
+    expect(String(doc)).toBe(exp)
   })
 
   test('minimal', () => {

--- a/tests/yaml-test-suite.js
+++ b/tests/yaml-test-suite.js
@@ -91,11 +91,15 @@ testDirs.forEach(dir => {
       }
     })
     if (!error) {
-      const src2 =
-        docs.map(doc => String(doc).replace(/\n$/, '')).join('\n...\n') + '\n'
-      const docs2 = parseAllDocuments(src2, { resolveKnownTags: false })
-
-      if (json) _test('stringfy+re-parse', () => matchJson(docs2, json))
+      if (json) {
+        _test('stringfy+re-parse', () => {
+          const src2 =
+            docs.map(doc => String(doc).replace(/\n$/, '')).join('\n...\n') +
+            '\n'
+          const docs2 = parseAllDocuments(src2, { resolveKnownTags: false })
+          matchJson(docs2, json)
+        })
+      }
 
       if (outYaml) {
         _test('out.yaml', () => {


### PR DESCRIPTION
As discovered in #306, the tests don't pass on Windows. This adds `windows-latest` (and `macos-latest` because why not) environment to the GitHub Actions Node.js test workflow, and fixes the issues that then arise.

It would appear that setting `autocrlf false` is required by the yaml-test-suite tests, as otherwise something there is causing a busy loop that eventually results in a `Allocation failed - JavaScript heap out of memory` crash.