### PR TITLE
feat: Add --indent option to CLI tool

### DIFF
--- a/docs/09_cli.md
+++ b/docs/09_cli.md
@@ -16,6 +16,7 @@ Usage:
 Options:
   --help, -h    Show this message.
   --json, -j    Output JSON.
+  --pretty, -p  Output pretty-printed JSON.
 
 Additional options for bare "yaml" command:
   --doc, -d     Output pretty-printed JS Document objects.

--- a/docs/09_cli.md
+++ b/docs/09_cli.md
@@ -16,7 +16,7 @@ Usage:
 Options:
   --help, -h    Show this message.
   --json, -j    Output JSON.
-  --pretty, -p  Output pretty-printed JSON.
+  --indent 2    Output pretty-printed data, indented by the given number of spaces.
 
 Additional options for bare "yaml" command:
   --doc, -d     Output pretty-printed JS Document objects.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ Usage:
 Options:
   --help, -h    Show this message.
   --json, -j    Output JSON.
-  --pretty, -p  Output pretty-printed JSON.
+  --indent 2    Output pretty-printed data, indented by the given number of spaces.
 
 Additional options for bare "yaml" command:
   --doc, -d     Output pretty-printed JS Document objects.
@@ -56,8 +56,8 @@ export async function cli(
       options: {
         doc: { type: 'boolean', short: 'd' },
         help: { type: 'boolean', short: 'h' },
+        indent: { type: 'string', short: 'i' },
         json: { type: 'boolean', short: 'j' },
-        pretty: { type: 'boolean', short: 'p' },
         single: { type: 'boolean', short: '1' },
         strict: { type: 'boolean', short: 's' },
         visit: { type: 'string', short: 'v' },
@@ -72,6 +72,8 @@ export async function cli(
     positionals: [mode],
     values: opt
   } = args
+
+  let indent = Number(opt.indent)
 
   stdin.setEncoding('utf-8')
 
@@ -94,7 +96,7 @@ export async function cli(
       })
       stdin.on('end', () => {
         for (const tok of lexer.lex('', false)) add(tok)
-        if (opt.json) console.log(JSON.stringify(data))
+        if (opt.json) console.log(JSON.stringify(data, null, indent))
         done()
       })
       break
@@ -112,7 +114,7 @@ export async function cli(
       })
       stdin.on('end', () => {
         for (const tok of parser.parse('', false)) add(tok)
-        if (opt.json) console.log(JSON.stringify(data))
+        if (opt.json) console.log(JSON.stringify(data, null, indent))
         done()
       })
       break
@@ -161,7 +163,8 @@ export async function cli(
         } else {
           if (reqDocEnd) console.log('...')
           try {
-            const str = String(doc)
+            indent ||= 2
+            const str = doc.toString({ indent })
             console.log(str.endsWith('\n') ? str.slice(0, -1) : str)
           } catch (error) {
             done(error as Error)
@@ -190,7 +193,6 @@ export async function cli(
           )
         }
         if (mode !== 'valid' && opt.json) {
-          const indent = opt.pretty ? 2 : 0
           console.log(JSON.stringify(opt.single ? data[0] : data, null, indent))
         }
         done()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ Usage:
 Options:
   --help, -h    Show this message.
   --json, -j    Output JSON.
+  --pretty, -p  Output pretty-printed JSON.
 
 Additional options for bare "yaml" command:
   --doc, -d     Output pretty-printed JS Document objects.
@@ -56,6 +57,7 @@ export async function cli(
         doc: { type: 'boolean', short: 'd' },
         help: { type: 'boolean', short: 'h' },
         json: { type: 'boolean', short: 'j' },
+        pretty: { type: 'boolean', short: 'p' },
         single: { type: 'boolean', short: '1' },
         strict: { type: 'boolean', short: 's' },
         visit: { type: 'string', short: 'v' },
@@ -188,7 +190,8 @@ export async function cli(
           )
         }
         if (mode !== 'valid' && opt.json) {
-          console.log(JSON.stringify(opt.single ? data[0] : data))
+          const indent = opt.pretty ? 2 : 0
+          console.log(JSON.stringify(opt.single ? data[0] : data, null, indent))
         }
         done()
       })

--- a/tests/cli.ts
+++ b/tests/cli.ts
@@ -147,7 +147,7 @@ const skip = Number(major) < 20
       )
       ok(
         'CST parser',
-        'hello: world',
+        'hello: world\n',
         ['cst', '--json', '--indent', '2'],
         [JSON.stringify([
           {

--- a/tests/cli.ts
+++ b/tests/cli.ts
@@ -114,6 +114,26 @@ const skip = Number(major) < 20
         ['[{"hello":"world"},42]']
       )
     })
+    describe('--pretty', () => {
+      ok(
+        'basic',
+        'hello: world',
+        ['--json', '--pretty'],
+        ['[\n  {\n    "hello": "world"\n  }\n]']
+      )
+      ok(
+        '--single',
+        'hello: world',
+        ['--json', '--pretty', '--single'],
+        ['{\n  "hello": "world"\n}']
+      )
+      ok(
+        'multiple',
+        'hello: world\n---\n42',
+        ['--json', '--pretty'],
+        ['[\n  {\n    "hello": "world"\n  },\n  42\n]']
+      )
+    })
     describe('--doc', () => {
       ok('basic', 'hello: world', ['--doc'], [{ contents: { items: [{}] } }])
       ok(

--- a/tests/cli.ts
+++ b/tests/cli.ts
@@ -114,24 +114,92 @@ const skip = Number(major) < 20
         ['[{"hello":"world"},42]']
       )
     })
-    describe('--pretty', () => {
+    describe('--indent', () => {
       ok(
         'basic',
+        'hello:\n  world: 2',
+        ['--indent', '3'],
+        ['hello:\n   world: 2']
+      )
+      ok(
+        '--json',
         'hello: world',
-        ['--json', '--pretty'],
+        ['--json', '--indent', '2'],
         ['[\n  {\n    "hello": "world"\n  }\n]']
       )
       ok(
         '--single',
         'hello: world',
-        ['--json', '--pretty', '--single'],
+        ['--json', '--indent', '2', '--single'],
         ['{\n  "hello": "world"\n}']
       )
       ok(
         'multiple',
         'hello: world\n---\n42',
-        ['--json', '--pretty'],
+        ['--json', '--indent', '2'],
         ['[\n  {\n    "hello": "world"\n  },\n  42\n]']
+      )
+      ok(
+        'Lexer',
+        'hello: world',
+        ['lex', '--json', '--indent', '2'],
+        ['[\n  "\\u0002",\n  "\\u001f",\n  "hello",\n  ":",\n  " ",\n  "\\u001f",\n  "world"\n]']
+      )
+      ok(
+        'CST parser',
+        'hello: world',
+        ['cst', '--json', '--indent', '2'],
+        [JSON.stringify([
+          {
+            type: 'document',
+            offset: 0,
+            start: [],
+            value: {
+              type: 'block-map',
+              offset: 0,
+              indent: 0,
+              items: [
+                {
+                  start: [],
+                  key: {
+                    type: 'scalar',
+                    offset: 0,
+                    indent: 0,
+                    source: 'hello'
+                  },
+                  sep: [
+                    {
+                      type: 'map-value-ind',
+                      offset: 5,
+                      indent: 0,
+                      source: ':'
+                    },
+                    {
+                      type: "space",
+                      offset: 6,
+                      indent: 0,
+                      source: ' '
+                    }
+                  ],
+                  value: {
+                    type: 'scalar',
+                    offset: 7,
+                    indent: 0,
+                    source: 'world',
+                    end: [
+                      {
+                        type: 'newline',
+                        offset: 12,
+                        indent: 0,
+                        source: '\n'
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ], null, 2)]
       )
     })
     describe('--doc', () => {


### PR DESCRIPTION
Add a `--indent` option, to be used with `--json` to output 2 space indentation.

See also #479 and #523.