### PR TITLE
Use the null prototype when parsing YAML maps

### DIFF
--- a/src/nodes/Pair.ts
+++ b/src/nodes/Pair.ts
@@ -36,7 +36,7 @@ export class Pair<
     doc: Document<DocValue, boolean>,
     ctx: ToJSContext
   ): ReturnType<typeof addPairToJSMap> {
-    const pair = ctx.mapAsMap ? new Map() : {}
+    const pair = ctx.mapAsMap ? new Map() : { __proto__: null }
     return addPairToJSMap(doc, ctx, pair, this)
   }
 

--- a/src/nodes/Pair.ts
+++ b/src/nodes/Pair.ts
@@ -36,7 +36,7 @@ export class Pair<
     doc: Document<DocValue, boolean>,
     ctx: ToJSContext
   ): ReturnType<typeof addPairToJSMap> {
-    const pair = ctx.mapAsMap ? new Map() : { __proto__: null }
+    const pair = ctx.mapAsMap ? new Map() : Object.create(null)
     return addPairToJSMap(doc, ctx, pair, this)
   }
 

--- a/src/nodes/Pair.ts
+++ b/src/nodes/Pair.ts
@@ -36,7 +36,9 @@ export class Pair<
     doc: Document<DocValue, boolean>,
     ctx: ToJSContext
   ): ReturnType<typeof addPairToJSMap> {
-    const pair = ctx.mapAsMap ? new Map() : Object.create(null)
+    const pair = ctx.mapAsMap
+      ? new Map()
+      : (Object.create(null) as Record<string, unknown>)
     return addPairToJSMap(doc, ctx, pair, this)
   }
 

--- a/src/nodes/YAMLMap.ts
+++ b/src/nodes/YAMLMap.ts
@@ -239,7 +239,7 @@ export class YAMLMap<
       ? new Type()
       : ctx?.mapAsMap
         ? new Map()
-        : { __proto__: null }
+        : Object.create(null)
     if (this.anchor) ctx.setAnchor(this, map)
     for (const pair of this.values.values()) addPairToJSMap(doc, ctx, map, pair)
     return map

--- a/src/nodes/YAMLMap.ts
+++ b/src/nodes/YAMLMap.ts
@@ -235,7 +235,11 @@ export class YAMLMap<
     Type?: { new (): T }
   ) {
     ctx ??= new ToJSContext()
-    const map = Type ? new Type() : ctx?.mapAsMap ? new Map() : {}
+    const map = Type
+      ? new Type()
+      : ctx?.mapAsMap
+        ? new Map()
+        : { __proto__: null }
     if (this.anchor) ctx.setAnchor(this, map)
     for (const pair of this.values.values()) addPairToJSMap(doc, ctx, map, pair)
     return map

--- a/src/nodes/YAMLMap.ts
+++ b/src/nodes/YAMLMap.ts
@@ -239,7 +239,7 @@ export class YAMLMap<
       ? new Type()
       : ctx?.mapAsMap
         ? new Map()
-        : Object.create(null)
+        : (Object.create(null) as Record<string, unknown>)
     if (this.anchor) ctx.setAnchor(this, map)
     for (const pair of this.values.values()) addPairToJSMap(doc, ctx, map, pair)
     return map

--- a/tests/node-to-js.ts
+++ b/tests/node-to-js.ts
@@ -17,12 +17,12 @@ describe('scalars', () => {
 describe('collections', () => {
   test('map', () => {
     const doc = parseDocument('key: 42')
-    expect(doc.value.toJS(doc)).toMatchObject({ key: 42 })
+    expect(doc.value.toJS(doc)).toStrictEqual({ __proto__: null, key: 42 })
   })
 
   test('map in seq', () => {
     const doc = parseDocument<YAMLSeq, false>('- key: 42')
-    expect(doc.get(0).toJS(doc)).toMatchObject({ key: 42 })
+    expect(doc.get(0).toJS(doc)).toStrictEqual({ __proto__: null, key: 42 })
   })
 })
 
@@ -51,7 +51,10 @@ describe('alias', () => {
       two: &b { key: *a }
       three: *b
     `)
-    expect(doc.get('three').toJS(doc)).toMatchObject({ key: 42 })
+    expect(doc.get('three').toJS(doc)).toStrictEqual({
+      __proto__: null,
+      key: 42
+    })
   })
 
   test('missing anchor', () => {

--- a/tests/node-to-js.ts
+++ b/tests/node-to-js.ts
@@ -17,12 +17,16 @@ describe('scalars', () => {
 describe('collections', () => {
   test('map', () => {
     const doc = parseDocument('key: 42')
-    expect(doc.value.toJS(doc)).toStrictEqual({ __proto__: null, key: 42 })
+    expect(doc.value.toJS(doc)).toStrictEqual(
+      Object.assign(Object.create(null), { key: 42 })
+    )
   })
 
   test('map in seq', () => {
     const doc = parseDocument<YAMLSeq, false>('- key: 42')
-    expect(doc.get(0).toJS(doc)).toStrictEqual({ __proto__: null, key: 42 })
+    expect(doc.get(0).toJS(doc)).toStrictEqual(
+      Object.assign(Object.create(null), { key: 42 })
+    )
   })
 })
 
@@ -51,10 +55,11 @@ describe('alias', () => {
       two: &b { key: *a }
       three: *b
     `)
-    expect(doc.get('three').toJS(doc)).toStrictEqual({
-      __proto__: null,
-      key: 42
-    })
+    expect(doc.get('three').toJS(doc)).toStrictEqual(
+      Object.assign(Object.create(null), {
+        key: 42
+      })
+    )
   })
 
   test('missing anchor', () => {

--- a/tests/properties.ts
+++ b/tests/properties.ts
@@ -9,7 +9,7 @@ function nullifyProto(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(nullifyProto)
   }
-  const result: Record<string, unknown> = { __proto__: null }
+  const result: Record<string, unknown> = Object.create(null)
   for (const key in value) {
     if (Object.hasOwn(value, key)) {
       result[key] = nullifyProto((value as Record<string, unknown>)[key])

--- a/tests/properties.ts
+++ b/tests/properties.ts
@@ -1,6 +1,23 @@
 import * as fc from 'fast-check'
 import { parse, stringify } from 'yaml'
 
+/** Set pojo prototypes to `null` recursively */
+function nullifyProto(value: unknown): unknown {
+  if (typeof value !== 'object' || value == null) {
+    return value
+  }
+  if (Array.isArray(value)) {
+    return value.map(nullifyProto)
+  }
+  const result: Record<string, unknown> = { __proto__: null }
+  for (const key in value) {
+    if (Object.hasOwn(value, key)) {
+      result[key] = nullifyProto((value as Record<string, unknown>)[key])
+    }
+  }
+  return result
+}
+
 describe('properties', () => {
   test('parse stringified object', () => {
     const key = fc.fullUnicodeString()
@@ -25,7 +42,9 @@ describe('properties', () => {
 
     fc.assert(
       fc.property(yamlArbitrary, optionsArbitrary, (obj, opts) => {
-        expect(parse(stringify(obj, opts), opts)).toStrictEqual(obj)
+        expect(parse(stringify(obj, opts), opts)).toStrictEqual(
+          nullifyProto(obj)
+        )
       })
     )
   })


### PR DESCRIPTION
YAML maps map a key to a value. These keys may conflict with keys on the JavaScript `Object` prototype. Several JavaScript APIs that use a plain object to represent a key/value map, use a null prototype.

Closes #675