### PR TITLE
Expose block scalar header

### DIFF
--- a/src/compose/compose-scalar.ts
+++ b/src/compose/compose-scalar.ts
@@ -53,6 +53,12 @@ export function composeScalar(
   if (tagName) scalar.tag = tagName
   if (tag.format) scalar.format = tag.format
   if (comment) scalar.comment = comment
+  if (ctx.options.keepSourceTokens && token.type === 'block-scalar') {
+    const headerToken = token.props[0]
+    if (headerToken.type === 'block-scalar-header') {
+      scalar.blockScalarHeader = headerToken.source
+    }
+  }
 
   return scalar as Scalar.Parsed
 }

--- a/src/nodes/Scalar.ts
+++ b/src/nodes/Scalar.ts
@@ -13,6 +13,7 @@ export declare namespace Scalar {
     range: Range
     source: string
     srcToken?: FlowScalar | BlockScalar
+    blockScalarHeader?: string
   }
 
   type BLOCK_FOLDED = 'BLOCK_FOLDED'
@@ -51,6 +52,14 @@ export class Scalar<T = unknown> extends NodeBase {
 
   /** The scalar style used for the node's string representation */
   declare type?: Scalar.Type
+
+  /**
+   * The block scalar header, if this node was parsed from a block scalar.
+   * Only set when the `keepSourceTokens` option is enabled during parsing.
+   *
+   * Examples: `|`, `|-`, `|+`, `|2`, `>`, `>-`, `>+`, `>2`
+   */
+  declare blockScalarHeader?: string
 
   constructor(value: T) {
     super(SCALAR)

--- a/tests/doc/parse.ts
+++ b/tests/doc/parse.ts
@@ -717,6 +717,92 @@ describe('keepSourceTokens', () => {
     const res = tokens.map(YAML.CST.stringify).join('')
     expect(res).toBe('foo:\n  eek')
   })
+
+  describe('blockScalarHeader', () => {
+    test('not set without keepSourceTokens', () => {
+      const doc = YAML.parseDocument('|\n  foo\n')
+      expect(doc.contents).not.toHaveProperty('blockScalarHeader')
+    })
+
+    test('literal block scalar with clip (default)', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('|\n  foo\n', {
+        keepSourceTokens: true
+      })
+      expect(doc.contents.blockScalarHeader).toBe('|')
+    })
+
+    test('literal block scalar with strip', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('|-\n  foo\n', {
+        keepSourceTokens: true
+      })
+      expect(doc.contents.blockScalarHeader).toBe('|-')
+    })
+
+    test('literal block scalar with keep', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('|+\n  foo\n', {
+        keepSourceTokens: true
+      })
+      expect(doc.contents.blockScalarHeader).toBe('|+')
+    })
+
+    test('folded block scalar with clip', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('>\n  foo\n', {
+        keepSourceTokens: true
+      })
+      expect(doc.contents.blockScalarHeader).toBe('>')
+    })
+
+    test('folded block scalar with strip', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('>-\n  foo\n', {
+        keepSourceTokens: true
+      })
+      expect(doc.contents.blockScalarHeader).toBe('>-')
+    })
+
+    test('folded block scalar with keep', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('>+\n  foo\n', {
+        keepSourceTokens: true
+      })
+      expect(doc.contents.blockScalarHeader).toBe('>+')
+    })
+
+    test('block scalar with explicit indentation', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('|2\n  foo\n', {
+        keepSourceTokens: true
+      })
+      expect(doc.contents.blockScalarHeader).toBe('|2')
+    })
+
+    test('block scalar with explicit indentation and strip', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('|2-\n  foo\n', {
+        keepSourceTokens: true
+      })
+      expect(doc.contents.blockScalarHeader).toBe('|2-')
+    })
+
+    test('block scalar with explicit indentation and keep', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('|2+\n  foo\n', {
+        keepSourceTokens: true
+      })
+      expect(doc.contents.blockScalarHeader).toBe('|2+')
+    })
+
+    test('flow scalar has no blockScalarHeader', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('foo', {
+        keepSourceTokens: true
+      })
+      expect(doc.contents).not.toHaveProperty('blockScalarHeader')
+    })
+
+    test('block scalar in collection', () => {
+      const src = 'key: |-\n  value\n'
+      const doc = YAML.parseDocument<any, false>(src, {
+        keepSourceTokens: true
+      })
+      const scalar = doc.get('key', true)
+      expect(scalar.blockScalarHeader).toBe('|-')
+    })
+  })
 })
 
 describe('reviver', () => {


### PR DESCRIPTION
## Summary

Adds property `blockScalarHeader` on `Scalar.Parsed` when `keepSourceTokens` is enabled. This includes the style indicator, chomp indicator, and explicit indentation. For example `|`, `|-`, `|+`, or `|2`.

Closes:
- https://github.com/eemeli/yaml/issues/643

## Usage

```typescript
const doc = YAML.parseDocument('|-\n  content\n', { keepSourceTokens: true });
console.log(doc.contents.blockScalarHeader); // '|-'
```

## Implementation

Added `blockScalarHeader?: string` to `Scalar.Parsed` interface and populated it during parsing from the CST token. Follows the same pattern as other optional metadata properties like `srcToken`.
