### PR TITLE
fix: don't add trailing newline for empty values with spaceBefore

### DIFF
--- a/src/stringify/stringifyPair.ts
+++ b/src/stringify/stringifyPair.ts
@@ -123,6 +123,7 @@ export function stringifyPair(
     }
     if (valueStr === '' && !ctx.inFlow) {
       if (ws === '\n' && valueComment) ws = '\n\n'
+      else if (ws === '\n') ws = ''
     } else {
       ws += `\n${ctx.indent}`
     }

--- a/tests/doc/stringify.ts
+++ b/tests/doc/stringify.ts
@@ -427,6 +427,21 @@ z:
       const doc = YAML.parseDocument(src)
       expect(String(doc)).toBe(src)
     })
+
+    test('spaceBefore: blank line before nested mapping key', () => {
+      const src = 'a:\n  b:\n\nc:'
+      expect(YAML.parseDocument(src).toString()).toBe('a:\n  b:\n\nc:\n')
+    })
+
+    test('spaceBefore: blank line between sequence items', () => {
+      const src = '- a:\n\n- b'
+      expect(YAML.parseDocument(src).toString()).toBe('- a:\n\n- b\n')
+    })
+
+    test('spaceBefore: blank line between top-level keys', () => {
+      const src = 'a:\n\nb:'
+      expect(YAML.parseDocument(src).toString()).toBe('a:\n\nb:\n')
+    })
   })
 
   describe('properties on collections in block mapping', () => {


### PR DESCRIPTION
Fixes #639.

## Root cause

When a YAML pair has an empty value followed by blank lines (e.g. `b:` in `a:\n  b:\n\nc:`), the parser stores those blank lines in the pair's `sep` tokens. When the nested block-map exits before a new item starts at the same level, the special "move blank lines to next item's start" handling in the parser never fires. As a result, `resolveProps` processes the blank lines in `sep` and sets `spaceBefore: true` on the empty value node.

In `stringifyPair`, this causes `ws = '\n'` (from `vsb = !!value.spaceBefore`), which adds a trailing newline to the pair string (`'b:\n'`). That trailing newline then combines with the blank line added at the parent collection level via `pair.key.spaceBefore` for the following pair, producing a double blank line.

## Fix

One line in `stringifyPair.ts`: when `ws === '\n'` (set from `value.spaceBefore` with no `commentBefore`) and `valueStr === ''` (empty value), set `ws = ''`. The blank line separation between entries is already handled by the parent collection's `pair.key.spaceBefore` logic — the trailing newline from `vsb` is redundant and incorrect for empty values.

## Tests

Three test cases added inside the existing `No extra whitespace for empty values` describe block in `tests/doc/stringify.ts`, matching the minimal examples from the issue:

```js
parseDocument('a:\n  b:\n\nc:').toString()   // was 'a:\n  b:\n\n\nc:\n' → now 'a:\n  b:\n\nc:\n'
parseDocument('- a:\n\n- b').toString()       // was '- a:\n\n\n- b\n'   → now '- a:\n\n- b\n'
parseDocument('a:\n\nb:').toString()          // was 'a:\n\n\nb:\n'       → now 'a:\n\nb:\n'
```