### PR TITLE
Update schema.ts

### DIFF
--- a/src/schema/json/schema.ts
+++ b/src/schema/json/schema.ts
@@ -30,7 +30,7 @@ const jsonScalars: ScalarTag[] = [
     identify: value => typeof value === 'boolean',
     default: true,
     tag: 'tag:yaml.org,2002:bool',
-    test: /^true|false$/,
+    test: /^true$|^false$/,
     resolve: str => str === 'true',
     stringify: stringifyJSON
   },

--- a/tests/doc/types.ts
+++ b/tests/doc/types.ts
@@ -285,23 +285,23 @@ describe('json schema', () => {
     )
   })
 
-    test('!!bool: js-regex-missing-regexp-anchor', () => {
-    const src = `"canonical": true
+  test('!!bool: js-regex-missing-regexp-anchor', () => {
+    const src = `"canonical": truea
 "answer": ffalse
 "logical": Truea
 "option": TruEp`
 
     const doc = parseDocument(src, { schema: 'json' })
     expect(doc.toJS()).toMatchObject({
-      canonical: true,
+      canonical: 'truea',
       answer: 'ffalse',
       logical: 'Truea',
       option: 'TruEp'
     })
-    expect(doc.errors).toHaveLength(3)
+    expect(doc.errors).toHaveLength(4)
     doc.errors = []
     expect(String(doc)).toBe(
-      '"canonical": true\n"answer": "ffalse"\n"logical": "Truea"\n"option": "TruEp"\n'
+      '"canonical": "truea"\n"answer": "ffalse"\n"logical": "Truea"\n"option": "TruEp"\n'
     )
   })
 

--- a/tests/doc/types.ts
+++ b/tests/doc/types.ts
@@ -285,6 +285,26 @@ describe('json schema', () => {
     )
   })
 
+    test('!!bool: js-regex-missing-regexp-anchor', () => {
+    const src = `"canonical": true
+"answer": ffalse
+"logical": Truea
+"option": TruEp`
+
+    const doc = parseDocument(src, { schema: 'json' })
+    expect(doc.toJS()).toMatchObject({
+      canonical: true,
+      answer: 'ffalse',
+      logical: 'Truea',
+      option: 'TruEp'
+    })
+    expect(doc.errors).toHaveLength(3)
+    doc.errors = []
+    expect(String(doc)).toBe(
+      '"canonical": true\n"answer": "ffalse"\n"logical": "Truea"\n"option": "TruEp"\n'
+    )
+  })
+
   test('!!float', () => {
     const src = `"canonical": 6.8523015e+5
 "fixed": 685230.15


### PR DESCRIPTION
CodeQL is complaining about missing js regex anchors.

`Misleading operator precedence. The subexpression '^true' is anchored at the beginning, but the other parts of this regular expression are not
Misleading operator precedence. The subexpression 'false$' is anchored at the end, but the other parts of this regular expression are not`

https://codeql.github.com/codeql-query-help/javascript/js-regex-missing-regexp-anchor/
