### PR TITLE
Allow for Schema instance as schema option

### DIFF
--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -347,7 +347,7 @@ export class Document<T = unknown> {
 
   /**
    * Change the YAML version and schema used by the document.
-   * A `null` version disables support for directives and explicit tags.
+   * A `null` version disables support for directives, explicit tags, anchors, and aliases.
    * It also requires the `schema` option to be given as a `Schema` instance value.
    *
    * Overrides all previously set schema options.

--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -349,29 +349,34 @@ export class Document<T = unknown> {
    *
    * Overrides all previously set schema options
    */
-  setSchema(version: '1.1' | '1.2', options?: SchemaOptions) {
-    let _options: SchemaOptions
-    switch (String(version)) {
-      case '1.1':
-        this.directives.yaml.version = '1.1'
-        _options = Object.assign(
-          { merge: true, resolveKnownTags: false, schema: 'yaml-1.1' },
-          options
-        )
-        break
-      case '1.2':
-        this.directives.yaml.version = '1.2'
-        _options = Object.assign(
-          { merge: false, resolveKnownTags: true, schema: 'core' },
-          options
-        )
-        break
-      default: {
-        const sv = JSON.stringify(version)
-        throw new Error(`Expected '1.1' or '1.2' as version, but found: ${sv}`)
+  setSchema(version: '1.1' | '1.2', options?: SchemaOptions): void
+  setSchema(schema: Schema): void
+  setSchema(version: '1.1' | '1.2' | Schema, options: SchemaOptions = {}) {
+    // Not using `instanceof Schema` to allow for duck typing
+    if (version instanceof Object) {
+      this.schema = version
+    } else if (options.schema instanceof Object) {
+      this.schema = options.schema
+    } else {
+      let opt: SchemaOptions & { schema: string }
+      switch (String(version)) {
+        case '1.1':
+          this.directives.yaml.version = '1.1'
+          opt = { merge: true, resolveKnownTags: false, schema: 'yaml-1.1' }
+          break
+        case '1.2':
+          this.directives.yaml.version = '1.2'
+          opt = { merge: false, resolveKnownTags: true, schema: 'core' }
+          break
+        default: {
+          const sv = JSON.stringify(version)
+          throw new Error(
+            `Expected '1.1', '1.2' or Schema instance as first argument, but found: ${sv}`
+          )
+        }
       }
+      this.schema = new Schema(Object.assign(opt, options))
     }
-    this.schema = new Schema(_options)
   }
 
   /** A plain JavaScript representation of the document `contents`. */

--- a/src/options.ts
+++ b/src/options.ts
@@ -5,6 +5,7 @@ import type { ParsedNode } from './nodes/Node.js'
 import type { Pair } from './nodes/Pair.js'
 import type { Scalar } from './nodes/Scalar.js'
 import type { LineCounter } from './parse/line-counter.js'
+import type { Schema } from './schema/Schema.js'
 import type { Tags } from './schema/tags.js'
 import type { CollectionTag, ScalarTag } from './schema/types.js'
 
@@ -131,7 +132,7 @@ export type SchemaOptions = {
    *
    * Default: `'core'` for YAML 1.2, `'yaml-1.1'` for earlier versions
    */
-  schema?: string
+  schema?: string | Schema
 
   /**
    * When adding to or stringifying a map, sort the entries.

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -21,12 +21,10 @@ export interface EmptyStream
   empty: true
 }
 
-function parseOptions(options: ParseOptions | undefined) {
-  const prettyErrors = !options || options.prettyErrors !== false
+function parseOptions(options: ParseOptions) {
+  const prettyErrors = options.prettyErrors !== false
   const lineCounter =
-    (options && options.lineCounter) ||
-    (prettyErrors && new LineCounter()) ||
-    null
+    options.lineCounter || (prettyErrors && new LineCounter()) || null
   return { lineCounter, prettyErrors }
 }
 

--- a/src/schema/Schema.ts
+++ b/src/schema/Schema.ts
@@ -39,7 +39,7 @@ export class Schema {
       ? getTags(null, compat)
       : null
     this.merge = !!merge
-    this.name = schema || 'core'
+    this.name = (typeof schema === 'string' && schema) || 'core'
     this.knownTags = resolveKnownTags ? coreKnownTags : {}
     this.tags = getTags(customTags, this.name)
     this.toStringOptions = toStringDefaults || null

--- a/src/stringify/stringify.ts
+++ b/src/stringify/stringify.ts
@@ -119,10 +119,9 @@ function stringifyProps(
     anchors.add(anchor)
     props.push(`&${anchor}`)
   }
-  if (node.tag) {
-    props.push(doc.directives.tagString(node.tag))
-  } else if (!tagObj.default) {
-    props.push(doc.directives.tagString(tagObj.tag))
+  if (doc.directives) {
+    const tag = node.tag || (tagObj.default ? null : tagObj.tag)
+    if (tag) props.push(doc.directives.tagString(tag))
   }
   return props.join(' ')
 }

--- a/src/stringify/stringifyDocument.ts
+++ b/src/stringify/stringifyDocument.ts
@@ -14,7 +14,7 @@ export function stringifyDocument(
 ) {
   const lines: string[] = []
   let hasDirectives = options.directives === true
-  if (options.directives !== false) {
+  if (options.directives !== false && doc.directives) {
     const dir = doc.directives.toString(doc)
     if (dir) {
       lines.push(dir)

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -923,19 +923,19 @@ describe('schema changes', () => {
   })
 
   test('custom schema instance', () => {
-    const src = '[ !!bool yes, no ]'
+    const src = '[ !!bool yes, &foo no, *foo ]'
     const doc = YAML.parseDocument(src, { version: '1.1' })
 
     doc.setSchema('1.2', new YAML.Schema({ schema: 'core' }))
-    expect(String(doc)).toBe('[ !!bool true, false ]\n')
+    expect(String(doc)).toBe('[ !!bool true, &foo false, *foo ]\n')
 
     const yaml11 = new YAML.Schema({ schema: 'yaml-1.1' })
     doc.setSchema('1.1', Object.assign({}, yaml11))
-    expect(String(doc)).toBe('[ !!bool yes, no ]\n')
+    expect(String(doc)).toBe('[ !!bool yes, &foo no, *foo ]\n')
 
     const schema = new YAML.Schema({ schema: 'core' })
     doc.setSchema(null, { schema })
-    expect(String(doc)).toBe('[ true, false ]\n')
+    expect(String(doc)).toBe('[ true, false, false ]\n')
   })
 
   test('null version requires Schema instance', () => {

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -923,17 +923,28 @@ describe('schema changes', () => {
   })
 
   test('custom schema instance', () => {
-    const src = '[y, yes, on, n, no, off]'
+    const src = '[ !!bool yes, no ]'
     const doc = YAML.parseDocument(src, { version: '1.1' })
 
+    doc.setSchema('1.2', new YAML.Schema({ schema: 'core' }))
+    expect(String(doc)).toBe('[ !!bool true, false ]\n')
+
+    const yaml11 = new YAML.Schema({ schema: 'yaml-1.1' })
+    doc.setSchema('1.1', Object.assign({}, yaml11))
+    expect(String(doc)).toBe('[ !!bool yes, no ]\n')
+
     const schema = new YAML.Schema({ schema: 'core' })
-    doc.setSchema(schema)
-    expect(String(doc)).toBe('[ true, true, true, false, false, false ]\n')
+    doc.setSchema(null, { schema })
+    expect(String(doc)).toBe('[ true, false ]\n')
+  })
 
-    doc.setSchema(Object.assign({}, new YAML.Schema({ schema: 'yaml-1.1' })))
-    expect(String(doc)).toBe('[ y, yes, on, n, no, off ]\n')
-
-    doc.setSchema('1.1', { schema })
-    expect(String(doc)).toBe('[ true, true, true, false, false, false ]\n')
+  test('null version requires Schema instance', () => {
+    const doc = YAML.parseDocument('foo: bar')
+    const msg =
+      'With a null YAML version, the { schema: Schema } option is required'
+    expect(() => doc.setSchema(null)).toThrow(msg)
+    expect(() => doc.setSchema(null, { schema: 'core' })).toThrow(msg)
+    doc.setSchema(null, { schema: doc.schema })
+    expect(doc.toString()).toBe('foo: bar\n')
   })
 })

--- a/tests/doc/types.js
+++ b/tests/doc/types.js
@@ -775,7 +775,7 @@ describe('custom tags', () => {
     expect(str).toBe('re: !re /re/g\nsymbol: !symbol/shared foo\n')
   })
 
-  describe('completely custom schema', () => {
+  describe('schema from custom tags', () => {
     test('customTags is required', () => {
       expect(() =>
         YAML.parseDocument('foo', { schema: 'custom-test' })
@@ -835,6 +835,23 @@ describe('custom tags', () => {
         schema: 'custom-test'
       })
       expect(() => String(doc)).toThrow(/Tag not resolved for String value/)
+    })
+
+    test('setSchema', () => {
+      const src = '- foo\n'
+      const doc = YAML.parseDocument(src)
+
+      doc.setSchema('1.2', {
+        customTags: [seqTag, stringTag],
+        schema: 'custom-test-1'
+      })
+      expect(doc.toString()).toBe(src)
+
+      doc.setSchema('1.2', {
+        customTags: [stringTag],
+        schema: 'custom-test-2'
+      })
+      expect(() => String(doc)).toThrow(/Tag not resolved for YAMLSeq value/)
     })
   })
 })
@@ -903,5 +920,20 @@ describe('schema changes', () => {
     })
     doc.set('a', false)
     expect(String(doc)).toBe('a: false\n')
+  })
+
+  test('custom schema instance', () => {
+    const src = '[y, yes, on, n, no, off]'
+    const doc = YAML.parseDocument(src, { version: '1.1' })
+
+    const schema = new YAML.Schema({ schema: 'core' })
+    doc.setSchema(schema)
+    expect(String(doc)).toBe('[ true, true, true, false, false, false ]\n')
+
+    doc.setSchema(Object.assign({}, new YAML.Schema({ schema: 'yaml-1.1' })))
+    expect(String(doc)).toBe('[ y, yes, on, n, no, off ]\n')
+
+    doc.setSchema('1.1', { schema })
+    expect(String(doc)).toBe('[ true, true, true, false, false, false ]\n')
   })
 })


### PR DESCRIPTION
Previously, `doc.setSchema` always created a new Schema instance based on the given schema identifier. This change allows for an externally defined schema to be used instead, which makes using a different predefined set of default option values easier.