### PR TITLE
[package.json] add types in exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "node": "./dist/index.js",
       "default": "./browser/index.js"
     },
     "./package.json": "./package.json",
     "./util": {
+      "types": "./dist/util.d.ts",
       "node": "./dist/util.js",
       "default": "./browser/dist/util.js"
     }


### PR DESCRIPTION
Starting from TS 4.7 ([see release note](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing)), we need to add a types field in the exports object when then path to the .d.ts file doesn’t match the file exposed.

If it isn’t set, we have the following error:

```
There are types at '[...]/node_modules/yaml/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'yaml' library may need to update its package.json or typings.
```

This should fix it by adding the same types as top level, but within the exports object