### PR TITLE
Add directives.docEnd, for ... marker

### DIFF
--- a/docs/04_documents.md
+++ b/docs/04_documents.md
@@ -159,7 +159,7 @@ See [Options](#options) for more information on the optional parameter.
 const doc = new Document()
 doc.directives
 > {
-    marker: null, // set true to force the doc-start marker
+    docStart: null, // set true to force the doc-start marker
     tags: { '!!': 'tag:yaml.org,2002:' }, // Record<handle, prefix>
     yaml: { explicit: false, version: '1.2' }
   }

--- a/docs/04_documents.md
+++ b/docs/04_documents.md
@@ -160,6 +160,7 @@ const doc = new Document()
 doc.directives
 > {
     docStart: null, // set true to force the doc-start marker
+    docEnd: false, // set true to force the doc-end marker
     tags: { '!!': 'tag:yaml.org,2002:' }, // Record<handle, prefix>
     yaml: { explicit: false, version: '1.2' }
   }

--- a/src/compose/compose-doc.ts
+++ b/src/compose/compose-doc.ts
@@ -37,7 +37,7 @@ export function composeDoc(
     startOnNewline: true
   })
   if (props.found) {
-    doc.directives.marker = true
+    doc.directives.docStart = true
     if (
       value &&
       (value.type === 'block-map' || value.type === 'block-seq') &&

--- a/src/compose/composer.ts
+++ b/src/compose/composer.ts
@@ -96,7 +96,7 @@ export class Composer {
       const dc = doc.contents
       if (afterDoc) {
         doc.comment = doc.comment ? `${doc.comment}\n${comment}` : comment
-      } else if (afterEmptyLine || doc.directives.marker || !dc) {
+      } else if (afterEmptyLine || doc.directives.docStart || !dc) {
         doc.commentBefore = comment
       } else if (isCollection(dc) && !dc.flow && dc.items.length > 0) {
         let it = dc.items[0]
@@ -167,7 +167,7 @@ export class Composer {
           token,
           this.onError
         )
-        if (this.atDirectives && !doc.directives.marker)
+        if (this.atDirectives && !doc.directives.docStart)
           this.onError(
             token,
             'MISSING_CHAR',

--- a/src/compose/composer.ts
+++ b/src/compose/composer.ts
@@ -171,7 +171,7 @@ export class Composer {
           this.onError(
             token,
             'MISSING_CHAR',
-            'Missing directives-end indicator line'
+            'Missing directives-end/doc-start indicator line'
           )
         this.decorate(doc, false)
         if (this.doc) yield this.doc
@@ -207,6 +207,7 @@ export class Composer {
           )
           break
         }
+        this.doc.directives.docEnd = true
         const end = resolveEnd(
           token.end,
           token.offset + token.source.length,

--- a/src/doc/directives.ts
+++ b/src/doc/directives.ts
@@ -25,7 +25,7 @@ export class Directives {
    * The directives-end/doc-start marker `---`. If `null`, a marker may still be
    * included in the document's stringified representation.
    */
-  marker: true | null = null
+  docStart: true | null = null
 
   /**
    * Used when parsing YAML 1.1, where:
@@ -42,7 +42,7 @@ export class Directives {
 
   clone(): Directives {
     const copy = new Directives(this.yaml, this.tags)
-    copy.marker = this.marker
+    copy.docStart = this.docStart
     return copy
   }
 

--- a/src/doc/directives.ts
+++ b/src/doc/directives.ts
@@ -27,6 +27,9 @@ export class Directives {
    */
   docStart: true | null = null
 
+  /** The doc-end marker `...`.  */
+  docEnd = false
+
   /**
    * Used when parsing YAML 1.1, where:
    * > If the document specifies no directives, it is parsed using the same

--- a/src/stringify/stringifyDocument.ts
+++ b/src/stringify/stringifyDocument.ts
@@ -19,7 +19,7 @@ export function stringifyDocument(
     if (dir) {
       lines.push(dir)
       hasDirectives = true
-    } else if (doc.directives.marker) hasDirectives = true
+    } else if (doc.directives.docStart) hasDirectives = true
   }
   if (hasDirectives) lines.push('---')
 

--- a/src/stringify/stringifyDocument.ts
+++ b/src/stringify/stringifyDocument.ts
@@ -65,12 +65,26 @@ export function stringifyDocument(
   } else {
     lines.push(stringify(doc.contents, ctx))
   }
-  let dc = doc.comment
-  if (dc && chompKeep) dc = dc.replace(/^\n+/, '')
-  if (dc) {
-    if ((!chompKeep || contentComment) && lines[lines.length - 1] !== '')
-      lines.push('')
-    lines.push(indentComment(commentString(dc), ''))
+  if (doc.directives?.docEnd) {
+    if (doc.comment) {
+      const cs = commentString(doc.comment)
+      if (cs.includes('\n')) {
+        lines.push('...')
+        lines.push(indentComment(cs, ''))
+      } else {
+        lines.push(`... ${cs}`)
+      }
+    } else {
+      lines.push('...')
+    }
+  } else {
+    let dc = doc.comment
+    if (dc && chompKeep) dc = dc.replace(/^\n+/, '')
+    if (dc) {
+      if ((!chompKeep || contentComment) && lines[lines.length - 1] !== '')
+        lines.push('')
+      lines.push(indentComment(commentString(dc), ''))
+    }
   }
   return lines.join('\n') + '\n'
 }

--- a/src/test-events.ts
+++ b/src/test-events.ts
@@ -47,8 +47,7 @@ export function testEvents(src: string) {
       const doc = docs[i]
       let root = doc.contents
       if (Array.isArray(root)) root = root[0]
-      // eslint-disable-next-line no-sparse-arrays
-      const [rootStart, , rootEnd] = doc.range || [0, , 0]
+      const [rootStart] = doc.range || [0]
       const error = doc.errors[0]
       if (error && (!error.pos || error.pos[0] < rootStart)) throw new Error()
       let docStart = '+DOC'
@@ -59,10 +58,7 @@ export function testEvents(src: string) {
       addEvents(events, doc, error?.pos[0] ?? -1, root)
 
       let docEnd = '-DOC'
-      if (rootEnd) {
-        const post = src.slice(rootStart, rootEnd)
-        if (/^\.\.\.($|\s)/m.test(post)) docEnd += ' ...'
-      }
+      if (doc.directives.docEnd) docEnd += ' ...'
       events.push(docEnd)
     }
   } catch (e) {

--- a/src/test-events.ts
+++ b/src/test-events.ts
@@ -52,7 +52,7 @@ export function testEvents(src: string) {
       const error = doc.errors[0]
       if (error && (!error.pos || error.pos[0] < rootStart)) throw new Error()
       let docStart = '+DOC'
-      if (doc.directives.marker) docStart += ' ---'
+      if (doc.directives.docStart) docStart += ' ---'
       else if (doc.contents && doc.contents.range[2] === doc.contents.range[0])
         continue
       events.push(docStart)

--- a/tests/doc/YAML-1.1.spec.js
+++ b/tests/doc/YAML-1.1.spec.js
@@ -47,9 +47,9 @@ test('Use preceding directives if none defined', () => {
     }
   ])
   expect(docs.map(String)).toMatchObject([
-    '!bar "First document"\n',
+    '!bar "First document"\n...\n',
     '%TAG ! !foo\n---\n!bar "With directives"\n',
-    '%TAG ! !foo\n---\n!bar "Using previous TAG directive"\n',
+    '%TAG ! !foo\n---\n!bar "Using previous TAG directive"\n...\n',
     '%YAML 1.1\n---\n!bar "Reset settings"\n',
     '%YAML 1.1\n---\n!bar "Using previous YAML directive"\n'
   ])

--- a/tests/doc/YAML-1.2.spec.js
+++ b/tests/doc/YAML-1.2.spec.js
@@ -1823,7 +1823,7 @@ for (const section in spec) {
         })
         if (special) special(src)
         if (!errors) {
-          const src2 = documents.map(doc => String(doc)).join('\n...\n')
+          const src2 = documents.map(String).join('')
           const documents2 = YAML.parseAllDocuments(src2, {
             prettyErrors: false
           })

--- a/tests/yaml-test-suite.ts
+++ b/tests/yaml-test-suite.ts
@@ -123,9 +123,7 @@ for (const dir of testDirs) {
       if (!error) {
         if (json) {
           test_('stringfy+re-parse', () => {
-            const src2 =
-              docs.map(doc => String(doc).replace(/\n$/, '')).join('\n...\n') +
-              '\n'
+            const src2 = docs.map(String).join('')
             const docs2 = parseAllDocuments(src2, { resolveKnownTags: false })
             testJsonMatch(docs2, json)
           })


### PR DESCRIPTION
Fixes #368, CC @ferrarimarco

This PR contains a **BREAKING CHANGE**, as it renames the `directives.marker` to `directives.docStart`. The behaviour of the property stays the same, though.

Next to that, we add `directives.docEnd` to mark whether the document contains a `...` doc-end marker.