### PR TITLE
feat: Build cached anchor/alias node list for faster alias resolving

### DIFF
--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -433,8 +433,7 @@ export class Document<
       keep: !json,
       mapAsMap: mapAsMap === true,
       mapKeyWarned: false,
-      maxAliasCount: typeof maxAliasCount === 'number' ? maxAliasCount : 100,
-      anchorAndAliasNodes: []
+      maxAliasCount: typeof maxAliasCount === 'number' ? maxAliasCount : 100
     }
     const res = toJS(this.contents, jsonArg ?? '', ctx)
     if (typeof onAnchor === 'function')

--- a/src/doc/Document.ts
+++ b/src/doc/Document.ts
@@ -433,7 +433,8 @@ export class Document<
       keep: !json,
       mapAsMap: mapAsMap === true,
       mapKeyWarned: false,
-      maxAliasCount: typeof maxAliasCount === 'number' ? maxAliasCount : 100
+      maxAliasCount: typeof maxAliasCount === 'number' ? maxAliasCount : 100,
+      anchorAndAliasNodes: []
     }
     const res = toJS(this.contents, jsonArg ?? '', ctx)
     if (typeof onAnchor === 'function')

--- a/src/nodes/Alias.ts
+++ b/src/nodes/Alias.ts
@@ -52,7 +52,17 @@ export class Alias extends NodeBase {
   toJSON(_arg?: unknown, ctx?: ToJSContext): unknown {
     if (!ctx) return { source: this.source }
     const { anchors, doc, maxAliasCount } = ctx
-    const source = this.resolve(doc)
+
+    let source: Scalar | YAMLMap | YAMLSeq | undefined = undefined
+    if (ctx.anchorAndAliasNodes) {
+      for (const node of ctx.anchorAndAliasNodes) {
+        if (node === this) break
+        if (node.anchor === this.source) source = node
+      }
+    } else {
+      source = this.resolve(doc)
+    }
+
     if (!source) {
       const msg = `Unresolved alias (the anchor must be set before the alias): ${this.source}`
       throw new ReferenceError(msg)

--- a/src/nodes/toJS.ts
+++ b/src/nodes/toJS.ts
@@ -10,7 +10,7 @@ export interface AnchorData {
 
 export interface ToJSContext {
   anchors: Map<Node, AnchorData>
-  /** Cached anchor and allias nodes in the order they occurred in the document */
+  /** Cached anchor and alias nodes in the order they occur in the document */
   aliasResolveCache?: Node[]
   doc: Document<Node, boolean>
   keep: boolean

--- a/src/nodes/toJS.ts
+++ b/src/nodes/toJS.ts
@@ -1,10 +1,6 @@
 import type { Document } from '../doc/Document.ts'
 import { hasAnchor } from './identity.ts'
 import type { Node } from './Node.ts'
-import type { Alias } from './Alias.ts'
-import type { Scalar } from './Scalar.ts'
-import type { YAMLMap } from './YAMLMap.ts'
-import type { YAMLSeq } from './YAMLSeq.ts'
 
 export interface AnchorData {
   aliasCount: number
@@ -15,7 +11,7 @@ export interface AnchorData {
 export interface ToJSContext {
   anchors: Map<Node, AnchorData>
   /** Cached anchor and allias nodes in the order they occurred in the document */
-  aliasResolveCache?: (Alias | Scalar | YAMLMap | YAMLSeq)[]
+  aliasResolveCache?: Node[]
   doc: Document<Node, boolean>
   keep: boolean
   mapAsMap: boolean

--- a/src/nodes/toJS.ts
+++ b/src/nodes/toJS.ts
@@ -1,6 +1,10 @@
 import type { Document } from '../doc/Document.ts'
-import { hasAnchor } from './identity.ts'
+import { hasAnchor, isAlias } from './identity.ts'
 import type { Node } from './Node.ts'
+import type { Alias } from './Alias.ts'
+import type { Scalar } from './Scalar.ts'
+import type { YAMLMap } from './YAMLMap.ts'
+import type { YAMLSeq } from './YAMLSeq.ts'
 
 export interface AnchorData {
   aliasCount: number
@@ -10,6 +14,8 @@ export interface AnchorData {
 
 export interface ToJSContext {
   anchors: Map<Node, AnchorData>
+  /** Cached anchor and allias nodes in the order they occurred in the document */
+  anchorAndAliasNodes?: (Alias | Scalar | YAMLMap | YAMLSeq)[]
   doc: Document<Node, boolean>
   keep: boolean
   mapAsMap: boolean
@@ -33,13 +39,24 @@ export function toJS(value: any, arg: string | null, ctx?: ToJSContext): any {
   if (Array.isArray(value)) return value.map((v, i) => toJS(v, String(i), ctx))
   if (value && typeof value.toJSON === 'function') {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    if (!ctx || !hasAnchor(value)) return value.toJSON(arg, ctx)
+    if (!ctx) return value.toJSON(arg, ctx)
+
+    if (!hasAnchor(value)) {
+      if (ctx.anchorAndAliasNodes && isAlias(value))
+        ctx.anchorAndAliasNodes.push(value)
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+      return value.toJSON(arg, ctx)
+    }
+
     const data: AnchorData = { aliasCount: 0, count: 1, res: undefined }
     ctx.anchors.set(value, data)
     ctx.onCreate = res => {
       data.res = res
       delete ctx.onCreate
     }
+
+    if (ctx.anchorAndAliasNodes) ctx.anchorAndAliasNodes.push(value)
+
     const res = value.toJSON(arg, ctx)
     if (ctx.onCreate) ctx.onCreate(res)
     return res


### PR DESCRIPTION
Currently, to resolve an alias, we have to visit the whole document tree until the alias node is found. The lower in the file we put an alias, the slower the resolution is.

This is an attempt to speed this process significantly by:
1. Putting all nodes in a list and iterating over it, this is significantly faster than descending the tree via visitor every time
2. If we are putting nodes into a list we might as well filter them to only the ones that are needed for alias resolution, so only aliases and anchors are cached

Not sure if this is the right approach, but it helped me reduce the load time of my dataset, which is not very alias-heavy, from 10s to 4s.