### PR TITLE
Preserve indentation when using `parseDocument`

### DIFF
--- a/src/compose/resolve-block-map.ts
+++ b/src/compose/resolve-block-map.ts
@@ -109,8 +109,10 @@ export function resolveBlockMap(
       // Check to see if the key tokens exist and have an indentation set.
       // If so, we can compute the difference between them and preserve it
       // if the preserveCollectionIndentation option is set.
-      const keyIndent: number | undefined = (collItem?.key as any)?.indent
-      const valueIndent: number | undefined = (collItem?.value as any)?.indent
+      const keyIndent: number | undefined =
+        key && 'indent' in key ? key.indent : undefined
+      const valueIndent: number | undefined =
+        value && 'indent' in value ? value.indent : undefined
 
       if (
         ctx.options.preserveCollectionIndentation &&

--- a/src/compose/resolve-block-map.ts
+++ b/src/compose/resolve-block-map.ts
@@ -104,22 +104,23 @@ export function resolveBlockMap(
       const pair = new Pair(keyNode, valueNode)
       if (ctx.options.keepSourceTokens) {
         pair.srcToken = collItem
-
-        // Check to see if the key tokens exist and have an indentation set.
-        // If so, we can compute the difference between them and preserve it
-        // if the preserveCollectionIndentation option is set.
-        const keyIndent: number | undefined = (collItem?.key as any)?.indent
-        const valueIndent: number | undefined = (collItem?.value as any)?.indent
-
-        if (
-          ctx.options.preserveCollectionIndentation &&
-          keyIndent !== undefined &&
-          valueIndent !== undefined &&
-          valueIndent >= keyIndent
-        ) {
-          pair.srcIndentStep = valueIndent - keyIndent
-        }
       }
+
+      // Check to see if the key tokens exist and have an indentation set.
+      // If so, we can compute the difference between them and preserve it
+      // if the preserveCollectionIndentation option is set.
+      const keyIndent: number | undefined = (collItem?.key as any)?.indent
+      const valueIndent: number | undefined = (collItem?.value as any)?.indent
+
+      if (
+        ctx.options.preserveCollectionIndentation &&
+        keyIndent !== undefined &&
+        valueIndent !== undefined &&
+        valueIndent >= keyIndent
+      ) {
+        pair.srcIndentStep = valueIndent - keyIndent
+      }
+
       map.items.push(pair)
     } else {
       // key with no value

--- a/src/compose/resolve-block-map.ts
+++ b/src/compose/resolve-block-map.ts
@@ -105,6 +105,9 @@ export function resolveBlockMap(
       if (ctx.options.keepSourceTokens) {
         pair.srcToken = collItem
 
+        // Check to see if the key tokens exist and have an indentation set.
+        // If so, we can compute the difference between them and preserve it
+        // if the preserveCollectionIndentation option is set.
         const keyIndent: number | undefined = (collItem?.key as any)?.indent
         const valueIndent: number | undefined = (collItem?.value as any)?.indent
 

--- a/src/compose/resolve-block-map.ts
+++ b/src/compose/resolve-block-map.ts
@@ -109,6 +109,7 @@ export function resolveBlockMap(
         const valueIndent: number | undefined = (collItem?.value as any)?.indent
 
         if (
+          ctx.options.preserveCollectionIndentation &&
           keyIndent !== undefined &&
           valueIndent !== undefined &&
           valueIndent >= keyIndent

--- a/src/compose/resolve-block-map.ts
+++ b/src/compose/resolve-block-map.ts
@@ -102,7 +102,20 @@ export function resolveBlockMap(
         : composeEmptyNode(ctx, offset, sep, null, valueProps, onError)
       offset = valueNode.range[2]
       const pair = new Pair(keyNode, valueNode)
-      if (ctx.options.keepSourceTokens) pair.srcToken = collItem
+      if (ctx.options.keepSourceTokens) {
+        pair.srcToken = collItem
+
+        const keyIndent: number | undefined = (collItem?.key as any)?.indent
+        const valueIndent: number | undefined = (collItem?.value as any)?.indent
+
+        if (
+          keyIndent !== undefined &&
+          valueIndent !== undefined &&
+          valueIndent >= keyIndent
+        ) {
+          pair.srcIndentStep = valueIndent - keyIndent
+        }
+      }
       map.items.push(pair)
     } else {
       // key with no value

--- a/src/nodes/Pair.ts
+++ b/src/nodes/Pair.ts
@@ -29,6 +29,9 @@ export class Pair<K = unknown, V = unknown> {
   /** The CST token that was composed into this pair.  */
   declare srcToken?: CollectionItem
 
+  /** The indentation between key and value in the source. */
+  declare srcIndentStep?: number
+
   constructor(key: K, value: V | null = null) {
     Object.defineProperty(this, NODE_TYPE, { value: PAIR })
     this.key = key

--- a/src/nodes/Pair.ts
+++ b/src/nodes/Pair.ts
@@ -29,7 +29,10 @@ export class Pair<K = unknown, V = unknown> {
   /** The CST token that was composed into this pair.  */
   declare srcToken?: CollectionItem
 
-  /** The indentation between key and value in the source. */
+  /**
+   * The indentation step between key and value in the source, to be
+   * preserved during stringification.
+   */
   declare srcIndentStep?: number
 
   constructor(key: K, value: V | null = null) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -29,10 +29,7 @@ export type ParseOptions = {
 
   /**
    * When parsing a document, stores indentation levels on each collection node,
-   * allowing them to be preserved when latery stringified.
-   *
-   * If 'keepSourceTokens' is not `true`, this has no affect, since source tokens
-   * must be provided in order to determine indentation.
+   * allowing them to be preserved when later stringified.
    *
    * Default: `false`
    */

--- a/src/options.ts
+++ b/src/options.ts
@@ -28,6 +28,17 @@ export type ParseOptions = {
   keepSourceTokens?: boolean
 
   /**
+   * When parsing a document, stores indentation levels on each collection node,
+   * allowing them to be preserved when latery stringified.
+   *
+   * If 'keepSourceTokens' is not `true`, this has no affect, since source tokens
+   * must be provided in order to determine indentation.
+   *
+   * Default: `false`
+   */
+  preserveCollectionIndentation?: boolean
+
+  /**
    * If set, newlines will be tracked, to allow for `lineCounter.linePos(offset)`
    * to provide the `{ line, col }` positions within the input.
    */

--- a/src/stringify/stringifyPair.ts
+++ b/src/stringify/stringifyPair.ts
@@ -5,18 +5,22 @@ import { stringify, StringifyContext } from './stringify.js'
 import { addComment, stringifyComment } from './stringifyComment.js'
 
 export function stringifyPair(
-  { key, value }: Readonly<Pair>,
+  { key, value, srcIndentStep }: Readonly<Pair>,
   ctx: StringifyContext,
   onComment?: () => void,
   onChompKeep?: () => void
 ) {
-  const {
+  let {
     allNullValues,
     doc,
     indent,
     indentStep,
     options: { indentSeq, simpleKeys }
   } = ctx
+  if (srcIndentStep !== undefined) {
+    indentStep = ' '.repeat(srcIndentStep)
+  }
+
   let keyComment = (isNode(key) && key.comment) || null
   if (simpleKeys) {
     if (keyComment) {

--- a/src/stringify/stringifyPair.ts
+++ b/src/stringify/stringifyPair.ts
@@ -18,7 +18,24 @@ export function stringifyPair(
     options: { indentSeq, simpleKeys }
   } = ctx
   if (srcIndentStep !== undefined) {
-    indentStep = ' '.repeat(srcIndentStep)
+    // If the pair originally had some indentation step, preserve that
+    // value.
+    if (srcIndentStep > 0 || (srcIndentStep === 0 && isSeq(value))) {
+      // Indentation can only be preserved if it's positive, or if it's 0
+      // and the item to render is a seq, since:
+
+      // foo:
+      // - a
+      // - b
+      // - c
+
+      // is a valid seq with 0 indentStep.
+
+      // Note that ctx.indentStep is *not* modified, so later indentations
+      // will still use the original indentStep if not being preserved from
+      // input.
+      indentStep = ' '.repeat(srcIndentStep)
+    }
   }
 
   let keyComment = (isNode(key) && key.comment) || null

--- a/tests/preserve-indentation.ts
+++ b/tests/preserve-indentation.ts
@@ -37,7 +37,6 @@ more:
 
   test('preserveCollectionIndentation: toString() preserve document indentation', () => {
     const document = parseDocument(sample, {
-      keepSourceTokens: true,
       preserveCollectionIndentation: true
     })
     const roundtrippedSource = document.toString()
@@ -67,7 +66,6 @@ foo:
 
   test('preserveCollectionIndentation: produces correct yaml when preserving indentation with edits', () => {
     const document = parseDocument(sample2, {
-      keepSourceTokens: true,
       preserveCollectionIndentation: true
     })
     expect(document.toString().trim()).toEqual(sample2.trim())
@@ -142,7 +140,6 @@ preservedDocument:
 
   test('preserveCollectionIndentation: documents with preserved indentation can be inserted into other documents', () => {
     const document = parseDocument(sample, {
-      keepSourceTokens: true,
       preserveCollectionIndentation: true
     })
 

--- a/tests/preserve-indentation.ts
+++ b/tests/preserve-indentation.ts
@@ -1,0 +1,160 @@
+import { parseDocument } from 'yaml'
+
+describe('preserveCollectionIndentation', () => {
+  // This sample document has very unusual indentation, which helps
+  // to ensure that it really does end up being preserved exactly.
+  const sample = `
+a:
+      b:
+       c: d
+       more: e
+
+big_indent:
+         - a
+         - b
+         - c
+more:
+   # A comment goes here,
+   # which spans multiple lines.
+
+   # Ideally, a blank line is still preserved as well,
+   # so that large comment blocks can be separated.
+   a:
+    - x # after the item
+    # between items
+    - y:
+       further:
+        indentation:
+        - is
+        - possible
+        - even:
+           tho:
+                  it:
+                         changes: a lot
+    - z
+    # after last
+`
+
+  test('preserveCollectionIndentation: toString() preserve document indentation', () => {
+    const document = parseDocument(sample, {
+      keepSourceTokens: true,
+      preserveCollectionIndentation: true
+    })
+    const roundtrippedSource = document.toString()
+
+    expect(roundtrippedSource.trim()).toEqual(sample.trim())
+  })
+
+  // sample2 corresponds to the JSON `{"foo": ["a", "b", "c"]}`
+  // The Seq is not indented at all, and we can preserve that when
+  // parsing.
+  const sample2 = `
+foo:
+- a
+- b
+- c
+`
+  // However, when we edit the field to replace the list with an object,
+  // some indentation is now required. In this case, we default to the
+  // original 'indentStep' value (e.g. 2 in this case) because some
+  // level of indentation is required.
+  const sample3 = `
+foo:
+  a: 1
+  b: 2
+  c: 3
+`
+
+  test('preserveCollectionIndentation: produces correct yaml when preserving indentation with edits', () => {
+    const document = parseDocument(sample2, {
+      keepSourceTokens: true,
+      preserveCollectionIndentation: true
+    })
+    expect(document.toString().trim()).toEqual(sample2.trim())
+
+    // When replacing the item, we now need indentation, since otherwise
+    // the document has a different structure than it initially did.
+    document.set('foo', { a: 1, b: 2, c: 3 })
+    expect(document.toString().trim()).toEqual(sample3.trim())
+  })
+
+  const combined = `
+a:
+  b:
+    c: d
+    more: e
+
+big_indent:
+  - a
+  - b
+  - c
+more:
+  # A comment goes here,
+  # which spans multiple lines.
+
+  # Ideally, a blank line is still preserved as well,
+  # so that large comment blocks can be separated.
+  a:
+    - x # after the item
+    # between items
+    - y:
+        further:
+          indentation:
+            - is
+            - possible
+            - even:
+                tho:
+                  it:
+                    changes: a lot
+    - z
+    # after last
+preservedDocument:
+  a:
+        b:
+         c: d
+         more: e
+
+  big_indent:
+           - a
+           - b
+           - c
+  more:
+     # A comment goes here,
+     # which spans multiple lines.
+
+     # Ideally, a blank line is still preserved as well,
+     # so that large comment blocks can be separated.
+     a:
+      - x # after the item
+      # between items
+      - y:
+         further:
+          indentation:
+          - is
+          - possible
+          - even:
+             tho:
+                    it:
+                           changes: a lot
+      - z
+      # after last
+`
+
+  test('preserveCollectionIndentation: documents with preserved indentation can be inserted into other documents', () => {
+    const document = parseDocument(sample, {
+      keepSourceTokens: true,
+      preserveCollectionIndentation: true
+    })
+
+    // In this new document, we purposefully skip preserving indentation:
+    const newDocument = parseDocument(sample, {
+      preserveCollectionIndentation: false
+    })
+
+    // The indentation-preserved document is inserted into the "main" document,
+    // and maintains its original indentation level.
+    newDocument.set('preservedDocument', document)
+
+    expect(newDocument.toString().trim()).toEqual(combined.trim())
+  })
+})

--- a/tests/preserve-indentation.ts
+++ b/tests/preserve-indentation.ts
@@ -13,6 +13,13 @@ big_indent:
          - a
          - b
          - c
+list_map1:
+  - foo: 1
+    bar: 2
+    qux: 3
+  - foo: 4
+    bar: 5
+    qux: 6
 more:
    # A comment goes here,
    # which spans multiple lines.
@@ -86,6 +93,13 @@ big_indent:
   - a
   - b
   - c
+list_map1:
+  - foo: 1
+    bar: 2
+    qux: 3
+  - foo: 4
+    bar: 5
+    qux: 6
 more:
   # A comment goes here,
   # which spans multiple lines.
@@ -116,6 +130,13 @@ preservedDocument:
            - a
            - b
            - c
+  list_map1:
+    - foo: 1
+      bar: 2
+      qux: 3
+    - foo: 4
+      bar: 5
+      qux: 6
   more:
      # A comment goes here,
      # which spans multiple lines.
@@ -153,5 +174,30 @@ preservedDocument:
     newDocument.set('preservedDocument', document)
 
     expect(newDocument.toString().trim()).toEqual(combined.trim())
+  })
+
+  const editingSample = `
+foo:
+            big_indent: 1
+            again: 2
+            more: 3
+  `.trim()
+
+  const editingSampleAfter = `
+foo:
+            big_indent: 1
+            again: 2
+            more: 3
+            new: 4
+`.trim()
+
+  test('preserveCollectionIndentation: adds new item preserving indentation', () => {
+    const document = parseDocument(editingSample, {
+      preserveCollectionIndentation: true
+    })
+
+    document.setIn(['foo', 'new'], 4)
+
+    expect(document.toString().trim()).toEqual(editingSampleAfter)
   })
 })

--- a/tests/yaml-test-suite.ts
+++ b/tests/yaml-test-suite.ts
@@ -102,7 +102,6 @@ for (const dir of testDirs) {
           test('stringify+re-parse when preserving indentation', () => {
             const roundTripDocuments = parseAllDocuments(yaml, {
               resolveKnownTags: false,
-              keepSourceTokens: true,
               preserveCollectionIndentation: true
             })
             testJsonMatch(roundTripDocuments, json)

--- a/tests/yaml-test-suite.ts
+++ b/tests/yaml-test-suite.ts
@@ -98,6 +98,21 @@ for (const dir of testDirs) {
             const docs2 = parseAllDocuments(src2, { resolveKnownTags: false })
             testJsonMatch(docs2, json)
           })
+
+          test('stringify+re-parse when preserving indentation', () => {
+            const roundTripDocuments = parseAllDocuments(yaml, {
+              resolveKnownTags: false,
+              keepSourceTokens: true,
+              preserveCollectionIndentation: true
+            })
+            testJsonMatch(roundTripDocuments, json)
+
+            const src2 =
+              docs.map(doc => String(doc).replace(/\n$/, '')).join('\n...\n') +
+              '\n'
+            const docs2 = parseAllDocuments(src2, { resolveKnownTags: false })
+            testJsonMatch(docs2, json)
+          })
         }
 
         const outYaml = load('out.yaml')


### PR DESCRIPTION
This fixes #283 (with some qualifications).

Documents like the following now get their indentation preserved:

```yaml
foo0:
- a
- b
- c
foo2:
  - a
  - b
  - c
foo8:
        - a
        - b
        - c
bar:
       more:
                     indentation:
                                             is: needed
```

when you enable the new option `preserveCollectionIndentation` and also enable the `keepSourceTokens` option:

```ts
const document = parseDocument(yamlContents, {
  keepSourceTokens: true,
  preserveCollectionIndentation: true,
});
```

If you insert/edit/move around nodes in this document, or insert them into others, their indentation is also preserved.

---

I added the new option `preserveCollectionIndentation` purely as a backwards compatibility measure. It could also default to `true`, in which case you'd only need to enable `keepSourceTokens` for it to work.

Unfortunately at least with the way the parser is structured right now, we do need the source tokens since they contain the relevant indentation information that makes the preservation possible.

---

I added a new test similar to the example above which ensures that the document round-trips exactly, maintaining all indentation.

I also added a test that verifies all documents in the yaml-suite can be round-tripped twice to verify that this doesn't break them (not that we'd expect that).

The one special edge case is that if we have a document like

```yaml
list:
- not indented
- at all
```

and we replace the `list` with an object like `{greeting: "hello"}` as in:
```ts
const doc = parseDocument(yamlContents);
doc.set('list', {greeting: "hello"});

console.info(doc.toString());
```
then we need to insert some new indentation; lists are allowed to have an `indentStep` of `0` since the hyphen marks that the item starts, but non-lists are not:

```
# right
list:
  greeting: hello

# wrong (missing indentation changes meaning of document)
list:
greeting: hello
```


in this case, we default back to the configured `indentStep` (e.g. 2).