### PR TITLE
Fix `false` capitalization

### DIFF
--- a/src/schema/yaml-1.1/bool.ts
+++ b/src/schema/yaml-1.1/bool.ts
@@ -21,7 +21,7 @@ export const falseTag: ScalarTag & { test: RegExp } = {
   identify: value => value === false,
   default: true,
   tag: 'tag:yaml.org,2002:bool',
-  test: /^(?:N|n|[Nn]o|NO|[Ff]alse|FALSE|[Oo]ff|OFF)$/i,
+  test: /^(?:N|n|[Nn]o|NO|[Ff]alse|FALSE|[Oo]ff|OFF)$/,
   resolve: () => new Scalar(false),
   stringify: boolStringify
 }

--- a/tests/doc/stringify.ts
+++ b/tests/doc/stringify.ts
@@ -633,7 +633,7 @@ describe('scalar styles', () => {
 
   test('bool Scalar styles on YAML1.1', () => {
     const doc = YAML.parseDocument(
-      '[ n, N, NO, no, No, False, false, FALSE, Off, off, OFF, y, Y, Yes, yes, YES, true, True, TRUE, ON, on, On ]',
+      '[ n, N, NO, no, No, False, false, FALSE, FALse, Off, off, OFF, OfF, y, Y, Yes, yes, YES, true, True, TRUE, ON, on, On ]',
       { schema: 'yaml-1.1' }
     )
     const str = `[
@@ -645,9 +645,11 @@ describe('scalar styles', () => {
   False,
   false,
   FALSE,
+  FALse,
   Off,
   off,
   OFF,
+  OfF,
   y,
   Y,
   Yes,
@@ -670,9 +672,11 @@ describe('scalar styles', () => {
       false,
       false,
       false,
+      'FALse',
       false,
       false,
       false,
+      'OfF',
       true,
       true,
       true,


### PR DESCRIPTION
With `yaml-1.1` the lib incorrectly parses badly capitalized literals like `FALse` and `OfF` as a `false` value. This PR fixes it.