### PR TITLE
Update the `Range` type to labeled tuple for improved type hints

### DIFF
--- a/src/nodes/Node.ts
+++ b/src/nodes/Node.ts
@@ -42,7 +42,6 @@ export type ParsedNode =
   | YAMLMap.Parsed
   | YAMLSeq.Parsed
 
-/** `[start, value-end, node-end]` */
 export type Range = [start: number, valueEnd: number, nodeEnd: number]
 
 export abstract class NodeBase {


### PR DESCRIPTION
Labeled tuple is introduced in TypeScript 4.0, which was released in [2020](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#labeled-tuple-elements). Compatibility should be fine.

References:
- Official documentation for labeled tuple: [link](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-0.html#labeled-tuple-elements)
- Example `Range` type with labeled tuple on TypeScript Playground: [link](https://www.typescriptlang.org/play/?&q=231#code/PQKhAIAMG0GcBcCGAneAacA3RAbArgKYC0BAdgCYakD25xZ5AupOCMAFAEAeADtauHgBPHgXAAlRKQDmYgLzg4SVAC5wpPAFsARgWQZs+AgFEKajTr1VaJs+q27kjTr37xwAYxyJYscADkbcABvdnBPalIEZDwPeH4ACh48bRwASw9wZAJEckicISypWTVJGQIAShCAX3Za9g9IhHUghVICAHcAmwToAEYMACYMAGZGCvYGpvcEFHc2mwA6ZGKCaAAGZ2BgcN29-YPdgD0Afimo90NCU3JwBbpl1f6tncO39-BT8+aaOhu7loPFblaCDF4fCF7L5AA)