### PR TITLE
Allow for pathlike aliases

### DIFF
--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -423,11 +423,14 @@ export class Document<T = unknown> {
       mapAsMap: mapAsMap === true,
       mapKeyWarned: false,
       maxAliasCount: typeof maxAliasCount === 'number' ? maxAliasCount : 100,
+      resolved: new WeakMap(),
       stringify
     }
     const res = toJS(this.contents, jsonArg ?? '', ctx)
-    if (typeof onAnchor === 'function')
-      for (const { count, res } of ctx.anchors.values()) onAnchor(res, count)
+    if (typeof onAnchor === 'function') {
+      for (const [node, { count }] of ctx.anchors)
+        onAnchor(ctx.resolved.get(node), count)
+    }
     return typeof reviver === 'function'
       ? applyReviver(reviver, { '': res }, '', res)
       : res

--- a/tests/next.ts
+++ b/tests/next.ts
@@ -1,0 +1,55 @@
+import { parse, parseDocument } from 'yaml'
+import { source } from './_utils'
+
+describe('relative-path alias', () => {
+  test('resolves a map value by key', () => {
+    const src = source`
+      - &a { foo: 1 }
+      - *a/foo
+    `
+    expect(parse(src, { version: 'next' })).toEqual([{ foo: 1 }, 1])
+  })
+
+  test('resolves a sequence value by index', () => {
+    const src = source`
+      - &a [ 2, 4, 8 ]
+      - *a/1
+    `
+    expect(parse(src, { version: 'next' })).toEqual([[2, 4, 8], 4])
+  })
+
+  test('resolves a deeper value', () => {
+    const src = source`
+      - &a { foo: [1, 42] }
+      - *a/foo/1
+    `
+    expect(parse(src, { version: 'next' })).toEqual([{ foo: [1, 42] }, 42])
+  })
+
+  test('resolves to an equal value', () => {
+    const src = source`
+      - &a { foo: [42] }
+      - *a/foo
+    `
+    const res = parse(src, { version: 'next' })
+    expect(res[1]).toBe(res[0].foo)
+  })
+
+  test('does not resolve an alias value', () => {
+    const src = source`
+      - &a { foo: *a }
+      - *a/foo
+    `
+    const doc = parseDocument(src, { version: 'next' })
+    expect(() => doc.toJS()).toThrow(ReferenceError)
+  })
+
+  test('does not resolve a later value', () => {
+    const src = source`
+      - *a/foo
+      - &a { foo: 1 }
+    `
+    const doc = parseDocument(src, { version: 'next' })
+    expect(() => doc.toJS()).toThrow(ReferenceError)
+  })
+})


### PR DESCRIPTION
This enables the resolution of YAML looking like this:

```yaml
- &foo 
  bar:
    - 1
    - 2
    - 42
- *foo/bar/2
```
to resolve as:
```js
[
  { bar: [1, 2, 42] },
  42
]
```

In other words, if an alias contains a `/` character, it is resolved as follows:
1. If a preceding anchor matches the alias exactly, use that and resolve the value as previously.
2. Else, find the last longest preceding anchor which matches the start of the alias if it were followed by a `/` character.
3. Considering the node of that anchor as a root node, use the rest of the alias as a `/` separated path to the target node.
4. Provided that the target node is a scalar or a collection, resolve it as the alias's value.

Put together, this means that all existing valid YAML continues to have the exact same meaning as before, but it's possible for an alias to point at nodes within a structure with an anchor. As with anchors, JS equality is maintained across aliased values, so e.g. this works:

```js
import { parse } from 'yaml'

const src = `
  - &foo { bar: [1, 2, 42] }
  - { alias: *foo/bar }
`
const res = parse(src, { version: 'next' })

Array.isArray(res[0].bar) // true
res[0].bar === res[1].alias // true
```

In the implementation, this currently requires tracking some additional nodes during the native value composition, but a later optimisation should be able to reduce the impact of that.

This feature is not yet in the YAML spec, and so requires using `version: 'next'` as an option. Its implementation is also not guaranteed to follow semver.