### PR TITLE
Add `YAML.visitAsync()`

### DIFF
--- a/docs/01_intro.md
+++ b/docs/01_intro.md
@@ -74,9 +74,9 @@ import {
 <!-- prettier-ignore -->
 ```js
 import {
-  isAlias, isCollection, isMap,
-  isNode, isPair, isScalar, isSeq,
-  Scalar, visit, YAMLMap, YAMLSeq
+  isAlias, isCollection, isMap, isNode,
+  isPair, isScalar, isSeq, Scalar,
+  visit, visitAsync, YAMLMap, YAMLSeq
 } from 'yaml'
 ```
 
@@ -88,6 +88,7 @@ import {
 - [`doc.createNode(value, options?): Node`](#creating-nodes)
 - [`doc.createPair(key, value): Pair`](#creating-nodes)
 - [`visit(node, visitor)`](#modifying-nodes)
+- [`visitAsync(node, visitor)`](#modifying-nodes)
 
 <h3>Parsing YAML</h3>
 

--- a/docs/05_content_nodes.md
+++ b/docs/05_content_nodes.md
@@ -342,7 +342,7 @@ In general, it's safe to modify nodes manually, e.g. splicing the `items` array 
 For operations on nodes at a known location in the tree, it's probably easiest to use `doc.getIn(path, true)` to access them.
 For more complex or general operations, a visitor API is provided:
 
-#### `YAML.visit(node, visitor)`
+#### `YAML.visit(node, visitor): void`
 
 Apply a visitor to an AST node or document.
 
@@ -366,6 +366,12 @@ The return value of the visitor may be used to control the traversal:
 
 If `visitor` is a single function, it will be called with all values encountered in the tree, including e.g. `null` values.
 Alternatively, separate visitor functions may be defined for each `Map`, `Pair`, `Seq`, `Alias` and `Scalar` node.
+
+#### `YAML.visitAsync(node, visitor): Promise<void>`
+
+The same as `visit()`,
+but allows for visitor functions that return a promise
+which resolves to one of the above-defined control values.
 
 ## Comments and Blank Lines
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,4 +49,11 @@ export {
 export type { TagId, Tags } from './schema/tags'
 export type { CollectionTag, ScalarTag } from './schema/types'
 
-export { visit, visitor, visitorFn } from './visit.js'
+export {
+  asyncVisitor,
+  asyncVisitorFn,
+  visit,
+  visitAsync,
+  visitor,
+  visitorFn
+} from './visit.js'

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -39,6 +39,31 @@ export type visitor =
       Value?: visitorFn<Scalar | YAMLMap | YAMLSeq>
     }
 
+export type asyncVisitorFn<T> = (
+  key: number | 'key' | 'value' | null,
+  node: T,
+  path: readonly (Document | Node | Pair)[]
+) =>
+  | void
+  | symbol
+  | number
+  | Node
+  | Pair
+  | Promise<void | symbol | number | Node | Pair>
+
+export type asyncVisitor =
+  | asyncVisitorFn<unknown>
+  | {
+      Alias?: asyncVisitorFn<Alias>
+      Collection?: asyncVisitorFn<YAMLMap | YAMLSeq>
+      Map?: asyncVisitorFn<YAMLMap>
+      Node?: asyncVisitorFn<Alias | Scalar | YAMLMap | YAMLSeq>
+      Pair?: asyncVisitorFn<Pair>
+      Scalar?: asyncVisitorFn<Scalar>
+      Seq?: asyncVisitorFn<YAMLSeq>
+      Value?: asyncVisitorFn<Scalar | YAMLMap | YAMLSeq>
+    }
+
 /**
  * Apply a visitor to an AST node or document.
  *
@@ -69,26 +94,171 @@ export type visitor =
  * and `Node` (alias, map, seq & scalar) targets. Of all these, only the most
  * specific defined one will be used for each node.
  */
-export function visit(
-  node: Node | Document | null,
-  visitor:
-    | visitorFn<unknown>
-    | {
-        Alias?: visitorFn<Alias>
-        Collection?: visitorFn<YAMLMap | YAMLSeq>
-        Map?: visitorFn<YAMLMap>
-        Node?: visitorFn<Alias | Scalar | YAMLMap | YAMLSeq>
-        Pair?: visitorFn<Pair>
-        Scalar?: visitorFn<Scalar>
-        Seq?: visitorFn<YAMLSeq>
-        Value?: visitorFn<Scalar | YAMLMap | YAMLSeq>
+export function visit(node: Node | Document | null, visitor: visitor) {
+  const visitor_ = initVisitor(visitor)
+  if (isDocument(node)) {
+    const cd = visit_(null, node.contents, visitor_, Object.freeze([node]))
+    if (cd === REMOVE) node.contents = null
+  } else visit_(null, node, visitor_, Object.freeze([]))
+}
+
+// Without the `as symbol` casts, TS declares these in the `visit`
+// namespace using `var`, but then complains about that because
+// `unique symbol` must be `const`.
+
+/** Terminate visit traversal completely */
+visit.BREAK = BREAK as symbol
+
+/** Do not visit the children of the current node */
+visit.SKIP = SKIP as symbol
+
+/** Remove the current node */
+visit.REMOVE = REMOVE as symbol
+
+function visit_(
+  key: number | 'key' | 'value' | null,
+  node: unknown,
+  visitor: visitor,
+  path: readonly (Document | Node | Pair)[]
+): number | symbol | void {
+  const ctrl = callVisitor(key, node, visitor, path)
+
+  if (isNode(ctrl) || isPair(ctrl)) {
+    replaceNode(key, path, ctrl)
+    return visit_(key, ctrl, visitor, path)
+  }
+
+  if (typeof ctrl !== 'symbol') {
+    if (isCollection(node)) {
+      path = Object.freeze(path.concat(node))
+      for (let i = 0; i < node.items.length; ++i) {
+        const ci = visit_(i, node.items[i], visitor, path)
+        if (typeof ci === 'number') i = ci - 1
+        else if (ci === BREAK) return BREAK
+        else if (ci === REMOVE) {
+          node.items.splice(i, 1)
+          i -= 1
+        }
       }
+    } else if (isPair(node)) {
+      path = Object.freeze(path.concat(node))
+      const ck = visit_('key', node.key, visitor, path)
+      if (ck === BREAK) return BREAK
+      else if (ck === REMOVE) node.key = null
+      const cv = visit_('value', node.value, visitor, path)
+      if (cv === BREAK) return BREAK
+      else if (cv === REMOVE) node.value = null
+    }
+  }
+
+  return ctrl
+}
+
+/**
+ * Apply an async visitor to an AST node or document.
+ *
+ * Walks through the tree (depth-first) starting from `node`, calling a
+ * `visitor` function with three arguments:
+ *   - `key`: For sequence values and map `Pair`, the node's index in the
+ *     collection. Within a `Pair`, `'key'` or `'value'`, correspondingly.
+ *     `null` for the root node.
+ *   - `node`: The current node.
+ *   - `path`: The ancestry of the current node.
+ *
+ * The return value of the visitor may be used to control the traversal:
+ *   - `Promise`: Must resolve to one of the following values
+ *   - `undefined` (default): Do nothing and continue
+ *   - `visit.SKIP`: Do not visit the children of this node, continue with next
+ *     sibling
+ *   - `visit.BREAK`: Terminate traversal completely
+ *   - `visit.REMOVE`: Remove the current node, then continue with the next one
+ *   - `Node`: Replace the current node, then continue by visiting it
+ *   - `number`: While iterating the items of a sequence or map, set the index
+ *     of the next step. This is useful especially if the index of the current
+ *     node has changed.
+ *
+ * If `visitor` is a single function, it will be called with all values
+ * encountered in the tree, including e.g. `null` values. Alternatively,
+ * separate visitor functions may be defined for each `Map`, `Pair`, `Seq`,
+ * `Alias` and `Scalar` node. To define the same visitor function for more than
+ * one node type, use the `Collection` (map and seq), `Value` (map, seq & scalar)
+ * and `Node` (alias, map, seq & scalar) targets. Of all these, only the most
+ * specific defined one will be used for each node.
+ */
+export async function visitAsync(
+  node: Node | Document | null,
+  visitor: asyncVisitor
 ) {
+  const visitor_ = initVisitor(visitor)
+  if (isDocument(node)) {
+    const cd = await visitAsync_(
+      null,
+      node.contents,
+      visitor_,
+      Object.freeze([node])
+    )
+    if (cd === REMOVE) node.contents = null
+  } else await visitAsync_(null, node, visitor_, Object.freeze([]))
+}
+
+// Without the `as symbol` casts, TS declares these in the `visit`
+// namespace using `var`, but then complains about that because
+// `unique symbol` must be `const`.
+
+/** Terminate visit traversal completely */
+visitAsync.BREAK = BREAK as symbol
+
+/** Do not visit the children of the current node */
+visitAsync.SKIP = SKIP as symbol
+
+/** Remove the current node */
+visitAsync.REMOVE = REMOVE as symbol
+
+async function visitAsync_(
+  key: number | 'key' | 'value' | null,
+  node: unknown,
+  visitor: asyncVisitor,
+  path: readonly (Document | Node | Pair)[]
+): Promise<number | symbol | void> {
+  const ctrl = await callVisitor(key, node, visitor, path)
+
+  if (isNode(ctrl) || isPair(ctrl)) {
+    replaceNode(key, path, ctrl)
+    return visitAsync_(key, ctrl, visitor, path)
+  }
+
+  if (typeof ctrl !== 'symbol') {
+    if (isCollection(node)) {
+      path = Object.freeze(path.concat(node))
+      for (let i = 0; i < node.items.length; ++i) {
+        const ci = await visitAsync_(i, node.items[i], visitor, path)
+        if (typeof ci === 'number') i = ci - 1
+        else if (ci === BREAK) return BREAK
+        else if (ci === REMOVE) {
+          node.items.splice(i, 1)
+          i -= 1
+        }
+      }
+    } else if (isPair(node)) {
+      path = Object.freeze(path.concat(node))
+      const ck = await visitAsync_('key', node.key, visitor, path)
+      if (ck === BREAK) return BREAK
+      else if (ck === REMOVE) node.key = null
+      const cv = await visitAsync_('value', node.value, visitor, path)
+      if (cv === BREAK) return BREAK
+      else if (cv === REMOVE) node.value = null
+    }
+  }
+
+  return ctrl
+}
+
+function initVisitor<V extends visitor | asyncVisitor>(visitor: V) {
   if (
     typeof visitor === 'object' &&
     (visitor.Collection || visitor.Node || visitor.Value)
   ) {
-    visitor = Object.assign(
+    return Object.assign(
       {
         Alias: visitor.Node,
         Map: visitor.Node,
@@ -107,83 +277,52 @@ export function visit(
       visitor
     )
   }
-  if (isDocument(node)) {
-    const cd = _visit(null, node.contents, visitor, Object.freeze([node]))
-    if (cd === REMOVE) node.contents = null
-  } else _visit(null, node, visitor, Object.freeze([]))
+
+  return visitor
 }
 
-// Without the `as symbol` casts, TS declares these in the `visit`
-// namespace using `var`, but then complains about that because
-// `unique symbol` must be `const`.
-
-/** Terminate visit traversal completely */
-visit.BREAK = BREAK as symbol
-
-/** Do not visit the children of the current node */
-visit.SKIP = SKIP as symbol
-
-/** Remove the current node */
-visit.REMOVE = REMOVE as symbol
-
-function _visit(
+function callVisitor(
   key: number | 'key' | 'value' | null,
   node: unknown,
   visitor: visitor,
   path: readonly (Document | Node | Pair)[]
+): ReturnType<visitorFn<unknown>>
+function callVisitor(
+  key: number | 'key' | 'value' | null,
+  node: unknown,
+  visitor: asyncVisitor,
+  path: readonly (Document | Node | Pair)[]
+): ReturnType<asyncVisitorFn<unknown>>
+function callVisitor(
+  key: number | 'key' | 'value' | null,
+  node: unknown,
+  visitor: visitor | asyncVisitor,
+  path: readonly (Document | Node | Pair)[]
+): ReturnType<visitorFn<unknown>> | ReturnType<asyncVisitorFn<unknown>> {
+  if (typeof visitor === 'function') return visitor(key, node, path)
+  if (isMap(node)) return visitor.Map?.(key, node, path)
+  if (isSeq(node)) return visitor.Seq?.(key, node, path)
+  if (isPair(node)) return visitor.Pair?.(key, node, path)
+  if (isScalar(node)) return visitor.Scalar?.(key, node, path)
+  if (isAlias(node)) return visitor.Alias?.(key, node, path)
+  return undefined
+}
+
+function replaceNode(
+  key: number | 'key' | 'value' | null,
+  path: readonly (Document | Node | Pair)[],
+  node: Node | Pair
 ): number | symbol | void {
-  let ctrl: void | symbol | number | Node | Pair = undefined
-  if (typeof visitor === 'function') ctrl = visitor(key, node, path)
-  else if (isMap(node)) {
-    if (visitor.Map) ctrl = visitor.Map(key, node, path)
-  } else if (isSeq(node)) {
-    if (visitor.Seq) ctrl = visitor.Seq(key, node, path)
-  } else if (isPair(node)) {
-    if (visitor.Pair) ctrl = visitor.Pair(key, node, path)
-  } else if (isScalar(node)) {
-    if (visitor.Scalar) ctrl = visitor.Scalar(key, node, path)
-  } else if (isAlias(node)) {
-    if (visitor.Alias) ctrl = visitor.Alias(key, node, path)
+  const parent = path[path.length - 1]
+  if (isCollection(parent)) {
+    parent.items[key as number] = node
+  } else if (isPair(parent)) {
+    if (key === 'key') parent.key = node
+    else parent.value = node
+  } else if (isDocument(parent)) {
+    parent.contents = node
+  } else {
+    const pt = isAlias(parent) ? 'alias' : 'scalar'
+    throw new Error(`Cannot replace node with ${pt} parent`)
   }
-
-  if (isNode(ctrl) || isPair(ctrl)) {
-    const parent = path[path.length - 1]
-    if (isCollection(parent)) {
-      parent.items[key as number] = ctrl
-    } else if (isPair(parent)) {
-      if (key === 'key') parent.key = ctrl
-      else parent.value = ctrl
-    } else if (isDocument(parent)) {
-      parent.contents = ctrl
-    } else {
-      const pt = isAlias(parent) ? 'alias' : 'scalar'
-      throw new Error(`Cannot replace node with ${pt} parent`)
-    }
-    return _visit(key, ctrl, visitor, path)
-  }
-
-  if (typeof ctrl !== 'symbol') {
-    if (isCollection(node)) {
-      path = Object.freeze(path.concat(node))
-      for (let i = 0; i < node.items.length; ++i) {
-        const ci = _visit(i, node.items[i], visitor, path)
-        if (typeof ci === 'number') i = ci - 1
-        else if (ci === BREAK) return BREAK
-        else if (ci === REMOVE) {
-          node.items.splice(i, 1)
-          i -= 1
-        }
-      }
-    } else if (isPair(node)) {
-      path = Object.freeze(path.concat(node))
-      const ck = _visit('key', node.key, visitor, path)
-      if (ck === BREAK) return BREAK
-      else if (ck === REMOVE) node.key = null
-      const cv = _visit('value', node.value, visitor, path)
-      if (cv === BREAK) return BREAK
-      else if (cv === REMOVE) node.value = null
-    }
-  }
-
-  return ctrl
 }

--- a/tests/visit.ts
+++ b/tests/visit.ts
@@ -1,229 +1,242 @@
-import { Document, isSeq, parseDocument, Scalar, visit } from 'yaml'
+import { Document, isSeq, parseDocument, Scalar, visit, visitAsync } from 'yaml'
 
 const coll = { items: {} }
 
-test('Map', () => {
-  const doc = parseDocument('{ one: 1, two }')
-  const fn = jest.fn()
-  visit(doc, { Map: fn, Pair: fn, Seq: fn, Alias: fn, Scalar: fn })
-  expect(fn.mock.calls).toMatchObject([
-    [null, coll, [{}]],
-    [0, { key: {}, value: {} }, [{}, {}]],
-    ['key', { type: 'PLAIN', value: 'one' }, [{}, {}, {}]],
-    ['value', { type: 'PLAIN', value: 1 }, [{}, {}, {}]],
-    [1, { key: {}, value: {} }, [{}, {}]],
-    ['key', { type: 'PLAIN', value: 'two' }, [{}, {}, {}]]
-  ])
-})
+for (const [visit_, title] of [
+  [visit, 'visit()'],
+  [visitAsync, 'visitAsync()']
+] as const) {
+  describe(title, () => {
+    test('Map', async () => {
+      const doc = parseDocument('{ one: 1, two }')
+      const fn = jest.fn()
+      await visit_(doc, { Map: fn, Pair: fn, Seq: fn, Alias: fn, Scalar: fn })
+      expect(fn.mock.calls).toMatchObject([
+        [null, coll, [{}]],
+        [0, { key: {}, value: {} }, [{}, {}]],
+        ['key', { type: 'PLAIN', value: 'one' }, [{}, {}, {}]],
+        ['value', { type: 'PLAIN', value: 1 }, [{}, {}, {}]],
+        [1, { key: {}, value: {} }, [{}, {}]],
+        ['key', { type: 'PLAIN', value: 'two' }, [{}, {}, {}]]
+      ])
+    })
 
-test('Seq', () => {
-  const doc = parseDocument('- 1\n- two\n')
-  const fn = jest.fn()
-  visit(doc, { Map: fn, Pair: fn, Seq: fn, Alias: fn, Scalar: fn })
-  expect(fn.mock.calls).toMatchObject([
-    [null, coll, [{ contents: {} }]],
-    [0, { type: 'PLAIN', value: 1 }, [{ contents: {} }, coll]],
-    [1, { type: 'PLAIN', value: 'two' }, [{ contents: {} }, coll]]
-  ])
-})
+    test('Seq', async () => {
+      const doc = parseDocument('- 1\n- two\n')
+      const fn = jest.fn()
+      await visit_(doc, { Map: fn, Pair: fn, Seq: fn, Alias: fn, Scalar: fn })
+      expect(fn.mock.calls).toMatchObject([
+        [null, coll, [{ contents: {} }]],
+        [0, { type: 'PLAIN', value: 1 }, [{ contents: {} }, coll]],
+        [1, { type: 'PLAIN', value: 'two' }, [{ contents: {} }, coll]]
+      ])
+    })
 
-test('Alias', () => {
-  const doc = parseDocument('- &a 1\n- *a\n')
-  const fn = jest.fn()
-  visit(doc, { Map: fn, Pair: fn, Seq: fn, Alias: fn, Scalar: fn })
-  expect(fn.mock.calls).toMatchObject([
-    [null, coll, [{}]],
-    [0, { type: 'PLAIN', value: 1, anchor: 'a' }, [{}, {}]],
-    [1, { source: 'a' }, [{}, {}]]
-  ])
-})
+    test('Alias', async () => {
+      const doc = parseDocument('- &a 1\n- *a\n')
+      const fn = jest.fn()
+      await visit_(doc, { Map: fn, Pair: fn, Seq: fn, Alias: fn, Scalar: fn })
+      expect(fn.mock.calls).toMatchObject([
+        [null, coll, [{}]],
+        [0, { type: 'PLAIN', value: 1, anchor: 'a' }, [{}, {}]],
+        [1, { source: 'a' }, [{}, {}]]
+      ])
+    })
 
-test('Seq in Map', () => {
-  const doc = parseDocument('foo:\n  - "one"\n  - \'two\'\n')
-  const fn = jest.fn()
-  visit(doc, { Map: fn, Pair: fn, Seq: fn, Alias: fn, Scalar: fn })
-  expect(fn.mock.calls).toMatchObject([
-    [null, coll, [{}]],
-    [0, { key: {}, value: {} }, [{}, {}]],
-    ['key', { type: 'PLAIN', value: 'foo' }, [{}, {}, {}]],
-    ['value', coll, [{}, {}, {}]],
-    [0, { type: 'QUOTE_DOUBLE', value: 'one' }, [{}, {}, {}, {}]],
-    [1, { type: 'QUOTE_SINGLE', value: 'two' }, [{}, {}, {}, {}]]
-  ])
-})
+    test('Seq in Map', async () => {
+      const doc = parseDocument('foo:\n  - "one"\n  - \'two\'\n')
+      const fn = jest.fn()
+      await visit_(doc, { Map: fn, Pair: fn, Seq: fn, Alias: fn, Scalar: fn })
+      expect(fn.mock.calls).toMatchObject([
+        [null, coll, [{}]],
+        [0, { key: {}, value: {} }, [{}, {}]],
+        ['key', { type: 'PLAIN', value: 'foo' }, [{}, {}, {}]],
+        ['value', coll, [{}, {}, {}]],
+        [0, { type: 'QUOTE_DOUBLE', value: 'one' }, [{}, {}, {}, {}]],
+        [1, { type: 'QUOTE_SINGLE', value: 'two' }, [{}, {}, {}, {}]]
+      ])
+    })
 
-test('Visit called with non-Document root', () => {
-  const doc = parseDocument('foo:\n  - "one"\n  - \'two\'\n')
-  const fn = jest.fn()
-  visit(doc.get('foo') as Scalar, fn)
-  expect(fn.mock.calls).toMatchObject([
-    [null, coll, []],
-    [0, { type: 'QUOTE_DOUBLE', value: 'one' }, [coll]],
-    [1, { type: 'QUOTE_SINGLE', value: 'two' }, [coll]]
-  ])
-})
+    test('Visit called with non-Document root', async () => {
+      const doc = parseDocument('foo:\n  - "one"\n  - \'two\'\n')
+      const fn = jest.fn()
+      await visit_(doc.get('foo') as Scalar, fn)
+      expect(fn.mock.calls).toMatchObject([
+        [null, coll, []],
+        [0, { type: 'QUOTE_DOUBLE', value: 'one' }, [coll]],
+        [1, { type: 'QUOTE_SINGLE', value: 'two' }, [coll]]
+      ])
+    })
 
-test('Visiting a constructed document', () => {
-  const doc = new Document([1, 'two'])
-  const fn = jest.fn()
-  visit(doc, { Map: fn, Pair: fn, Seq: fn, Alias: fn, Scalar: fn })
-  expect(fn.mock.calls).toMatchObject([
-    [null, { items: [{}, {}] }, [{}]],
-    [0, { value: 1 }, [{}, {}]],
-    [1, { value: 'two' }, [{}, {}]]
-  ])
-  expect(String(doc)).toBe('- 1\n- two\n')
-})
+    test('Visiting a constructed document', async () => {
+      const doc = new Document([1, 'two'])
+      const fn = jest.fn()
+      await visit_(doc, { Map: fn, Pair: fn, Seq: fn, Alias: fn, Scalar: fn })
+      expect(fn.mock.calls).toMatchObject([
+        [null, { items: [{}, {}] }, [{}]],
+        [0, { value: 1 }, [{}, {}]],
+        [1, { value: 'two' }, [{}, {}]]
+      ])
+      expect(String(doc)).toBe('- 1\n- two\n')
+    })
 
-test('Only Scalar defined', () => {
-  const doc = parseDocument('foo:\n  - "one"\n  - \'two\'\n')
-  const Scalar = jest.fn()
-  visit(doc, { Scalar })
-  expect(Scalar.mock.calls).toMatchObject([
-    ['key', { type: 'PLAIN', value: 'foo' }, [{}, {}, {}]],
-    [0, { type: 'QUOTE_DOUBLE', value: 'one' }, [{}, {}, {}, {}]],
-    [1, { type: 'QUOTE_SINGLE', value: 'two' }, [{}, {}, {}, {}]]
-  ])
-})
+    test('Only Scalar defined', async () => {
+      const doc = parseDocument('foo:\n  - "one"\n  - \'two\'\n')
+      const Scalar = jest.fn()
+      await visit_(doc, { Scalar })
+      expect(Scalar.mock.calls).toMatchObject([
+        ['key', { type: 'PLAIN', value: 'foo' }, [{}, {}, {}]],
+        [0, { type: 'QUOTE_DOUBLE', value: 'one' }, [{}, {}, {}, {}]],
+        [1, { type: 'QUOTE_SINGLE', value: 'two' }, [{}, {}, {}, {}]]
+      ])
+    })
 
-test('Function as visitor', () => {
-  const doc = parseDocument('{ one: 1, two }')
-  const fn = jest.fn()
-  visit(doc, fn)
-  expect(fn.mock.calls).toMatchObject([
-    [null, coll, [{}]],
-    [0, { key: {}, value: {} }, [{}, {}]],
-    ['key', { type: 'PLAIN', value: 'one' }, [{}, {}, {}]],
-    ['value', { type: 'PLAIN', value: 1 }, [{}, {}, {}]],
-    [1, { key: {}, value: {} }, [{}, {}]],
-    ['key', { type: 'PLAIN', value: 'two' }, [{}, {}, {}]],
-    ['value', null, [{}, {}, {}]]
-  ])
-})
+    test('Function as visitor', async () => {
+      const doc = parseDocument('{ one: 1, two }')
+      const fn = jest.fn()
+      await visit_(doc, fn)
+      expect(fn.mock.calls).toMatchObject([
+        [null, coll, [{}]],
+        [0, { key: {}, value: {} }, [{}, {}]],
+        ['key', { type: 'PLAIN', value: 'one' }, [{}, {}, {}]],
+        ['value', { type: 'PLAIN', value: 1 }, [{}, {}, {}]],
+        [1, { key: {}, value: {} }, [{}, {}]],
+        ['key', { type: 'PLAIN', value: 'two' }, [{}, {}, {}]],
+        ['value', null, [{}, {}, {}]]
+      ])
+    })
 
-test('Change key value within Pair', () => {
-  const doc = parseDocument('foo:\n  - "one"\n  - \'two\'\n')
-  visit(doc, {
-    Pair(_, pair) {
-      const sc = pair.key as Scalar
-      if (sc.value === 'foo') sc.value = 'bar'
-    }
+    test('Change key value within Pair', async () => {
+      const doc = parseDocument('foo:\n  - "one"\n  - \'two\'\n')
+      await visit_(doc, {
+        Pair(_, pair) {
+          const sc = pair.key as Scalar
+          if (sc.value === 'foo') sc.value = 'bar'
+        }
+      })
+      expect(String(doc)).toBe('bar:\n  - "one"\n  - \'two\'\n')
+    })
+
+    test('Change key value within Scalar', async () => {
+      const doc = parseDocument('foo:\n  - "one"\n  - \'two\'\n')
+      await visit_(doc, {
+        Scalar(key, node) {
+          if (key === 'key' && node.value === 'foo') node.value = 'bar'
+        }
+      })
+      expect(String(doc)).toBe('bar:\n  - "one"\n  - \'two\'\n')
+    })
+
+    test('Add item to Seq', async () => {
+      const doc = parseDocument('- one\n- two\n')
+      const Scalar = jest.fn()
+      await visit_(doc, {
+        Seq(_, seq) {
+          seq.items.push(doc.createNode('three'))
+        },
+        Scalar
+      })
+      expect(Scalar.mock.calls).toMatchObject([
+        [0, { type: 'PLAIN', value: 'one' }, [{}, {}]],
+        [1, { type: 'PLAIN', value: 'two' }, [{}, {}]],
+        [2, { value: 'three' }, [{}, {}]]
+      ])
+      expect(String(doc)).toBe('- one\n- two\n- three\n')
+    })
+
+    test('Do not visit block seq items', async () => {
+      const doc = parseDocument('foo:\n  - one\n  - two\nbar:\n')
+      const fn = jest.fn((_, node) => (isSeq(node) ? visit_.SKIP : undefined))
+      await visit_(doc, { Map: fn, Pair: fn, Seq: fn, Scalar: fn })
+      expect(fn.mock.calls).toMatchObject([
+        [null, coll, [{}]],
+        [0, { key: {}, value: {} }, [{}, {}]],
+        ['key', { type: 'PLAIN', value: 'foo' }, [{}, {}, {}]],
+        ['value', coll, [{}, {}, {}]],
+        [1, { key: {}, value: {} }, [{}, {}]],
+        ['key', { type: 'PLAIN', value: 'bar' }, [{}, {}, {}]],
+        ['value', { type: 'PLAIN', value: null }, [{}, {}, {}]]
+      ])
+    })
+
+    test('Break visit on command', async () => {
+      const doc = parseDocument('- one\n- two\n- three\n')
+      const Scalar = jest.fn((_, node) =>
+        node.value === 'two' ? visit_.BREAK : undefined
+      )
+      await visit_(doc, { Scalar })
+      expect(Scalar.mock.calls).toMatchObject([
+        [0, { type: 'PLAIN', value: 'one' }, [{}, {}]],
+        [1, { type: 'PLAIN', value: 'two' }, [{}, {}]]
+      ])
+    })
+
+    test('Modify seq item', async () => {
+      const doc = parseDocument('- one\n- two\n- three\n')
+      const Scalar = jest.fn((_, node) =>
+        node.value === 'two' ? doc.createNode(42) : undefined
+      )
+      await visit_(doc, { Scalar })
+      expect(Scalar.mock.calls).toMatchObject([
+        [0, { type: 'PLAIN', value: 'one' }, [{}, {}]],
+        [1, { type: 'PLAIN', value: 'two' }, [{}, {}]],
+        [1, { value: 42 }, [{}, {}]],
+        [2, { type: 'PLAIN', value: 'three' }, [{}, {}]]
+      ])
+      expect(String(doc)).toBe('- one\n- 42\n- three\n')
+    })
+
+    test('Skip seq item', async () => {
+      const doc = parseDocument('- one\n- two\n- three\n')
+      const Scalar = jest.fn(key => (key === 0 ? 2 : undefined))
+      await visit_(doc, { Scalar })
+      expect(Scalar.mock.calls).toMatchObject([
+        [0, { type: 'PLAIN', value: 'one' }, [{}, {}]],
+        [2, { type: 'PLAIN', value: 'three' }, [{}, {}]]
+      ])
+    })
+
+    test('Remove seq item', async () => {
+      const doc = parseDocument('- one\n- two\n- three\n')
+      const Scalar = jest.fn((_, node) =>
+        node.value === 'two' ? visit_.REMOVE : undefined
+      )
+      await visit_(doc, { Scalar })
+      expect(Scalar.mock.calls).toMatchObject([
+        [0, { type: 'PLAIN', value: 'one' }, [{}, {}]],
+        [1, { type: 'PLAIN', value: 'two' }, [{}, {}]],
+        [1, { type: 'PLAIN', value: 'three' }, [{}, {}]]
+      ])
+      expect(String(doc)).toBe('- one\n- three\n')
+    })
+
+    test('Remove map value', async () => {
+      const doc = parseDocument('one: 1\ntwo: 2\n')
+      const Scalar = jest.fn((key, node) =>
+        key === 'value' && node.value === 2 ? visit_.REMOVE : undefined
+      )
+      await visit_(doc, { Scalar })
+      expect(Scalar.mock.calls).toMatchObject([
+        ['key', { type: 'PLAIN', value: 'one' }, [{}, {}, {}]],
+        ['value', { type: 'PLAIN', value: 1 }, [{}, {}, {}]],
+        ['key', { type: 'PLAIN', value: 'two' }, [{}, {}, {}]],
+        ['value', { type: 'PLAIN', value: 2 }, [{}, {}, {}]]
+      ])
+      expect(String(doc)).toBe('one: 1\ntwo: null\n')
+    })
+
+    test('Fail to replace root node', async () => {
+      const doc = parseDocument('- one\n- two\n- three\n')
+      const Seq = jest.fn(() => doc.createNode(42))
+      if (visit_ === visit) {
+        expect(() => visit_(doc.contents, { Seq })).toThrow(
+          'Cannot replace node with scalar parent'
+        )
+      } else {
+        expect(visit_(doc.contents, { Seq })).rejects.toMatchObject({
+          message: 'Cannot replace node with scalar parent'
+        })
+      }
+    })
   })
-  expect(String(doc)).toBe('bar:\n  - "one"\n  - \'two\'\n')
-})
-
-test('Change key value within Scalar', () => {
-  const doc = parseDocument('foo:\n  - "one"\n  - \'two\'\n')
-  visit(doc, {
-    Scalar(key, node) {
-      if (key === 'key' && node.value === 'foo') node.value = 'bar'
-    }
-  })
-  expect(String(doc)).toBe('bar:\n  - "one"\n  - \'two\'\n')
-})
-
-test('Add item to Seq', () => {
-  const doc = parseDocument('- one\n- two\n')
-  const Scalar = jest.fn()
-  visit(doc, {
-    Seq(_, seq) {
-      seq.items.push(doc.createNode('three'))
-    },
-    Scalar
-  })
-  expect(Scalar.mock.calls).toMatchObject([
-    [0, { type: 'PLAIN', value: 'one' }, [{}, {}]],
-    [1, { type: 'PLAIN', value: 'two' }, [{}, {}]],
-    [2, { value: 'three' }, [{}, {}]]
-  ])
-  expect(String(doc)).toBe('- one\n- two\n- three\n')
-})
-
-test('Do not visit block seq items', () => {
-  const doc = parseDocument('foo:\n  - one\n  - two\nbar:\n')
-  const fn = jest.fn((_, node) => (isSeq(node) ? visit.SKIP : undefined))
-  visit(doc, { Map: fn, Pair: fn, Seq: fn, Scalar: fn })
-  expect(fn.mock.calls).toMatchObject([
-    [null, coll, [{}]],
-    [0, { key: {}, value: {} }, [{}, {}]],
-    ['key', { type: 'PLAIN', value: 'foo' }, [{}, {}, {}]],
-    ['value', coll, [{}, {}, {}]],
-    [1, { key: {}, value: {} }, [{}, {}]],
-    ['key', { type: 'PLAIN', value: 'bar' }, [{}, {}, {}]],
-    ['value', { type: 'PLAIN', value: null }, [{}, {}, {}]]
-  ])
-})
-
-test('Break visit on command', () => {
-  const doc = parseDocument('- one\n- two\n- three\n')
-  const Scalar = jest.fn((_, node) =>
-    node.value === 'two' ? visit.BREAK : undefined
-  )
-  visit(doc, { Scalar })
-  expect(Scalar.mock.calls).toMatchObject([
-    [0, { type: 'PLAIN', value: 'one' }, [{}, {}]],
-    [1, { type: 'PLAIN', value: 'two' }, [{}, {}]]
-  ])
-})
-
-test('Modify seq item', () => {
-  const doc = parseDocument('- one\n- two\n- three\n')
-  const Scalar = jest.fn((_, node) =>
-    node.value === 'two' ? doc.createNode(42) : undefined
-  )
-  visit(doc, { Scalar })
-  expect(Scalar.mock.calls).toMatchObject([
-    [0, { type: 'PLAIN', value: 'one' }, [{}, {}]],
-    [1, { type: 'PLAIN', value: 'two' }, [{}, {}]],
-    [1, { value: 42 }, [{}, {}]],
-    [2, { type: 'PLAIN', value: 'three' }, [{}, {}]]
-  ])
-  expect(String(doc)).toBe('- one\n- 42\n- three\n')
-})
-
-test('Skip seq item', () => {
-  const doc = parseDocument('- one\n- two\n- three\n')
-  const Scalar = jest.fn(key => (key === 0 ? 2 : undefined))
-  visit(doc, { Scalar })
-  expect(Scalar.mock.calls).toMatchObject([
-    [0, { type: 'PLAIN', value: 'one' }, [{}, {}]],
-    [2, { type: 'PLAIN', value: 'three' }, [{}, {}]]
-  ])
-})
-
-test('Remove seq item', () => {
-  const doc = parseDocument('- one\n- two\n- three\n')
-  const Scalar = jest.fn((_, node) =>
-    node.value === 'two' ? visit.REMOVE : undefined
-  )
-  visit(doc, { Scalar })
-  expect(Scalar.mock.calls).toMatchObject([
-    [0, { type: 'PLAIN', value: 'one' }, [{}, {}]],
-    [1, { type: 'PLAIN', value: 'two' }, [{}, {}]],
-    [1, { type: 'PLAIN', value: 'three' }, [{}, {}]]
-  ])
-  expect(String(doc)).toBe('- one\n- three\n')
-})
-
-test('Remove map value', () => {
-  const doc = parseDocument('one: 1\ntwo: 2\n')
-  const Scalar = jest.fn((key, node) =>
-    key === 'value' && node.value === 2 ? visit.REMOVE : undefined
-  )
-  visit(doc, { Scalar })
-  expect(Scalar.mock.calls).toMatchObject([
-    ['key', { type: 'PLAIN', value: 'one' }, [{}, {}, {}]],
-    ['value', { type: 'PLAIN', value: 1 }, [{}, {}, {}]],
-    ['key', { type: 'PLAIN', value: 'two' }, [{}, {}, {}]],
-    ['value', { type: 'PLAIN', value: 2 }, [{}, {}, {}]]
-  ])
-  expect(String(doc)).toBe('one: 1\ntwo: null\n')
-})
-
-test('Fail to replace root node', () => {
-  const doc = parseDocument('- one\n- two\n- three\n')
-  const Seq = jest.fn(() => doc.createNode(42))
-  expect(() => visit(doc.contents, { Seq })).toThrow(
-    'Cannot replace node with scalar parent'
-  )
-})
+}


### PR DESCRIPTION
Fixes #362 by adding a utility function `visitAsync(node, visitor): Promise<void>`.

Its behaviour is the same as `visit()`, but it allows for visitor functions that return a promise which resolves to one of the control values.

A new function turned out to be necessary to allow keeping `visit()` synchronous when called with synchronous visitors.