### PR TITLE
feat: add indentBeforeInlineComment ToStringOption

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -323,6 +323,13 @@ export type ToStringOptions = {
   indent?: number
 
   /**
+   * The number of spaces to use when indenting an inline comment.
+   *
+   * Default: `1`
+   */
+  indentBeforeInlineComment?: number
+
+  /**
    * Whether block sequences should be indented.
    *
    * Default: `true`

--- a/src/stringify/stringify.ts
+++ b/src/stringify/stringify.ts
@@ -26,6 +26,7 @@ export type StringifyContext = {
   indentStep: string
   indentAtStart?: number
   inFlow: boolean | null
+  inlineIndentBeforeComment?: number,
   inStringifyKey?: boolean
   flowCollectionPadding: string
   options: Readonly<
@@ -50,6 +51,7 @@ export function createStringifyContext(
       falseStr: 'false',
       flowCollectionPadding: true,
       indentSeq: true,
+      inlineIndentBeforeComment: 1,
       lineWidth: 80,
       minContentWidth: 20,
       nullStr: 'null',

--- a/src/stringify/stringifyCollection.ts
+++ b/src/stringify/stringifyCollection.ts
@@ -63,7 +63,7 @@ function stringifyBlockCollection(
       () => (comment = null),
       () => (chompKeep = true)
     )
-    if (comment) str += lineComment(str, itemIndent, commentString(comment))
+    if (comment) str += lineComment(str, itemIndent, commentString(comment), ctx.inlineIndentBeforeComment ?? 1)
     if (chompKeep && comment) chompKeep = false
     lines.push(blockItemPrefix + str)
   }
@@ -135,7 +135,7 @@ function stringifyFlowCollection(
     if (comment) reqNewline = true
     let str = stringify(item, itemCtx, () => (comment = null))
     if (i < items.length - 1) str += ','
-    if (comment) str += lineComment(str, itemIndent, commentString(comment))
+    if (comment) str += lineComment(str, itemIndent, commentString(comment), ctx.inlineIndentBeforeComment ?? 1)
     if (!reqNewline && (lines.length > linesAtValue || str.includes('\n')))
       reqNewline = true
     lines.push(str)

--- a/src/stringify/stringifyComment.ts
+++ b/src/stringify/stringifyComment.ts
@@ -13,9 +13,14 @@ export function indentComment(comment: string, indent: string) {
   return indent ? comment.replace(/^(?! *$)/gm, indent) : comment
 }
 
-export const lineComment = (str: string, indent: string, comment: string) =>
+export const lineComment = (
+  str: string, 
+  indent: string, 
+  comment: string,
+  inlineIndentBeforeComment: number,
+) =>
   str.endsWith('\n')
     ? indentComment(comment, indent)
     : comment.includes('\n')
       ? '\n' + indentComment(comment, indent)
-      : (str.endsWith(' ') ? '' : ' ') + comment
+      : (' '.repeat(inlineIndentBeforeComment - (str.endsWith(' ') ? 1 : 0))) + comment

--- a/src/stringify/stringifyDocument.ts
+++ b/src/stringify/stringifyDocument.ts
@@ -54,7 +54,7 @@ export function stringifyDocument(
       onChompKeep
     )
     if (contentComment)
-      body += lineComment(body, '', commentString(contentComment))
+      body += lineComment(body, '', commentString(contentComment), options.indentBeforeInlineComment ?? 1)
     if (
       (body[0] === '|' || body[0] === '>') &&
       lines[lines.length - 1] === '---'

--- a/src/stringify/stringifyPair.ts
+++ b/src/stringify/stringifyPair.ts
@@ -16,7 +16,7 @@ export function stringifyPair(
     doc,
     indent,
     indentStep,
-    options: { commentString, indentSeq, simpleKeys }
+    options: { indentBeforeInlineComment: inlineIndentBeforeComment, commentString, indentSeq, simpleKeys }
   } = ctx
   let keyComment = (isNode(key) && key.comment) || null
   if (simpleKeys) {
@@ -28,6 +28,7 @@ export function stringifyPair(
       throw new Error(msg)
     }
   }
+  
   let explicitKey =
     !simpleKeys &&
     (!key ||
@@ -67,7 +68,7 @@ export function stringifyPair(
   } else if ((allNullValues && !simpleKeys) || (value == null && explicitKey)) {
     str = `? ${str}`
     if (keyComment && !keyCommentDone) {
-      str += lineComment(str, ctx.indent, commentString(keyComment))
+      str += lineComment(str, ctx.indent, commentString(keyComment), inlineIndentBeforeComment)
     } else if (chompKeep && onChompKeep) onChompKeep()
     return str
   }
@@ -75,12 +76,12 @@ export function stringifyPair(
   if (keyCommentDone) keyComment = null
   if (explicitKey) {
     if (keyComment)
-      str += lineComment(str, ctx.indent, commentString(keyComment))
+      str += lineComment(str, ctx.indent, commentString(keyComment), inlineIndentBeforeComment)
     str = `? ${str}\n${indent}:`
   } else {
     str = `${str}:`
     if (keyComment)
-      str += lineComment(str, ctx.indent, commentString(keyComment))
+      str += lineComment(str, ctx.indent, commentString(keyComment), inlineIndentBeforeComment)
   }
 
   let vsb, vcb, valueComment
@@ -160,7 +161,7 @@ export function stringifyPair(
   if (ctx.inFlow) {
     if (valueCommentDone && onComment) onComment()
   } else if (valueComment && !valueCommentDone) {
-    str += lineComment(str, ctx.indent, commentString(valueComment))
+    str += lineComment(str, ctx.indent, commentString(valueComment), inlineIndentBeforeComment)
   } else if (chompKeep && onChompKeep) {
     onChompKeep()
   }

--- a/tests/doc/stringify.ts
+++ b/tests/doc/stringify.ts
@@ -1035,6 +1035,29 @@ describe('Scalar options', () => {
     })
   })
 
+  describe('inlineIndentBeforeComment option', () => {
+    test('respects inlineIndentBeforeComment', () => {
+      const opt = {
+        indentBeforeInlineComment: 2
+      } as const
+      const yaml: string = `foo: bar  # a comment\n`
+      const doc = YAML.parseDocument(yaml)  
+      expect(doc.toString(opt)).toBe(yaml)
+    })
+    test('inlineIndentBeforeComment plays well with multiline comments', () => {
+      const opt = {
+        indentBeforeInlineComment: 2
+      } as const
+      const yaml: string = `# this is a comment
+# that extends
+# over multiple lines
+foo: bar  # a comment
+`  
+      const doc = YAML.parseDocument(yaml)
+      expect(doc.toString(opt)).toEqual(yaml)
+    })
+  })
+
   for (const { singleQuote, numeric, upgrade, parsed } of [
     {
       singleQuote: null,


### PR DESCRIPTION
Adding a new ToStringOption, indentBeforeInlineComment, to provide more flexibility on yaml output styling.

We already have linting conventions in place that conflict with the yaml being output by this library.  It would be nice to have the flexibility get the output to match the existing conventions.

We need to be able to specify that block comments have 2 not 1 space between the value and the start of the comment

```
key: value  # my comment
```
Naming is hard, would appreciate any better suggestions you may have for this config option !

