### PR TITLE
feat: Add `--merge` option to CLI tool

### DIFF
--- a/docs/09_cli.md
+++ b/docs/09_cli.md
@@ -17,6 +17,7 @@ Options:
   --help, -h    Show this message.
   --json, -j    Output JSON.
   --indent 2    Output pretty-printed data, indented by the given number of spaces.
+  --merge, -m   Enable support for "<<" merge keys.
 
 Additional options for bare "yaml" command:
   --doc, -d     Output pretty-printed JS Document objects.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,7 @@ Options:
   --help, -h    Show this message.
   --json, -j    Output JSON.
   --indent 2    Output pretty-printed data, indented by the given number of spaces.
+  --merge, -m   Enable support for "<<" merge keys.
 
 Additional options for bare "yaml" command:
   --doc, -d     Output pretty-printed JS Document objects.
@@ -59,6 +60,7 @@ export async function cli(
         doc: { type: 'boolean', short: 'd' },
         help: { type: 'boolean', short: 'h' },
         indent: { type: 'string', short: 'i' },
+        merge: { type: 'boolean', short: 'm' },
         json: { type: 'boolean', short: 'j' },
         single: { type: 'boolean', short: '1' },
         strict: { type: 'boolean', short: 's' },
@@ -127,7 +129,7 @@ export async function cli(
       const lineCounter = new LineCounter()
       const parser = new Parser(lineCounter.addNewLine)
       // @ts-expect-error Version is validated at runtime
-      const composer = new Composer({ version: opt.yaml })
+      const composer = new Composer({ version: opt.yaml, merge: opt.merge })
       const visitor: visitor | null = opt.visit
         ? (await import(resolve(opt.visit))).default
         : null

--- a/tests/cli.ts
+++ b/tests/cli.ts
@@ -208,6 +208,14 @@ const skip = Number(major) < 20
         ]
       )
     })
+    describe('--merge', () => {
+      ok(
+        'basic',
+        'hello:\n  world: 2\nfoo:\n  world: 2',
+        ['--merge', '--json'],
+        ['[{"hello":{"world":2},"foo":{"world":2}}]']
+      )
+    })
     describe('--doc', () => {
       ok('basic', 'hello: world', ['--doc'], [{ contents: { items: [{}] } }])
       ok(

--- a/tests/cli.ts
+++ b/tests/cli.ts
@@ -210,9 +210,21 @@ const skip = Number(major) < 20
     })
     describe('--merge', () => {
       ok(
-        'basic',
+        'can be set',
         'hello:\n  world: 2\nfoo:\n  world: 2',
         ['--merge', '--json'],
+        ['[{"hello":{"world":2},"foo":{"world":2}}]']
+      )
+      ok(
+        'basic',
+        'hello: &a\n  world: 2\nfoo: *a',
+        ['--merge', '--json'],
+        ['[{"hello":{"world":2},"foo":{"world":2}}]']
+      )
+      ok(
+        'also enabled with --yaml=1.1',
+        'hello: &a\n  world: 2\nfoo: *a',
+        ['--yaml=1.1', '--json'],
         ['[{"hello":{"world":2},"foo":{"world":2}}]']
       )
     })

--- a/tests/cli.ts
+++ b/tests/cli.ts
@@ -217,15 +217,21 @@ const skip = Number(major) < 20
       )
       ok(
         'basic',
-        'hello: &a\n  world: 2\nfoo: *a',
+        'hello: &a\n  world: 2\nfoo:\n  <<: *a',
         ['--merge', '--json'],
         ['[{"hello":{"world":2},"foo":{"world":2}}]']
       )
       ok(
         'also enabled with --yaml=1.1',
-        'hello: &a\n  world: 2\nfoo: *a',
+        'hello: &a\n  world: 2\nfoo:\n  <<: *a',
         ['--yaml=1.1', '--json'],
         ['[{"hello":{"world":2},"foo":{"world":2}}]']
+      )
+      ok(
+        'not enabled by default',
+        'hello: &a\n  world: 2\nfoo:\n  <<: *a',
+        ['--json'],
+        ['[{"hello":{"world":2},"foo":{"<<":{"world":2}}}]']
       )
     })
     describe('--doc', () => {


### PR DESCRIPTION
~~~ yaml
# test.yaml
a: &a
  a: 2
b:
  <<: *a
~~~
~~~ sh
yaml --single --merge --json < test.yaml
~~~
~~~ json
{
  "a": {
    "a": 2
  },
  "b": {
    "a": 2
  }
}
~~~
