### PR TITLE
Re-introduce compatibility with Node.js 14.6

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,17 +10,14 @@ on:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [18, 20, latest]
-
     steps:
       - uses: actions/checkout@v4
         with: { submodules: true }
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
@@ -37,3 +34,60 @@ jobs:
         with: { node-version: 20 }
       - run: npm ci
       - run: npm run lint
+
+  node-16:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['16.0.0', '16']
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: true }
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm install --no-save rollup@3
+      - run: npm test
+      - run: npm run test:dist
+
+  node-14-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['14.18.0']
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: true }
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install --global npm@7
+      - run: npm ci
+      - run: npm install --no-save rollup@2
+      - run: npm run test:dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: yaml-node14
+          path: dist/
+  node-14-run:
+    needs: node-14-build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['14.6.0', '14', '15.0.0']
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: true }
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install --global npm@7
+      - run: npm ci
+      - uses: actions/download-artifact@v4
+        with:
+          name: yaml-node14
+          path: dist/
+      - run: npx jest --config config/jest.config.js
+        env:
+          TEST: dist

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -19,28 +19,27 @@ const transform = {
   '[/\\\\]tests[/\\\\].*\\.(m?js|ts)$': babel
 }
 
-// The npm script name is significant.
-switch (process.env.npm_lifecycle_event) {
-  case 'test:dist':
-    console.log('Testing build output from dist/')
-    moduleNameMapper = {
-      '^yaml$': '<rootDir>/dist/index.js',
-      '^yaml/cli$': '<rootDir>/dist/cli.mjs',
-      '^yaml/util$': '<rootDir>/dist/util.js',
-      '^../src/test-events.ts$': '<rootDir>/dist/test-events.js'
-    }
-    transform['[/\\\\]dist[/\\\\].*\\.mjs$'] = babel
-    break
-
-  case 'test':
-  default:
-    process.env.TRACE_LEVEL = 'log'
-    moduleNameMapper = {
-      '^yaml$': '<rootDir>/src/index.ts',
-      '^yaml/cli$': '<rootDir>/src/cli.ts',
-      '^yaml/util$': '<rootDir>/src/util.ts'
-    }
-    transform['[/\\\\]src[/\\\\].*\\.ts$'] = babel
+// npm_lifecycle_event is the npm script name.
+if (
+  process.env.TEST === 'dist' ||
+  process.env.npm_lifecycle_event === 'test:dist'
+) {
+  console.log('Testing build output from dist/')
+  moduleNameMapper = {
+    '^yaml$': '<rootDir>/dist/index.js',
+    '^yaml/cli$': '<rootDir>/dist/cli.mjs',
+    '^yaml/util$': '<rootDir>/dist/util.js',
+    '^../src/test-events.ts$': '<rootDir>/dist/test-events.js'
+  }
+  transform['[/\\\\]dist[/\\\\].*\\.mjs$'] = babel
+} else {
+  process.env.TRACE_LEVEL = 'log'
+  moduleNameMapper = {
+    '^yaml$': '<rootDir>/src/index.ts',
+    '^yaml/cli$': '<rootDir>/src/cli.ts',
+    '^yaml/util$': '<rootDir>/src/util.ts'
+  }
+  transform['[/\\\\]src[/\\\\].*\\.ts$'] = babel
 }
 
 module.exports = {

--- a/config/rollup.node-config.mjs
+++ b/config/rollup.node-config.mjs
@@ -49,6 +49,14 @@ function fixDynamicImportRewrite(context) {
   }
 }
 
+/**
+ * Leave out `node:` prefix as unsupported in Node.js < 14.18
+ *
+ * @param {string} id
+ */
+const fixNodePaths = id =>
+  id.startsWith('node:') ? id.substring(5) : undefined
+
 export default [
   {
     input: {
@@ -60,7 +68,8 @@ export default [
       dir: 'dist',
       format: 'cjs',
       esModule: false,
-      preserveModules: true
+      preserveModules: true,
+      paths: fixNodePaths
     },
     external: ['node:buffer', 'node:process'],
     plugins: [
@@ -72,7 +81,7 @@ export default [
   },
   {
     input: 'src/cli.ts',
-    output: { file: 'dist/cli.mjs' },
+    output: { file: 'dist/cli.mjs', paths: fixNodePaths },
     external: () => true,
     plugins: [
       typescript({

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "typescript-eslint": "^8.4.0"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
     "typescript-eslint": "^8.4.0"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 14.6"
   }
 }

--- a/tests/cli.ts
+++ b/tests/cli.ts
@@ -1,4 +1,4 @@
-import { Readable } from 'node:stream'
+import { Readable } from 'stream'
 import { cli } from 'yaml/cli'
 
 const [major] = process.versions.node.split('.')

--- a/tests/doc/anchors.ts
+++ b/tests/doc/anchors.ts
@@ -239,7 +239,12 @@ describe('merge <<', () => {
     for (let i = 5; i < res.length - 1; ++i) {
       expect(res[i]).toHaveProperty('<<')
     }
-    expect(res.at(-1)).toMatchObject({ x: 1, y: 2, r: 10, label: 'center/big' })
+    expect(res[res.length - 1]).toMatchObject({
+      x: 1,
+      y: 2,
+      r: 10,
+      label: 'center/big'
+    })
   })
 
   test('YAML.parseDocument', () => {


### PR DESCRIPTION
Fixes #598 

Getting the code compatible with Node.js 14.6 turned out not to be too onerous, so that ought to be done. Getting the build to work in Node.js < 14.18 was too much work, though.

The package.json engines is fixed to require Node.js 14.6 or later, which was already the practical reality.