### PR TITLE
Update Document.ts

### DIFF
--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -55,7 +55,7 @@ export class Document<
   /** A comment immediately after this Document */
   comment: string | null = null
 
-  /** The document contents. */
+  /** The document contents. At runtime, the document node type will be of type YAMLMap, YAMLSeq, Scalar or null. */
   contents: Strict extends true ? Contents | null : Contents
 
   directives: Strict extends true ? Directives | undefined : Directives


### PR DESCRIPTION
The update to the documentation is mainly for TS so that people are more aware that a node's type isn't determined until runtime.
This is related to issue #503 .