### PR TITLE
Update addPairToJSMap.ts, missing ? operator

### DIFF
--- a/src/nodes/addPairToJSMap.ts
+++ b/src/nodes/addPairToJSMap.ts
@@ -13,7 +13,7 @@ export function addPairToJSMap(
   map: MapLike,
   { key, value }: Pair
 ) {
-  if (ctx?.doc.schema.merge && isMergeKey(key)) {
+  if (ctx?.doc?.schema.merge && isMergeKey(key)) {
     value = isAlias(value) ? value.resolve(ctx.doc) : value
     if (isSeq(value)) for (const it of value.items) mergeToJSMap(ctx, map, it)
     else if (Array.isArray(value))


### PR DESCRIPTION
Found while testing alias preservation, using the `visit` method:

```js
function parseWithAliases(str) {
  const aliases = new Map();
  const ast = yaml.parseDocument(str);
  yaml.visit(ast,function(key,node,path) {
    if (yaml.isAlias(node)) {
      aliases.set(node.source,node.resolve(ast).toJS());
    }
  });
  return { data: ast.toJS(), aliases };
}
```