### PR TITLE
fix: limit recursive merge aliases

### DIFF
--- a/src/nodes/Alias.ts
+++ b/src/nodes/Alias.ts
@@ -93,7 +93,7 @@ export class Alias implements NodeBase {
   toJS(doc: Document<DocValue, boolean>, ctx?: ToJSContext): any {
     if (!doc?.schema) throw new TypeError('A document argument is required')
     ctx ??= new ToJSContext()
-    const { anchors, maxAliasCount } = ctx
+    const { anchors } = ctx
 
     const source = this.resolve(doc, ctx)
     if (!source) {
@@ -101,28 +101,11 @@ export class Alias implements NodeBase {
       throw new ReferenceError(msg)
     }
 
-    let data = anchors.get(source)
-    if (!data) {
-      // Resolve anchors for Node.prototype.toJS()
-      source.toJS(doc, ctx)
-      data = anchors.get(source)
-    }
-    /* istanbul ignore if */
-    if (data?.res === undefined) {
-      const msg = 'This should not happen: Alias anchor was not resolved?'
-      throw new ReferenceError(msg)
-    }
-    if (maxAliasCount >= 0) {
-      data.count += 1
-      data.aliasCount ||= getAliasCount(doc, ctx, source, anchors)
-      if (data.count * data.aliasCount > maxAliasCount) {
-        const msg =
-          'Excessive alias count indicates a resource exhaustion attack'
-        throw new ReferenceError(msg)
-      }
-    }
-
-    return data.res
+    return ctx.resolveAlias(
+      doc,
+      source,
+      () => getAliasCount(doc, ctx, source, anchors)
+    )
   }
 
   toString(
@@ -143,7 +126,7 @@ export class Alias implements NodeBase {
   }
 }
 
-function getAliasCount(
+export function getAliasCount(
   doc: Document,
   ctx: ToJSContext,
   node: Node | Pair | null,

--- a/src/nodes/toJS.ts
+++ b/src/nodes/toJS.ts
@@ -17,7 +17,9 @@ export class ToJSContext {
   }
 
   setAnchor(node: Node, res: unknown): void {
-    this.anchors.set(node, { aliasCount: 0, count: 1, res })
+    const anchor = this.anchors.get(node)
+    if (anchor) anchor.res = res
+    else this.anchors.set(node, { aliasCount: 0, count: 1, res })
   }
 }
 

--- a/src/nodes/toJS.ts
+++ b/src/nodes/toJS.ts
@@ -1,3 +1,4 @@
+import type { Document } from '../doc/Document.ts'
 import type { ToJSOptions } from '../options.ts'
 import type { Node } from './types.ts'
 
@@ -20,6 +21,33 @@ export class ToJSContext {
     const anchor = this.anchors.get(node)
     if (anchor) anchor.res = res
     else this.anchors.set(node, { aliasCount: 0, count: 1, res })
+  }
+
+  resolveAlias(
+    doc: Document,
+    source: Node,
+    getAliasCount: () => number
+  ): unknown {
+    let data = this.anchors.get(source)
+    if (!data) {
+      source.toJS(doc, this)
+      data = this.anchors.get(source)
+    }
+    /* istanbul ignore if */
+    if (data?.res === undefined) {
+      const msg = 'This should not happen: Alias anchor was not resolved?'
+      throw new ReferenceError(msg)
+    }
+    if (this.maxAliasCount >= 0) {
+      data.count += 1
+      data.aliasCount ||= getAliasCount()
+      if (data.count * data.aliasCount > this.maxAliasCount) {
+        const msg =
+          'Excessive alias count indicates a resource exhaustion attack'
+        throw new ReferenceError(msg)
+      }
+    }
+    return data.res
   }
 }
 

--- a/src/schema/yaml-1.1/merge.ts
+++ b/src/schema/yaml-1.1/merge.ts
@@ -1,8 +1,8 @@
 import type { Document, DocValue } from '../../doc/Document.ts'
-import { Alias } from '../../nodes/Alias.ts'
+import { Alias, getAliasCount } from '../../nodes/Alias.ts'
 import { Scalar } from '../../nodes/Scalar.ts'
 import type { ToJSContext } from '../../nodes/toJS.ts'
-import { type MapLike, YAMLMap } from '../../nodes/YAMLMap.ts'
+import type { MapLike, YAMLMap } from '../../nodes/YAMLMap.ts'
 import type { ScalarTag } from '../types.ts'
 
 // If the value associated with a merge key is a single mapping node, each of
@@ -48,9 +48,8 @@ export function addMergeToJSMap(
   map: MapLike,
   value: unknown
 ): void {
-  const source = ctx && value instanceof Alias ? value.resolve(doc, ctx) : value
-  if (Array.isArray(source) && !(source instanceof YAMLMap)) {
-    if (value instanceof Alias) value.toJS(doc, ctx)
+  const source = getMergeSource(doc, ctx, value)
+  if (Array.isArray(source)) {
     for (const it of source) mergeValue(doc, ctx, map, it)
   } else {
     mergeValue(doc, ctx, map, value)
@@ -63,8 +62,7 @@ function mergeValue(
   map: MapLike,
   value: unknown
 ) {
-  if (value instanceof Alias) value.toJS(doc, ctx)
-  const source = value instanceof Alias ? value.resolve(doc, ctx) : value
+  const source = getMergeSource(doc, ctx, value)
   const srcMap = (source as YAMLMap).toJS(doc, ctx, Map<any, any>)
   if (!(srcMap instanceof Map))
     throw new Error('Merge sources must be maps or map aliases')
@@ -83,4 +81,25 @@ function mergeValue(
     }
   }
   return map
+}
+
+function getMergeSource(
+  doc: Document<DocValue, boolean>,
+  ctx: ToJSContext,
+  value: unknown
+) {
+  if (!(value instanceof Alias)) return value
+
+  const source = value.resolve(doc, ctx)
+  if (!source) {
+    const msg = `Unresolved alias (the anchor must be set before the alias): ${value.source}`
+    throw new ReferenceError(msg)
+  }
+
+  ctx.resolveAlias(
+    doc,
+    source,
+    () => getAliasCount(doc, ctx, source, ctx.anchors)
+  )
+  return source
 }

--- a/src/schema/yaml-1.1/merge.ts
+++ b/src/schema/yaml-1.1/merge.ts
@@ -48,9 +48,10 @@ export function addMergeToJSMap(
   map: MapLike,
   value: unknown
 ): void {
-  value = ctx && value instanceof Alias ? value.resolve(doc, ctx) : value
-  if (Array.isArray(value) && !(value instanceof YAMLMap)) {
-    for (const it of value) mergeValue(doc, ctx, map, it)
+  const source = ctx && value instanceof Alias ? value.resolve(doc, ctx) : value
+  if (Array.isArray(source) && !(source instanceof YAMLMap)) {
+    if (value instanceof Alias) value.toJS(doc, ctx)
+    for (const it of source) mergeValue(doc, ctx, map, it)
   } else {
     mergeValue(doc, ctx, map, value)
   }
@@ -62,6 +63,7 @@ function mergeValue(
   map: MapLike,
   value: unknown
 ) {
+  if (value instanceof Alias) value.toJS(doc, ctx)
   const source = value instanceof Alias ? value.resolve(doc, ctx) : value
   const srcMap = (source as YAMLMap).toJS(doc, ctx, Map<any, any>)
   if (!(srcMap instanceof Map))

--- a/tests/doc/anchors.ts
+++ b/tests/doc/anchors.ts
@@ -353,6 +353,28 @@ describe('merge <<', () => {
       expect(String(doc)).toBe('[ &AA { a: A }, { b: B, <<: *AA } ]\n')
     })
 
+    test('merge pair of an alias to a sequence', () => {
+      const doc = parseDocument<YAMLSeq, false>('[{ a: A }, [], { b: B }]', {
+        merge: true
+      })
+      const a = doc.get(0) as YAMLMap
+      const seq = doc.get(1) as YAMLSeq
+      const b = doc.get(2) as YAMLMap
+      seq.anchor = 'SEQ'
+      seq.push(doc.createAlias(a, 'AA'))
+      b.set(doc.createPair('<<', doc.createAlias(seq)))
+
+      expect(doc.toJS()).toMatchObject([
+        { a: 'A' },
+        [{ a: 'A' }],
+        { a: 'A', b: 'B' }
+      ])
+      expect(() => doc.toJS({ maxAliasCount: 0 })).toThrow(ReferenceError)
+      expect(String(doc)).toBe(
+        '[ &AA { a: A }, &SEQ [ *AA ], { b: B, <<: *SEQ } ]\n'
+      )
+    })
+
     test('require map node', () => {
       const doc = parseDocument<YAMLSeq, false>('[{ a: A }, { b: B }]', {
         merge: true

--- a/tests/doc/anchors.ts
+++ b/tests/doc/anchors.ts
@@ -155,8 +155,12 @@ describe('errors', () => {
     const doc = parseDocument(src, { merge: true })
     expect(doc.errors).toHaveLength(0)
     expect(doc.warnings).toHaveLength(0)
-    expect(() => doc.toJS()).toThrow('Maximum call stack size exceeded')
+    expect(() => doc.toJS()).toThrow(
+      'Excessive alias count indicates a resource exhaustion attack'
+    )
     expect(() => doc.toJS({ maxAliasCount: 0 })).toThrow(ReferenceError)
+    expect(() => doc.toJS({ maxAliasCount: 1 })).toThrow(ReferenceError)
+    expect(() => doc.toJS({ maxAliasCount: 2 })).toThrow(ReferenceError)
     expect(String(doc)).toBe(src)
   })
 })


### PR DESCRIPTION
Fixes #677.

This makes cyclic merge aliases fail through the existing alias-count guard instead of recursing until the call stack overflows.

The change keeps an existing anchor entry's count when the same node is re-entered during toJS() conversion, while allowing the resolved JS value to be updated. Merge alias handling now also runs alias toJS() before resolving the merge source, so maxAliasCount is applied to aliases reached through << merge handling.

Verification:

- npm test -- tests/doc/anchors.ts -t "circular reference"
- npm test -- tests/doc/anchors.ts
- npm test
- npm run lint
- npm run test:types
- npm run build
