### PR TITLE
fix: use the `lineWidth` option for line breaking in flow collections

### DIFF
--- a/src/stringify/stringifyCollection.ts
+++ b/src/stringify/stringifyCollection.ts
@@ -148,7 +148,7 @@ function stringifyFlowCollection(
   } else {
     if (!reqNewline) {
       const len = lines.reduce((sum, line) => sum + line.length + 2, 2)
-      reqNewline = len > Collection.maxFlowStringSingleLineLength
+      reqNewline = ctx.options.lineWidth > 0 && len > ctx.options.lineWidth
     }
     if (reqNewline) {
       str = start

--- a/tests/doc/stringify.ts
+++ b/tests/doc/stringify.ts
@@ -616,7 +616,7 @@ describe('scalar styles', () => {
   y,
   n
 ]\n`
-    expect(String(doc)).toBe(str)
+    expect(doc.toString({ lineWidth: 1 })).toBe(str)
     expect(YAML.parse(str)).toEqual([
       true,
       false,
@@ -865,6 +865,36 @@ describe('indentSeq: false', () => {
             #sc
             - a
     `)
+  })
+})
+
+describe('lineWidth', () => {
+  const doc = YAML.parseDocument(
+    "[ 'Sed', 'ut', 'perspiciatis', 'unde', 'omnis', 'iste', 'natus', 'error', 'sit', 'voluptatem', 'accusantium', 'doloremque', 'laudantium,', 'totam' ]"
+  )
+
+  test('limit to 80 with overlong flow collection', () => {
+    expect(doc.toString({lineWidth: 80})).toBe(`[
+  'Sed',
+  'ut',
+  'perspiciatis',
+  'unde',
+  'omnis',
+  'iste',
+  'natus',
+  'error',
+  'sit',
+  'voluptatem',
+  'accusantium',
+  'doloremque',
+  'laudantium,',
+  'totam'
+]
+`)
+  })
+
+  test('limit > flow collection length', () => {
+    expect(doc.toString({lineWidth: 162})).toBe("[ 'Sed', 'ut', 'perspiciatis', 'unde', 'omnis', 'iste', 'natus', 'error', 'sit', 'voluptatem', 'accusantium', 'doloremque', 'laudantium,', 'totam' ]\n")
   })
 })
 


### PR DESCRIPTION
This should address issues #288 and #507.