### PR TITLE
Add warning for aliases & anchors ending with a colon

### DIFF
--- a/src/compose/compose-node.ts
+++ b/src/compose/compose-node.ts
@@ -106,6 +106,13 @@ function composeAlias(
   const alias = new Alias(source.substring(1))
   if (alias.source === '')
     onError(offset, 'BAD_ALIAS', 'Alias cannot be an empty string')
+  if (alias.source.endsWith(':'))
+    onError(
+      offset + source.length - 1,
+      'BAD_ALIAS',
+      'Alias ending in : is ambiguous',
+      true
+    )
   const valueEnd = offset + source.length
   const re = resolveEnd(end, valueEnd, options.strict, onError)
   alias.range = [offset, valueEnd, re.offset]

--- a/src/compose/resolve-props.ts
+++ b/src/compose/resolve-props.ts
@@ -84,6 +84,13 @@ export function resolveProps(
             'MULTIPLE_ANCHORS',
             'A node can have at most one anchor'
           )
+        if (token.source.endsWith(':'))
+          onError(
+            token.offset + token.source.length - 1,
+            'BAD_ALIAS',
+            'Anchor ending in : is ambiguous',
+            true
+          )
         anchor = token
         if (start === null) start = token.offset
         atNewline = false

--- a/tests/doc/anchors.js
+++ b/tests/doc/anchors.js
@@ -145,6 +145,20 @@ describe('errors', () => {
   })
 })
 
+describe('warnings', () => {
+  test('anchor ending in colon', () => {
+    const doc = YAML.parseDocument('- &x:\n')
+    expect(doc.errors).toHaveLength(0)
+    expect(doc.warnings).toMatchObject([{ code: 'BAD_ALIAS' }])
+  })
+
+  test('alias ending in colon', () => {
+    const doc = YAML.parseDocument('- *x:\n')
+    expect(doc.errors).toHaveLength(0)
+    expect(doc.warnings).toMatchObject([{ code: 'BAD_ALIAS' }])
+  })
+})
+
 describe('__proto__ as anchor name', () => {
   test('parse', () => {
     const src = `- &__proto__ 1\n- *__proto__\n`


### PR DESCRIPTION
Fixes #350, CC @bwateratmsft

After some consideration, the current error is exactly valid for the given input. So, to clarify the situation, let's add a warning for anchors and aliases that end in a colon `:`, as those are probably erroneous.

This warning (as well as other warnings) may be silenced by using the option `logLevel: 'error'`.