### PR TITLE
Enable deep-merging of yaml docs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,3 +50,5 @@ export type { TagId, Tags } from './schema/tags'
 export type { CollectionTag, ScalarTag } from './schema/types'
 
 export { visit, visitor, visitorFn } from './visit.js'
+
+export { merge } from './merge.js'

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -24,9 +24,8 @@ function getPath(ancestry: readonly (Document | Node | Pair)[]): (string|number)
 
 function getFirstChildNode(collection: Collection): Node | undefined {
   if (isSeq(collection)) {
-    return <Node | undefined>(<YAMLSeq> collection).items.find(
-      (i) => isNode(i)
-    );
+    for (const item of collection.items) if (isNode(item)) return item;
+    return undefined;
   }
   if (collection.constructor.name === 'YAMLMap') {
     const firstChildKey = (<YAMLMap> collection).items[0]?.key;

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -23,7 +23,7 @@ function getPath(ancestry: readonly (Document | Node | Pair)[]): (string|number)
 }
 
 function getFirstChildNode(collection: Collection): Node | undefined {
-  if (collection.constructor.name === 'YAMLSeq') {
+  if (isSeq(collection)) {
     return <Node | undefined>(<YAMLSeq> collection).items.find(
       (i) => isNode(i)
     );

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,0 +1,133 @@
+import {
+  isCollection,
+  isDocument,
+  isMap,
+  isScalar,
+  isSeq,
+  isNode,
+  Node
+} from './nodes/Node'
+import { Document } from './doc/Document'
+import { Pair } from './nodes/Pair'
+import { visit } from './visit'
+import { Scalar } from './nodes/Scalar'
+import { Collection } from './nodes/Collection'
+import { YAMLMap } from './nodes/YAMLMap'
+import { YAMLSeq } from './nodes/YAMLSeq'
+import { MergeOptions } from './options'
+
+function getPath(ancestry: readonly (Document | Node | Pair)[]): (string|number)[] {
+  return ancestry.reduce<(string|number)[]>((p, { key }: any) => {
+    return (key !== undefined) ? [...p, key.value] : p;
+  }, []);
+}
+
+function getFirstChildNode(collection: Collection): Node | undefined {
+  if (collection.constructor.name === 'YAMLSeq') {
+    return <Node | undefined>(<YAMLSeq> collection).items.find(
+      (i) => isNode(i)
+    );
+  }
+  if (collection.constructor.name === 'YAMLMap') {
+    const firstChildKey = (<YAMLMap> collection).items[0]?.key;
+    if (!firstChildKey) {
+      return undefined;
+    }
+    if (isScalar(firstChildKey)) {
+      return firstChildKey;
+    }
+    return new Scalar(firstChildKey);
+  }
+  const type = collection.constructor?.name || typeof collection;
+  throw Error(`Cannot identify a child Node for type ${type}`);
+}
+
+function moveMetaPropsToFirstChildNode(collection: Collection): void {
+  const firstChildNode = getFirstChildNode(collection)
+
+  const {comment, commentBefore, spaceBefore} = collection;
+
+  if (!(comment || commentBefore || spaceBefore)) return;
+
+  if (!firstChildNode) throw new Error(
+    'Cannot move meta properties to a child of an empty Collection'
+  )
+
+  Object.assign(firstChildNode, { comment, commentBefore, spaceBefore })
+
+  delete collection.commentBefore
+  delete collection.comment
+  delete collection.spaceBefore
+}
+
+/** Merge another collection into this */
+export function merge(target: Document, source: unknown, options: MergeOptions = {}): Document {
+  const opt = Object.assign(
+    {
+      onSequence: 'replace',
+    },
+    options
+  )
+
+  const sourceNode = target.createNode(isDocument(source) ? source.contents : source)
+
+  if (!isCollection(sourceNode)) {
+    const type = (<any> source).constructor?.name || typeof source;
+    throw new Error(`Cannot merge type "${type}", expected a Collection`)
+  }
+
+  if (!isCollection(target.contents)) {
+    // If the target doc is empty add the source to it directly
+    target.add(source)
+    return target
+  }
+
+  visit(sourceNode, {
+    Map: (_, node, ancestors) => {
+      const path = getPath(ancestors);
+      moveMetaPropsToFirstChildNode(node)
+      // In case both the source and the target node have comments or spaces
+      // We'll move them to their first child so they do not conflict
+      if(target.hasIn(path)) {
+        const targetNode = target.getIn(path, true)
+
+        if (!isMap(targetNode)) {
+          const type = (<any> targetNode).constructor?.name || typeof targetNode;
+          throw new Error(`Conflict at "${path.join('.')}": Destination node is of type ${type}, the node to be merged is of type ${node.constructor.name}`)
+        }
+
+        moveMetaPropsToFirstChildNode(targetNode)
+      }
+    },
+    Pair: (_, node, ancestors) => {
+      if (isScalar(node.value)) {
+        const path = getPath(ancestors);
+        if (target.hasIn([...path, (<Scalar> node.key).value])) {
+          target.setIn(path, node);
+        } else {
+          target.addIn(path, node);
+        }
+        return visit.SKIP;
+      }
+    },
+    Seq: (_, node, ancestors) => {
+      const path = getPath(ancestors);
+      moveMetaPropsToFirstChildNode(node)
+      if(target.hasIn(path)) {
+        const targetNode = target.getIn(path, true)
+        if (!isSeq(targetNode)) {
+          const type = (<any> targetNode).constructor?.name || typeof targetNode;
+          throw new Error(`Conflict at "${path.join('.')}": Destination node is of type ${type}, the node to be merged is of type ${node.constructor.name}`)
+        }
+        moveMetaPropsToFirstChildNode(targetNode)
+      }
+      if (opt.onSequence === 'replace') {
+        target.setIn(path, node)
+        return visit.SKIP;
+      }
+      for (const item of node.items) target.addIn(path, item)
+      return visit.SKIP;
+    },
+  });
+ return target
+}

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -78,7 +78,7 @@ export function merge(target: Document, source: unknown, options: MergeOptions =
 
   if (!isCollection(target.contents)) {
     // If the target doc is empty add the source to it directly
-    target.add(source)
+    Object.assign(target, { contents: sourceNode })
     return target
   }
 

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -77,7 +77,7 @@ export function merge(target: Document, source: unknown, options: MergeOptions =
 
   if (!isCollection(target.contents)) {
     // If the target doc is empty add the source to it directly
-    Object.assign(target, { contents: sourceNode })
+    target.contents = sourceNode;
     return target
   }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -372,3 +372,13 @@ export type ToStringOptions = {
    */
   verifyAliasOrder?: boolean
 }
+
+export type MergeOptions = {
+  /**
+   *  Behavior when the merge function encounters two sequences at the same
+   *  path.
+   *
+   *  Default: `'replace'`
+   * */
+  onSequence?: 'append' | 'replace'
+}

--- a/tests/merge.ts
+++ b/tests/merge.ts
@@ -1,0 +1,156 @@
+import { Document, parseDocument, merge } from 'yaml'
+
+const getAsNode = (yamlStr: string) => {
+  return parseDocument(yamlStr).contents
+}
+
+describe('Merge two Nodes', () => {
+
+  test('maps', () => {
+    const sourceNode = getAsNode('foo:\n  bar: baz\n')
+    const targetDoc = parseDocument('foo:\n  abc: def\n')
+    merge(targetDoc, sourceNode)
+    const expected = parseDocument('foo:\n  abc: def\n  bar: baz\n')
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('seqs', () => {
+    const sourceNode = getAsNode('foo:\n  - bar\n')
+    const targetDoc = parseDocument('foo:\n  - abc\n')
+    merge(targetDoc, sourceNode)
+    const expected = parseDocument('foo:\n  - bar\n')
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('seqs with appendToSequences=true', () => {
+    const sourceNode = getAsNode('foo:\n  - bar\n')
+    const targetDoc = parseDocument('foo:\n  - abc\n')
+    merge(targetDoc, sourceNode, { onSequence: 'append' })
+    const expected = parseDocument('foo:\n  - abc\n  - bar\n')
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('existing paths are overridden', () => {
+    const sourceNode = getAsNode('foo:\n  bar: baz\n')
+    const targetDoc = parseDocument('foo:\n  bar: boo\n')
+    merge(targetDoc, sourceNode)
+    const expected = parseDocument('foo:\n  bar: baz\n')
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('deep maps', () => {
+    const sourceNode = getAsNode('foo:\n  bar:\n    abc: def\n')
+    const targetDoc = parseDocument('foo:\n  bar:\n    baz: boo\n  jkl:' +
+      ' mno\n')
+    merge(targetDoc, sourceNode)
+    const expected = parseDocument('foo:\n  bar:\n    baz: boo\n    abc:' +
+      ' def\n  jkl: mno\n')
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('maps inside seqs are appended', () => {
+    const sourceNode = getAsNode('foo:\n  - abc: def\n')
+    const targetDoc = parseDocument('foo:\n  - bar: baz\n')
+    merge(targetDoc, sourceNode, { onSequence: 'append' })
+    const expected = parseDocument('foo:\n  - bar: baz\n  - abc: def\n')
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('inexistent paths create new nodes', () => {
+    const sourceNode = getAsNode('foo:\n  bar: baz\n')
+    const targetDoc = parseDocument('abc: def\n')
+    merge(targetDoc, sourceNode)
+    const expected = parseDocument('abc: def\nfoo:\n  bar: baz\n')
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('merge accepts a document as an argument', () => {
+    const sourceDoc = parseDocument('foo:\n  bar: baz\n')
+    const targetDoc = parseDocument('foo:\n  abc: def\n')
+    merge(targetDoc, sourceDoc)
+    const expected = parseDocument('foo:\n  abc: def\n  bar: baz\n')
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('type conflict will throw an Error', () => {
+    const sourceDoc = parseDocument('foo:\n  bar:\n    - baz\n')
+    const targetDoc = parseDocument('foo:\n  bar: def\n')
+    expect(() => merge(targetDoc, sourceDoc)).toThrow(
+      'Conflict at "foo.bar": Destination node is of type Scalar, the node' +
+      ' to be merged is of type YAMLSeq'
+    )
+  })
+
+  test('comments on pairs', () => {
+    const sourceDoc = parseDocument(`foo:
+  # barbaz
+    bar: baz
+
+  # bazboo
+    baz: boo
+`)
+    const targetDoc = parseDocument(`foo:
+  # abcdef
+  abc: def
+  # boobaz
+  boo: baz
+`)
+    merge(targetDoc, sourceDoc)
+    const expected = parseDocument(`foo:
+  # abcdef
+  abc: def
+  # boobaz
+  boo: baz
+  # barbaz
+  bar: baz
+
+  # bazboo
+  baz: boo
+`)
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('comments on seqs', () => {
+    const sourceDoc = parseDocument(`foo:
+  # barbaz
+  - barbaz
+  # bazboo
+  - baz: boo
+`)
+    const targetDoc = parseDocument(`foo:
+  # abcdef
+  - abcdef
+
+  # boobaz
+  - boobaz
+`)
+    merge(targetDoc, sourceDoc, { onSequence: 'append' })
+    const expected = parseDocument(`foo:
+  # abcdef
+  - abcdef
+
+  # boobaz
+  - boobaz
+  # barbaz
+  - barbaz
+  # bazboo
+  - baz: boo
+`)
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('merging plain objects into doc', () => {
+    const targetDoc = parseDocument('foo:\n  abc: def\n')
+    merge(targetDoc,{ foo: { bar: 'baz' }  })
+    const expected = parseDocument('foo:\n  abc: def\n  bar: baz\n')
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+  test('merging a collection into an empty doc', () => {
+    const targetDoc = new Document({})
+    merge(targetDoc, { foo: { bar: 'baz' } })
+    const expected = parseDocument('foo:\n  bar: baz\n')
+    expect(targetDoc.toString()).toEqual(expected.toString())
+  })
+
+})

--- a/tests/merge.ts
+++ b/tests/merge.ts
@@ -147,7 +147,7 @@ describe('Merge two Nodes', () => {
   })
 
   test('merging a collection into an empty doc', () => {
-    const targetDoc = new Document({})
+    const targetDoc = new Document()
     merge(targetDoc, { foo: { bar: 'baz' } })
     const expected = parseDocument('foo:\n  bar: baz\n')
     expect(targetDoc.toString()).toEqual(expected.toString())


### PR DESCRIPTION
This MR enables deep-merging any Collection or JS Object into a yaml doc by introducing the `merge` function:

```js
import { merge } from 'yaml';

merge(doc, { foo: 'bar' })
```

## Implementation detail
This will use `visit()` to walk the tree of the node that is to be merged. For any `Pair` it finds it will `setIn()` or `addIn()` that Pair on the target Collection.

It will do the same with any `Seq` items.

For `Map` and `Seq`, it will also move their `commentBefore`, `comment` and `spaceBefore` to their respective first child node - this avoids overriding an existing comment on the target node if the incoming `Map` or `Seq` has a comment, too.