### PR TITLE
[toJSON] empty string to non-null empty object.

### DIFF
--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -414,6 +414,7 @@ export class Document<T extends Node = Node> {
     jsonArg,
     mapAsMap,
     maxAliasCount,
+    emptySourceAsObject,
     onAnchor,
     reviver
   }: ToJSOptions & { json?: boolean; jsonArg?: string | null } = {}): any {
@@ -423,6 +424,7 @@ export class Document<T extends Node = Node> {
       keep: !json,
       mapAsMap: mapAsMap === true,
       mapKeyWarned: false,
+      emptySourceAsObject: emptySourceAsObject === true,
       maxAliasCount: typeof maxAliasCount === 'number' ? maxAliasCount : 100,
       stringify
     }

--- a/src/nodes/Scalar.ts
+++ b/src/nodes/Scalar.ts
@@ -55,7 +55,18 @@ export class Scalar<T = unknown> extends NodeBase {
   }
 
   toJSON(arg?: any, ctx?: ToJSContext): any {
-    return ctx?.keep ? this.value : toJS(this.value, arg, ctx)
+    if (ctx?.keep)
+    {
+      return this.value;
+    }
+    if (ctx?.emptySourceAsObject) {
+      if (this.value == null) {
+        if (this.source?.length === 0) {
+          return {};
+        }
+      }
+    }
+    return toJS(this.value, arg, ctx)
   }
 
   toString() {

--- a/src/nodes/Scalar.ts
+++ b/src/nodes/Scalar.ts
@@ -55,16 +55,15 @@ export class Scalar<T = unknown> extends NodeBase {
   }
 
   toJSON(arg?: any, ctx?: ToJSContext): any {
-    if (ctx?.keep)
-    {
-      return this.value;
-    }
     if (ctx?.emptySourceAsObject) {
       if (this.value == null) {
         if (this.source?.length === 0) {
           return {};
         }
       }
+    }
+    if (ctx?.keep) {
+      return this.value;
     }
     return toJS(this.value, arg, ctx)
   }

--- a/src/nodes/toJS.ts
+++ b/src/nodes/toJS.ts
@@ -15,6 +15,7 @@ export interface ToJSContext {
   mapAsMap: boolean
   mapKeyWarned: boolean
   maxAliasCount: number
+  emptySourceAsObject: boolean
   onCreate?: (res: unknown) => void
 
   /** Requiring this directly in Pair would create circular dependencies */

--- a/src/options.ts
+++ b/src/options.ts
@@ -195,6 +195,13 @@ export type ToJSOptions = {
   mapAsMap?: boolean
 
   /**
+   * Convert empty source as empty Object
+   *
+   * Default: `false`
+   */
+  emptySourceAsObject?: boolean
+
+  /**
    * Prevent exponential entity expansion attacks by limiting data aliasing count;
    * set to `-1` to disable checks; `0` disallows all alias nodes.
    *

--- a/tests/to-json.ts
+++ b/tests/to-json.ts
@@ -1,0 +1,31 @@
+import { parseDocument } from 'yaml'
+
+describe('to-json', () => {
+  test('empty-source-as-null', () => {
+    const doc = parseDocument('foo: \nbar: 1234\nxxx: {}\nyyy: null')
+    const copy = doc.clone()
+
+    const json = copy.toJSON();
+
+    expect(json).toMatchObject({
+      foo: null,
+      bar: 1234,
+      xxx: {},
+      yyy: null
+    })
+  })
+
+  test('empty-source-as-non-null-object', () => {
+    const doc = parseDocument('foo: \nbar: 1234\nxxx: {}\nyyy: null')
+    const copy = doc.clone()
+
+    const json = copy.toJS({ json: true, emptySourceAsObject: true });
+
+    expect(json).toMatchObject({
+      foo: {},
+      bar: 1234,
+      xxx: {},
+      yyy: null
+    })
+  })
+});


### PR DESCRIPTION
Added a flag which allows conversion of empty strings to an empty object, instead of returning null.