### PR TITLE
Fix malformed uri

### DIFF
--- a/src/doc/directives.ts
+++ b/src/doc/directives.ts
@@ -149,8 +149,9 @@ export class Directives {
     if (prefix) {
       try {
         return prefix + decodeURIComponent(suffix)
-      } catch (_) {
-        onError('Failed to decode suffix')
+      } catch (error) {
+        onError(String(error))
+        return null
       }
     }
     if (handle === '!') return source // local tag

--- a/src/doc/directives.ts
+++ b/src/doc/directives.ts
@@ -149,7 +149,7 @@ export class Directives {
     if (prefix) {
       try {
         return prefix + decodeURIComponent(suffix)
-      } catch (error) {
+      } catch (_) {
         onError('Failed to decode suffix')
       }
     }

--- a/src/doc/directives.ts
+++ b/src/doc/directives.ts
@@ -146,7 +146,13 @@ export class Directives {
     const [, handle, suffix] = source.match(/^(.*!)([^!]*)$/) as string[]
     if (!suffix) onError(`The ${source} tag has no suffix`)
     const prefix = this.tags[handle]
-    if (prefix) return prefix + decodeURIComponent(suffix)
+    if (prefix) {
+      try {
+        return prefix + decodeURIComponent(suffix)
+      } catch (error) {
+        onError('Failed to decode suffix')
+      }
+    }
     if (handle === '!') return source // local tag
 
     onError(`Could not resolve tag: ${source}`)

--- a/tests/doc/parse.ts
+++ b/tests/doc/parse.ts
@@ -819,11 +819,3 @@ describe('CRLF line endings', () => {
     expect(res).toBe('foo bar')
   })
 })
-
-describe('URI malformed', () => {
-  test('for parseDocument', () => {
-    const doc = YAML.parseDocument('!!%ee 0')
-    expect(doc.errors).toHaveLength(1)
-    expect(doc.errors[0].message).toMatch(/URI malformed/)
-  })
-})

--- a/tests/doc/parse.ts
+++ b/tests/doc/parse.ts
@@ -820,9 +820,10 @@ describe('CRLF line endings', () => {
   })
 })
 
-describe('Failed to decode suffix', () => {
-  test('rise in parse for malformed uri', () => {
-    const data = `[!!eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeJJJJJJJeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeebooleaeeeeeeeeeee-eeeeeeeee%eeeeeeeeeeeee[`
-    expect(() => YAML.parse(data)).toThrow(/Failed to decode suffix/)
+describe('URI malformed', () => {
+  test('for parseDocument', () => {
+    const doc = YAML.parseDocument('!!%ee 0')
+    expect(doc.errors).toHaveLength(1)
+    expect(doc.errors[0].message).toMatch(/URI malformed/)
   })
 })

--- a/tests/doc/parse.ts
+++ b/tests/doc/parse.ts
@@ -819,3 +819,10 @@ describe('CRLF line endings', () => {
     expect(res).toBe('foo bar')
   })
 })
+
+describe('Failed to decode suffix', () => {
+  test('rise in parse for malformed uri', () => {
+    const data = `[!!eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeJJJJJJJeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeebooleaeeeeeeeeeee-eeeeeeeee%eeeeeeeeeeeee[`
+    expect(() => YAML.parse(data)).toThrow(/Failed to decode suffix/)
+  })
+})

--- a/tests/doc/types.ts
+++ b/tests/doc/types.ts
@@ -106,6 +106,12 @@ describe('tags', () => {
         expect(doc.errors[0].code).toBe('MISSING_CHAR')
       })
     }
+
+    test('malformed URI (eemeli/yaml#498)', () => {
+      const doc = parseDocument('!!%ee 0')
+      expect(doc.errors).toHaveLength(1)
+      expect(doc.errors[0].message).toMatch('URIError')
+    })
   })
 
   test('eemeli/yaml#97', () => {


### PR DESCRIPTION
While [Fuzzing](https://en.wikipedia.org/wiki/Fuzzing) locally using [jazzer.js](https://github.com/CodeIntelligenceTesting/jazzer.js) `YAML.parse()` threw uncaught exception at
https://github.com/eemeli/yaml/blob/a4d8569c2139eee8a0324b6b861283f7b3b508f8/src/doc/directives.ts#L149 this pr attempts to fix that.
```
URIError: URI malformed
    at decodeURIComponent (<anonymous>)
    at Directives.tagName (/home/maxx/dev/security/oss-fuzz-projects/eemeli-yaml/dist/doc/directives.js:126:29)
```