### PR TITLE
Add json-test-suite as git submodule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,4 +4,5 @@
 /lib/
 /package-lock.json
 /playground/dist/
+/tests/json-test-suite/
 /tests/yaml-test-suite/

--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,7 @@
 [submodule "playground"]
 	path = playground
 	url = https://github.com/eemeli/yaml-playground.git
+[submodule "tests/json-test-suite"]
+	path = tests/json-test-suite
+	url = https://github.com/nst/JSONTestSuite.git
+	branch = master

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,5 @@ coverage/
 dist/
 node_modules/
 /docs-slate/
+/tests/json-test-suite/
 /tests/yaml-test-suite/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ npm test # just to be sure
 - **`tests/`** - Tests for the library:
   - **`tests/artifacts/`** - YAML files used by some of the tests
   - **`tests/doc/`** - Tests for the AST level of the library
+  - **`tests/json-test-suite/`** - Git submodule of the [JSON Test Suite](https://github.com/nst/JSONTestSuite)
   - **`tests/yaml-test-suite/`** - Git submodule of a custom fork of the [YAML Test Suite](https://github.com/yaml/yaml-test-suite)
 
 ## Contributing Code

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -38,6 +38,6 @@ module.exports = {
   rootDir: '..',
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.{js,ts}'],
-  testPathIgnorePatterns: ['tests/_utils'],
+  testPathIgnorePatterns: ['tests/_utils', 'tests/json-test-suite/'],
   transform
 }

--- a/tests/json-test-suite.ts
+++ b/tests/json-test-suite.ts
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import { readdirSync, readFileSync } from 'fs'
+import { basename, resolve } from 'path'
+import { parseDocument } from 'yaml'
+
+const skip = [
+  // Maximum call stack size exceeded
+  'n_structure_100000_opening_arrays',
+  'n_structure_open_array_object',
+
+  // YAMLParseError: Map keys must be unique
+  'y_object_duplicated_key',
+  'y_object_duplicated_key_and_value',
+  'object_same_key_different_values',
+  'object_same_key_same_value',
+  'object_same_key_unclear_values'
+]
+
+function testReject(name: string, src: string) {
+  if (skip.includes(name)) return test.skip(name, () => {})
+
+  test(name, () => {
+    const doc = parseDocument(src)
+    if (doc.errors.length === 0) {
+      const res = doc.toJS()
+      const doc2 = parseDocument(doc.toString())
+      const res2 = doc2.toJS()
+      expect(JSON.stringify(res2)).toBe(JSON.stringify(res))
+    }
+  })
+}
+
+function testSuccess(name: string, src: string) {
+  if (skip.includes(name)) return test.skip(name, () => {})
+
+  test(name, () => {
+    const doc = parseDocument(src)
+    expect(doc.errors).toHaveLength(0)
+    expect(doc.warnings).toHaveLength(0)
+    const res = doc.toJS()
+
+    const doc2 = parseDocument(doc.toString())
+    expect(doc2.errors).toHaveLength(0)
+    expect(doc2.warnings).toHaveLength(0)
+    const res2 = doc2.toJS()
+
+    expect(JSON.stringify(res2)).toBe(JSON.stringify(res))
+  })
+}
+
+describe('json-test-suite test_parsing', () => {
+  const dir = resolve(__dirname, 'json-test-suite', 'test_parsing')
+  for (const fn of readdirSync(dir)) {
+    if (!fn.endsWith('.json')) continue
+    const name = basename(fn, '.json')
+    const src = readFileSync(resolve(dir, fn), 'utf8')
+    if (fn.startsWith('y_')) testSuccess(name, src)
+    else testReject(name, src)
+  }
+})
+
+describe('json-test-suite test_transform', () => {
+  const dir = resolve(__dirname, 'json-test-suite', 'test_transform')
+  for (const fn of readdirSync(dir)) {
+    if (!fn.endsWith('.json')) continue
+    const src = readFileSync(resolve(dir, fn), 'utf8')
+    testSuccess(basename(fn, '.json'), src)
+  }
+})


### PR DESCRIPTION
As I recently became aware of the [JSON Parsing Test Suite](https://github.com/nst/JSONTestSuite), that seems like a good thing to include here. This revealed two bugs: the stringification of non-finite scalars with `format: 'EXP'` (fixed in 51c1c74) and a "Maximum call stack size exceeded" error when composing ridiculously nested broken documents.

The tests that trigger the latter error are at least for now skipped, as avoiding the recursivity that causes the error might be more trouble than it's worth.

As this PR includes a new git submodule, running something like the following will subsequently be required:

```
git submodule update --init
```