### PR TITLE
fix: resolve out-of-range implicit floats as strings, not Infinity

### DIFF
--- a/src/compose/compose-scalar.ts
+++ b/src/compose/compose-scalar.ts
@@ -1,7 +1,7 @@
 import { Scalar } from '../nodes/Scalar.ts'
 import type { BlockScalar, FlowScalar, SourceToken } from '../parse/cst.ts'
 import type { Schema } from '../schema/Schema.ts'
-import type { ScalarTag } from '../schema/types.ts'
+import type { CollectionTag, ScalarTag } from '../schema/types.ts'
 import type { ComposeContext } from './compose-node.ts'
 import type { ComposeErrorHandler } from './composer.ts'
 import { resolveBlockScalar } from './resolve-block-scalar.ts'
@@ -89,22 +89,28 @@ function findScalarTagByName(
 }
 
 function findScalarTagByTest(
-  { atKey, directives, schema }: ComposeContext,
+  { atKey, directives, options, schema }: ComposeContext,
   value: string,
   token: FlowScalar,
   onError: ComposeErrorHandler
 ) {
-  const tag =
-    (schema.tags.find(
-      tag =>
-        (tag.default === true || (atKey && tag.default === 'key')) &&
-        tag.test?.test(value)
-    ) as ScalarTag) || schema.scalar
+  const test = (tag: CollectionTag | ScalarTag): tag is ScalarTag =>
+    !tag.collection &&
+    (tag.default === true || (atKey && tag.default === 'key')) &&
+    !!tag.test?.test(value) &&
+    resolvesImplicitly(tag, value, options)
+
+  const tag = schema.tags.find(test) ?? schema.scalar
 
   if (schema.compat) {
     const compat =
-      schema.compat.find(tag => tag.default && tag.test?.test(value)) ??
-      schema.scalar
+      schema.compat.find(
+        tag =>
+          !tag.collection &&
+          tag.default &&
+          tag.test?.test(value) &&
+          resolvesImplicitly(tag, value, options)
+      ) ?? schema.scalar
     if (tag.tag !== compat.tag) {
       const ts = directives.tagString(tag.tag)
       const cs = directives.tagString(compat.tag)
@@ -114,4 +120,22 @@ function findScalarTagByTest(
   }
 
   return tag
+}
+
+const nonFiniteFloat = /^(?:[-+]?\.(?:inf|Inf|INF)|\.nan|\.NaN|\.NAN)$/
+
+function resolvesImplicitly(
+  tag: ScalarTag,
+  value: string,
+  options: ComposeContext['options']
+) {
+  if (tag.tag !== 'tag:yaml.org,2002:float' || nonFiniteFloat.test(value))
+    return true
+  try {
+    const res = tag.resolve(value, () => {}, options)
+    const num = res instanceof Scalar ? res.value : res
+    return typeof num !== 'number' || Number.isFinite(num)
+  } catch {
+    return true
+  }
 }

--- a/tests/doc/types.ts
+++ b/tests/doc/types.ts
@@ -262,6 +262,36 @@ describe('number types', () => {
       expect(doc.value[5]).not.toHaveProperty('minFractionDigits')
     })
   })
+
+  test('out-of-range floats resolve as strings', () => {
+    expect(parse('gitsha: 61e9540')).toEqual({ gitsha: '61e9540' })
+
+    const doc = parseDocument<YAMLSeq>(`
+- 61e9540
+- -61e9540
+- 1e309
+- 1e308`)
+    expect(doc.value).toMatchObject([
+      { value: '61e9540' },
+      { value: '-61e9540' },
+      { value: '1e309' },
+      { value: 1e308, format: 'EXP' }
+    ])
+    expect(doc.toJS()).toEqual(['61e9540', '-61e9540', '1e309', 1e308])
+  })
+
+  test('out-of-range YAML 1.1 floats resolve as strings', () => {
+    const doc = parseDocument<YAMLSeq>(
+      `
+- 6_1e9540
+- 1e308`,
+      { version: '1.1' }
+    )
+    expect(doc.value).toMatchObject([
+      { value: '6_1e9540' },
+      { value: 1e308, format: 'EXP' }
+    ])
+  })
 })
 
 test('Indented sequence with sequence values (#2)', () => {


### PR DESCRIPTION
Fixes #657

## Problem
An untagged scalar like `61e9540` is matched by the implicit float regex and resolved to `Infinity`, even though it cannot round-trip as a JS number. Per YAML 1.2, an implicit tag should only be applied if the value round-trips properly.

## Fix
In `findScalarTagByTest` (`src/compose/compose-scalar.ts`), reject the implicit float tag when the resolved value is non-finite, falling through to the string tag. Explicit `!!float` is unaffected, and `.inf` / `.nan` literals still resolve correctly.

## Tests
Added regression tests (covering the core and compat schema paths) that fail before and pass after.
