### PR TITLE
feat: yaml.parse has generic type for return type

### DIFF
--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -131,23 +131,23 @@ export function parseDocument<
  *   document, so Maps become objects, Sequences arrays, and scalars result in
  *   nulls, booleans, numbers and strings.
  */
-export function parse(
+export function parse<R = any>(
   src: string,
   options?: ParseOptions & DocumentOptions & SchemaOptions & ToJSOptions
-): any
-export function parse(
+): R | null
+export function parse<R = any>(
   src: string,
   reviver: Reviver,
   options?: ParseOptions & DocumentOptions & SchemaOptions & ToJSOptions
-): any
+): R | null
 
-export function parse(
+export function parse<R = any>(
   src: string,
   reviver?:
     | Reviver
     | (ParseOptions & DocumentOptions & SchemaOptions & ToJSOptions),
   options?: ParseOptions & DocumentOptions & SchemaOptions & ToJSOptions
-): any {
+): R | null{
   let _reviver: Reviver | undefined = undefined
   if (typeof reviver === 'function') {
     _reviver = reviver
@@ -162,7 +162,7 @@ export function parse(
     if (doc.options.logLevel !== 'silent') throw doc.errors[0]
     else doc.errors = []
   }
-  return doc.toJS(Object.assign({ reviver: _reviver }, options))
+  return doc.toJS(Object.assign({ reviver: _reviver }, options)) as R
 }
 
 /**


### PR DESCRIPTION
I am migrating a repository from js-yaml to yaml. I saw that yaml has typescript typings, but the parse operation has no generic type for the return type. 

So here I propose to add a return Type.

before:

```typescript
const manifest = yaml.parse(file) as Manifest;
```

```typescript
const manifest = yaml.parse<Manifest>(file);
```

By doing so, I also get feedbeck by typescript, that manifest is potentially null, and I have to verify that I have not null as a result. 

Just because of this, I will need to check if js-yaml and yaml differ on parsing errors. I guess js-yaml, throws a YAMLException but yaml just returns null? Anyway. I think this is a usefull feature.