### PR TITLE
feat: provide explicit ESM pkg entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,19 +27,21 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "node": {
-        "import": "./browser/index.js",
-        "require": "./dist/index.js"
-      },
+      "node": "./dist/index.js",
       "default": "./browser/index.js"
     },
     "./package.json": "./package.json",
     "./util": {
       "types": "./dist/util.d.ts",
-      "node": {
-        "import": "./browser/dist/util.js",
-        "require": "./dist/util.js"
-      },
+      "node": "./dist/util.js",
+      "default": "./browser/dist/util.js"
+    },
+    "./esm": {
+      "types": "./dist/index.d.ts",
+      "default": "./browser/index.js"
+    },
+    "./esm/util": {
+      "types": "./dist/util.d.ts",
       "default": "./browser/dist/util.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -27,15 +27,19 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./browser/index.js",
-      "node": "./dist/index.js",
+      "node": {
+        "import": "./browser/index.js",
+        "require": "./dist/index.js"
+      },
       "default": "./browser/index.js"
     },
     "./package.json": "./package.json",
     "./util": {
       "types": "./dist/util.d.ts",
-      "import": "./browser/dist/util.js",
-      "node": "./dist/util.js",
+      "node": {
+        "import": "./browser/dist/util.js",
+        "require": "./dist/util.js"
+      },
       "default": "./browser/dist/util.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -27,12 +27,14 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./browser/index.js",
       "node": "./dist/index.js",
       "default": "./browser/index.js"
     },
     "./package.json": "./package.json",
     "./util": {
       "types": "./dist/util.d.ts",
+      "import": "./browser/dist/util.js",
       "node": "./dist/util.js",
       "default": "./browser/dist/util.js"
     }


### PR DESCRIPTION
Despite that the cjs format is widely used in Nodejs, there are many reasons to use ESM today. Let's add the corresponding entry points.

```json
  "exports": {
    ".": {
      "types": "./dist/index.d.ts",
      "import": "./browser/index.js",
      "node": "./dist/index.js",
      "default": "./browser/index.js"
    },
```