### PR TITLE
Do not require quotes for implicit keys with flow indicators

### DIFF
--- a/src/stringify/stringifyString.ts
+++ b/src/stringify/stringifyString.ts
@@ -280,7 +280,7 @@ function plainString(
   const { type, value } = item
   const { actualString, implicitKey, indent, indentStep, inFlow } = ctx
   if (
-    (implicitKey && /[\n[\]{},]/.test(value)) ||
+    (implicitKey && value.includes('\n')) ||
     (inFlow && /[[\]{},]/.test(value))
   ) {
     return quotedString(value, ctx)

--- a/tests/doc/stringify.ts
+++ b/tests/doc/stringify.ts
@@ -336,6 +336,11 @@ z:
     expect(String(doc)).toBe('a: 1\n? b: 2\n  c: 3\n')
   })
 
+  test('plain key containing flow indicators', () => {
+    const doc = YAML.parseDocument('foo[{}]: bar')
+    expect(doc.toString()).toBe('foo[{}]: bar\n')
+  })
+
   describe('No extra whitespace for empty values', () => {
     const getDoc = () =>
       new YAML.Document<YAML.YAMLMap<YAML.Scalar, YAML.Scalar>, false>({


### PR DESCRIPTION
Fixes #493

The oddity here turned out to be in part caused by a mismatch in the YAML spec text & rules; I've filed yaml/yaml-spec#313 to add an errata for that. See there for more technical details, but the fix required here is removing one part of the check in the stringifier. I'd followed the YAML rules for the parser, but the YAML text for the stringifier, and the latter was wrong.