### PR TITLE
Remove YAML.defaultOptions

### DIFF
--- a/src/compose/composer.ts
+++ b/src/compose/composer.ts
@@ -2,8 +2,7 @@ import { Directives } from '../doc/directives.js'
 import { Document } from '../doc/Document.js'
 import { ErrorCode, YAMLParseError, YAMLWarning } from '../errors.js'
 import { isCollection, isPair, Range } from '../nodes/Node.js'
-import {
-  defaultOptions,
+import type {
   DocumentOptions,
   ParseOptions,
   SchemaOptions
@@ -80,9 +79,7 @@ export class Composer {
   private warnings: YAMLWarning[] = []
 
   constructor(options: ParseOptions & DocumentOptions & SchemaOptions = {}) {
-    this.directives = new Directives({
-      version: options.version || defaultOptions.version
-    })
+    this.directives = new Directives({ version: options.version || '1.2' })
     this.options = options
   }
 

--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -16,9 +16,8 @@ import type { Scalar } from '../nodes/Scalar.js'
 import { toJS, ToJSContext } from '../nodes/toJS.js'
 import type { YAMLMap } from '../nodes/YAMLMap.js'
 import type { YAMLSeq } from '../nodes/YAMLSeq.js'
-import {
+import type {
   CreateNodeOptions,
-  defaultOptions,
   DocumentOptions,
   ParseOptions,
   SchemaOptions,
@@ -111,7 +110,18 @@ export class Document<T = unknown> {
       replacer = undefined
     }
 
-    const opt = Object.assign({}, defaultOptions, options)
+    const opt = Object.assign(
+      {
+        intAsBigInt: false,
+        keepSourceTokens: false,
+        logLevel: 'warn',
+        prettyErrors: true,
+        strict: true,
+        uniqueKeys: true,
+        version: '1.2'
+      },
+      options
+    )
     this.options = opt
     let { version } = opt
     if (options?.directives) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,9 +24,8 @@ export { Scalar } from './nodes/Scalar.js'
 export { YAMLMap } from './nodes/YAMLMap.js'
 export { YAMLSeq } from './nodes/YAMLSeq.js'
 
-export {
+export type {
   CreateNodeOptions,
-  defaultOptions,
   DocumentOptions,
   ParseOptions,
   SchemaOptions,

--- a/src/options.ts
+++ b/src/options.ts
@@ -372,22 +372,3 @@ export type ToStringOptions = {
    */
   verifyAliasOrder?: boolean
 }
-
-/**
- * `yaml` defines document-specific options in three places: as an argument of
- * parse, create and stringify calls, in the values of `YAML.defaultOptions`,
- * and in the version-dependent `YAML.Document.defaults` object. Values set in
- * `YAML.defaultOptions` override version-dependent defaults, and argument
- * options override both.
- */
-export const defaultOptions: Required<
-  Omit<ParseOptions, 'lineCounter'> & Omit<DocumentOptions, 'directives'>
-> = {
-  intAsBigInt: false,
-  keepSourceTokens: false,
-  logLevel: 'warn',
-  prettyErrors: true,
-  strict: true,
-  uniqueKeys: true,
-  version: '1.2'
-}


### PR DESCRIPTION
As this removes a public endpoint, this is indeed a **BREAKING CHANGE**.

In preparation for a `yaml@2.0.0` release, I've been reviewing the public API, and I think I'd like to drop the global `YAML.defaultOptions` object. In general, global state feels like a bad idea.

For a while, it's been undocumented, but still available. Since the options refactor of #235, it has only provided defaults for Parse & Document options, and not any of the others, so its name is a bit misleading as well.

If you're using `YAML.defaultOptions`, you'll need to explicitly set the options in the appropriate `parse*()` and `new Document()` calls after this change.