### PR TITLE
feat: add manifest logo with dark mode display condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,12 @@ The development and maintenance of this library is [sponsored](https://github.co
       alt="Scipress"
   /></a>
   &nbsp; &nbsp;
-  <a href="https://manifest.build/"
-    ><img
-      width="150"
-      align="top"
-      src="https://eemeli.org/yaml/images/manifest-d7a58dae.png"
-      alt="Manifest"
-  /></a>
+  <a href="https://manifest.build/#gh-light-mode-only">
+    <img alt="manifest" src="https://eemeli.org/yaml/images/manifest-transparent.svg" width="150px" alt="Manifest logo" title="Manifest - A backend so simple that it fits into a single YAML file" />
+  </a>s
+  <a href="https://manifest.build/#gh-dark-mode-only">
+    <img alt="manifest" src="https://eemeli.org/yaml/images/manifest-light.svg" width="150px" alt="Manifest logo" title="Manifest - A backend so simple that it fits into a single YAML file" />
+  </a>
 </p>
 
 ## API Overview

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The development and maintenance of this library is [sponsored](https://github.co
 <p align="center" width="100%">
   <a href="https://www.scipress.io/"
     ><img
-      width="166"
+      width="150"
       align="top"
       src="https://eemeli.org/yaml/images/scipress.svg"
       alt="Scipress"
@@ -41,7 +41,7 @@ The development and maintenance of this library is [sponsored](https://github.co
   &nbsp; &nbsp;
   <a href="https://manifest.build/"
     ><img
-      width="166"
+      width="150"
       align="top"
       src="https://eemeli.org/yaml/images/manifest.svg"
       alt="Manifest"

--- a/README.md
+++ b/README.md
@@ -33,18 +33,19 @@ The development and maintenance of this library is [sponsored](https://github.co
 <p align="center" width="100%">
   <a href="https://www.scipress.io/"
     ><img
-      width="150"
+      width="166"
       align="top"
       src="https://eemeli.org/yaml/images/scipress.svg"
       alt="Scipress"
   /></a>
   &nbsp; &nbsp;
-  <a href="https://manifest.build/#gh-light-mode-only">
-    <img alt="manifest" src="https://eemeli.org/yaml/images/manifest-transparent.svg" width="150px" alt="Manifest logo" title="Manifest - A backend so simple that it fits into a single YAML file" />
-  </a>s
-  <a href="https://manifest.build/#gh-dark-mode-only">
-    <img alt="manifest" src="https://eemeli.org/yaml/images/manifest-light.svg" width="150px" alt="Manifest logo" title="Manifest - A backend so simple that it fits into a single YAML file" />
-  </a>
+  <a href="https://manifest.build/"
+    ><img
+      width="166"
+      align="top"
+      src="https://eemeli.org/yaml/images/manifest.svg"
+      alt="Manifest"
+  /></a>
 </p>
 
 ## API Overview


### PR DESCRIPTION
Here are the logos :
We need theme to be added to `https://eemeli.org/yaml/images/` repo.

![manifest-light](https://github.com/user-attachments/assets/f356546a-344d-4ac6-a6bb-d92b242e50e3)
![manifest-transparent](https://github.com/user-attachments/assets/e4df687f-9d8b-4c8c-98e3-d51e8fe758d1)
