### PR TITLE
Add keepSoureToken parse option, adding srcToken values to Nodes

### DIFF
--- a/docs/03_options.md
+++ b/docs/03_options.md
@@ -22,13 +22,14 @@ Parse options affect the parsing and composition of a YAML Document from it sour
 
 Used by: `parse()`, `parseDocument()`, `parseAllDocuments()`, `new Composer()`, and `new Document()`
 
-| Name         | Type                          | Default | Description                                                                                                                                                                |
-| ------------ | ----------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| intAsBigInt  | `boolean`                     | `false` | Whether integers should be parsed into [BigInt] rather than `number` values.                                                                                               |
-| lineCounter  | `LineCounter`                 |         | If set, newlines will be tracked, to allow for `lineCounter.linePos(offset)` to provide the `{ line, col }` positions within the input.                                    |
-| prettyErrors | `boolean`                     | `true`  | Include line/col position in errors, along with an extract of the source string.                                                                                           |
-| strict       | `boolean`                     | `true`  | When parsing, do not ignore errors required by the YAML 1.2 spec, but caused by unambiguous content.                                                                       |
-| uniqueKeys   | `boolean ⎮ (a, b) => boolean` | `true`  | Whether key uniqueness is checked, or customised. If set to be a function, it will be passed two parsed nodes and should return a boolean value indicating their equality. |
+| Name             | Type                          | Default | Description                                                                                                                                                                |
+| ---------------- | ----------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| intAsBigInt      | `boolean`                     | `false` | Whether integers should be parsed into [BigInt] rather than `number` values.                                                                                               |
+| keepSourceTokens | `boolean`                     | `false` | Include a `srcToken` value on each parsed `Node`, containing the CST token that was composed into this node.                                                               |
+| lineCounter      | `LineCounter`                 |         | If set, newlines will be tracked, to allow for `lineCounter.linePos(offset)` to provide the `{ line, col }` positions within the input.                                    |
+| prettyErrors     | `boolean`                     | `true`  | Include line/col position in errors, along with an extract of the source string.                                                                                           |
+| strict           | `boolean`                     | `true`  | When parsing, do not ignore errors required by the YAML 1.2 spec, but caused by unambiguous content.                                                                       |
+| uniqueKeys       | `boolean ⎮ (a, b) => boolean` | `true`  | Whether key uniqueness is checked, or customised. If set to be a function, it will be passed two parsed nodes and should return a boolean value indicating their equality. |
 
 [bigint]: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/BigInt
 

--- a/src/compose/compose-node.ts
+++ b/src/compose/compose-node.ts
@@ -68,6 +68,7 @@ export function composeNode(
     if (token.type === 'scalar' && token.source === '') node.comment = comment
     else node.commentBefore = comment
   }
+  if (ctx.options.keepSourceTokens) node.srcToken = token
   return node
 }
 

--- a/src/compose/resolve-block-map.ts
+++ b/src/compose/resolve-block-map.ts
@@ -19,7 +19,9 @@ export function resolveBlockMap(
   const map = new YAMLMap<ParsedNode, ParsedNode>(ctx.schema)
 
   let offset = bm.offset
-  for (const { start, key, sep, value } of bm.items) {
+  for (const collItem of bm.items) {
+    const { start, key, sep, value } = collItem
+
     // key properties
     const keyProps = resolveProps(start, {
       indicator: 'explicit-key-ind',
@@ -99,7 +101,9 @@ export function resolveBlockMap(
         ? composeNode(ctx, value, valueProps, onError)
         : composeEmptyNode(ctx, offset, sep, null, valueProps, onError)
       offset = valueNode.range[2]
-      map.items.push(new Pair(keyNode, valueNode))
+      const pair = new Pair(keyNode, valueNode)
+      if (ctx.options.keepSourceTokens) pair.srcToken = collItem
+      map.items.push(pair)
     } else {
       // key with no value
       if (implicitKey)
@@ -112,7 +116,9 @@ export function resolveBlockMap(
         if (keyNode.comment) keyNode.comment += '\n' + valueProps.comment
         else keyNode.comment = valueProps.comment
       }
-      map.items.push(new Pair(keyNode))
+      const pair: Pair<ParsedNode, ParsedNode> = new Pair(keyNode)
+      if (ctx.options.keepSourceTokens) pair.srcToken = collItem
+      map.items.push(pair)
     }
   }
 

--- a/src/compose/resolve-flow-collection.ts
+++ b/src/compose/resolve-flow-collection.ts
@@ -29,7 +29,9 @@ export function resolveFlowCollection(
 
   let offset = fc.offset
   for (let i = 0; i < fc.items.length; ++i) {
-    const { start, key, sep, value } = fc.items[i]
+    const collItem = fc.items[i]
+    const { start, key, sep, value } = collItem
+
     const props = resolveProps(start, {
       flow: fcName,
       indicator: 'explicit-key-ind',
@@ -170,6 +172,7 @@ export function resolveFlowCollection(
       }
 
       const pair = new Pair(keyNode, valueNode)
+      if (ctx.options.keepSourceTokens) pair.srcToken = collItem
       if (isMap) {
         const map = coll as YAMLMap.Parsed
         if (mapIncludes(ctx, map.items, keyNode))

--- a/src/nodes/Alias.ts
+++ b/src/nodes/Alias.ts
@@ -1,7 +1,8 @@
-import { anchorIsValid } from '../doc/anchors'
-import type { Document } from '../doc/Document'
+import { anchorIsValid } from '../doc/anchors.js'
+import type { Document } from '../doc/Document.js'
+import type { FlowScalar } from '../parse/cst.js'
 import type { StringifyContext } from '../stringify/stringify.js'
-import { visit } from '../visit'
+import { visit } from '../visit.js'
 import {
   ALIAS,
   isAlias,
@@ -13,12 +14,13 @@ import {
 } from './Node.js'
 import type { Scalar } from './Scalar'
 import type { ToJSContext } from './toJS.js'
-import type { YAMLMap } from './YAMLMap'
-import type { YAMLSeq } from './YAMLSeq'
+import type { YAMLMap } from './YAMLMap.js'
+import type { YAMLSeq } from './YAMLSeq.js'
 
 export declare namespace Alias {
   interface Parsed extends Alias {
     range: Range
+    srcToken?: FlowScalar & { type: 'alias' }
   }
 }
 

--- a/src/nodes/Node.ts
+++ b/src/nodes/Node.ts
@@ -1,4 +1,5 @@
 import type { Document } from '../doc/Document.js'
+import { Token } from '../parse/cst.js'
 import type { StringifyContext } from '../stringify/stringify.js'
 import type { Alias } from './Alias.js'
 import type { Pair } from './Pair.js'
@@ -86,6 +87,9 @@ export abstract class NodeBase {
 
   /** A blank line before this node and its commentBefore */
   declare spaceBefore?: boolean
+
+  /** The CST token that was composed into this node.  */
+  declare srcToken?: Token
 
   /** A fully qualified tag, if required */
   declare tag?: string

--- a/src/nodes/Pair.ts
+++ b/src/nodes/Pair.ts
@@ -1,4 +1,5 @@
 import { createNode, CreateNodeContext } from '../doc/createNode.js'
+import type { CollectionItem } from '../parse/cst.js'
 import type { Schema } from '../schema/Schema.js'
 import type { StringifyContext } from '../stringify/stringify.js'
 import { stringifyPair } from '../stringify/stringifyPair.js'
@@ -24,6 +25,9 @@ export class Pair<K = unknown, V = unknown> {
 
   /** Always Node or null when parsed, but can be set to anything. */
   value: V | null
+
+  /** The CST token that was composed into this pair.  */
+  declare srcToken?: CollectionItem
 
   constructor(key: K, value: V | null = null) {
     Object.defineProperty(this, NODE_TYPE, { value: PAIR })

--- a/src/nodes/Scalar.ts
+++ b/src/nodes/Scalar.ts
@@ -1,3 +1,4 @@
+import type { BlockScalar, FlowScalar } from '../parse/cst.js'
 import { NodeBase, Range, SCALAR } from './Node.js'
 import { toJS, ToJSContext } from './toJS.js'
 
@@ -8,6 +9,7 @@ export declare namespace Scalar {
   interface Parsed extends Scalar {
     range: Range
     source: string
+    srcToken?: FlowScalar | BlockScalar
   }
 
   type BLOCK_FOLDED = 'BLOCK_FOLDED'

--- a/src/nodes/YAMLMap.ts
+++ b/src/nodes/YAMLMap.ts
@@ -1,3 +1,4 @@
+import type { BlockMap, FlowCollection } from '../parse/cst.js'
 import type { Schema } from '../schema/Schema.js'
 import type { StringifyContext } from '../stringify/stringify.js'
 import { stringifyCollection } from '../stringify/stringifyCollection.js'
@@ -29,6 +30,7 @@ export declare namespace YAMLMap {
   > extends YAMLMap<K, V> {
     items: Pair<K, V>[]
     range: Range
+    srcToken?: BlockMap | FlowCollection
   }
 }
 

--- a/src/nodes/YAMLSeq.ts
+++ b/src/nodes/YAMLSeq.ts
@@ -1,3 +1,4 @@
+import type { BlockSequence, FlowCollection } from '../parse/cst.js'
 import type { Schema } from '../schema/Schema.js'
 import type { StringifyContext } from '../stringify/stringify.js'
 import { stringifyCollection } from '../stringify/stringifyCollection.js'
@@ -13,6 +14,7 @@ export declare namespace YAMLSeq {
   > extends YAMLSeq<T> {
     items: T[]
     range: Range
+    srcToken?: BlockSequence | FlowCollection
   }
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -20,6 +20,14 @@ export type ParseOptions = {
   intAsBigInt?: boolean
 
   /**
+   * Include a `srcToken` value on each parsed `Node`, containing the CST token
+   * that was composed into this node.
+   *
+   * Default: `false`
+   */
+  keepSourceTokens?: boolean
+
+  /**
    * If set, newlines will be tracked, to allow for `lineCounter.linePos(offset)`
    * to provide the `{ line, col }` positions within the input.
    */
@@ -325,6 +333,7 @@ export const defaultOptions: Required<
   Omit<ParseOptions, 'lineCounter'> & Omit<DocumentOptions, 'directives'>
 > = {
   intAsBigInt: false,
+  keepSourceTokens: false,
   logLevel: 'warn',
   prettyErrors: true,
   strict: true,

--- a/tests/doc/parse.js
+++ b/tests/doc/parse.js
@@ -746,17 +746,27 @@ describe('__proto__ as mapping key', () => {
 })
 
 describe('keepSourceTokens', () => {
-  test('default false', () => {
-    const doc = YAML.parseDocument('foo: bar')
-    expect(doc.contents).not.toHaveProperty('srcToken')
-    expect(doc.get('foo', true)).not.toHaveProperty('srcToken')
-  })
+  for (const [src, type] of [
+    ['foo: bar', 'block-map'],
+    ['{ foo: bar }', 'flow-collection']
+  ]) {
+    test(`${type}: default false`, () => {
+      const doc = YAML.parseDocument(src)
+      expect(doc.contents).not.toHaveProperty('srcToken')
+      expect(doc.contents.items[0]).not.toHaveProperty('srcToken')
+      expect(doc.get('foo', true)).not.toHaveProperty('srcToken')
+    })
 
-  test('included when set', () => {
-    const doc = YAML.parseDocument('foo: bar', { keepSourceTokens: true })
-    expect(doc.contents.srcToken).toMatchObject({ type: 'block-map' })
-    expect(doc.get('foo', true).srcToken).toMatchObject({ type: 'scalar' })
-  })
+    test(`${type}: included when set`, () => {
+      const doc = YAML.parseDocument(src, { keepSourceTokens: true })
+      expect(doc.contents.srcToken).toMatchObject({ type })
+      expect(doc.contents.items[0].srcToken).toMatchObject({
+        key: { type: 'scalar' },
+        value: { type: 'scalar' }
+      })
+      expect(doc.get('foo', true).srcToken).toMatchObject({ type: 'scalar' })
+    })
+  }
 
   test('allow for CST modifications (eemeli/yaml#903)', () => {
     const src = 'foo:\n  [ 42 ]'


### PR DESCRIPTION
Fixes #308 

This allows for usage like this:

```js
import { Composer, CST, Parser } from 'yaml'

const src = 'foo:\n  [ 42 ]'
const tokens = Array.from(new Parser().parse(src))

const docs = new Composer({ keepSourceTokens: true }).compose(tokens)
for (const doc of docs) {
  const node = doc.get('foo', true)
  CST.setScalarValue(node.srcToken, 'eek')
}

const res = tokens.map(CST.stringify).join('')
assert.equal(res, 'foo:\n  eek')
```

The `srcToken` value isn't available on nodes that are created from empty contents, as those do not have a matching CST token. This means that for example the above would fail if the `src` was `'foo:\n'`, as then `node.srcToken` is undefined.

To handle that case, you'd probably need to `CST.visit` the parent collection, identify the right CollectionItem, and then use `CST.createScalarToken()` when setting its `value`. At which point it might be more straightforward to keep all of the operations in the CST, and to never even compose it into documents.