### PR TITLE
fix: don't auto-detect exponential floats that overflow to ±Infinity

### DIFF
--- a/src/compose/compose-scalar.ts
+++ b/src/compose/compose-scalar.ts
@@ -98,12 +98,18 @@ function findScalarTagByTest(
     (schema.tags.find(
       tag =>
         (tag.default === true || (atKey && tag.default === 'key')) &&
-        tag.test?.test(value)
+        tag.test?.test(value) &&
+        (!tag.matchDefault || tag.matchDefault(value))
     ) as ScalarTag) || schema.scalar
 
   if (schema.compat) {
     const compat =
-      schema.compat.find(tag => tag.default && tag.test?.test(value)) ??
+      schema.compat.find(
+        tag =>
+          tag.default &&
+          tag.test?.test(value) &&
+          (!tag.matchDefault || tag.matchDefault(value))
+      ) ??
       schema.scalar
     if (tag.tag !== compat.tag) {
       const ts = directives.tagString(tag.tag)

--- a/src/schema/core/float.ts
+++ b/src/schema/core/float.ts
@@ -22,6 +22,9 @@ export const floatExp: ScalarTag = {
   tag: 'tag:yaml.org,2002:float',
   format: 'EXP',
   test: /^[-+]?(?:\.[0-9]+|[0-9]+(?:\.[0-9]*)?)[eE][-+]?[0-9]+$/,
+  // Only auto-detect as float when the value round-trips: overflow to ±Infinity
+  // must fall through to the string tag (YAML 1.2 spec §2.4).
+  matchDefault: str => isFinite(parseFloat(str)),
   resolve: str => parseFloat(str),
   stringify(node) {
     const num = Number(node.value)

--- a/src/schema/types.ts
+++ b/src/schema/types.ts
@@ -81,6 +81,15 @@ export interface ScalarTag extends TagBase {
    * you do.
    */
   test?: RegExp
+
+  /**
+   * An optional additional predicate applied **only** during automatic tag
+   * detection (i.e. when no explicit tag is present). When provided, a scalar
+   * is only resolved with this tag if both `test` and `matchDefault` return
+   * `true`. This lets a tag reject values that would not round-trip faithfully
+   * (e.g. exponential floats that overflow to ±Infinity).
+   */
+  matchDefault?: (value: string) => boolean
 }
 
 export interface CollectionTag extends TagBase {

--- a/src/schema/yaml-1.1/float.ts
+++ b/src/schema/yaml-1.1/float.ts
@@ -22,6 +22,9 @@ export const floatExp: ScalarTag = {
   tag: 'tag:yaml.org,2002:float',
   format: 'EXP',
   test: /^[-+]?(?:[0-9][0-9_]*)?(?:\.[0-9_]*)?[eE][-+]?[0-9]+$/,
+  // Only auto-detect as float when the value round-trips: overflow to ±Infinity
+  // must fall through to the string tag (YAML 1.2 spec §2.4).
+  matchDefault: str => isFinite(parseFloat(str.replace(/_/g, ''))),
   resolve: (str: string) => parseFloat(str.replace(/_/g, '')),
   stringify(node) {
     const num = Number(node.value)

--- a/tests/doc/types.ts
+++ b/tests/doc/types.ts
@@ -435,6 +435,18 @@ not a number: .nan
 not a NaN: -.NaN\n`)
   })
 
+  test('exponential float overflow → string (#657)', () => {
+    // Values that would overflow to ±Infinity must not be parsed as floats;
+    // the YAML 1.2 spec requires that scalars only use a tag if they round-trip.
+    expect(parse('value: 61e9540')).toEqual({ value: '61e9540' })
+    expect(parse('value: -61e9540')).toEqual({ value: '-61e9540' })
+    expect(parse('gitsha: 61e9540')).toEqual({ gitsha: '61e9540' })
+    // Normal finite exponential values must still resolve to numbers.
+    expect(parse('value: 6.1e3')).toEqual({ value: 6100 })
+    // Explicit !!float tag overrides the round-trip guard.
+    expect(parse('value: !!float 61e9540')).toEqual({ value: Infinity })
+  })
+
   test('!!int', () => {
     const src = `canonical: 685230
 decimal: +685230
@@ -617,6 +629,13 @@ sexagesimal: 190:20:30.15
 negative infinity: -.inf
 not a number: .nan
 not a NaN: -.NaN\n`)
+  })
+
+  test('exponential float overflow → string, YAML 1.1 (#657)', () => {
+    const opts = { version: '1.1' as const }
+    expect(parse('value: 61e9540', opts)).toEqual({ value: '61e9540' })
+    expect(parse('value: -61e9540', opts)).toEqual({ value: '-61e9540' })
+    expect(parse('value: 6.1e3', opts)).toEqual({ value: 6100 })
   })
 
   test('!!int', () => {


### PR DESCRIPTION
Closes #657

## Problem

An untagged scalar like `61e9540` or (from the issue) `gitsha: 61e9540` matches the float-EXP regex, so `parseFloat()` is called — returning `Infinity`. The YAML 1.2 spec §2.4 states:

> A YAML processor may use such a type for floating-point numbers, **as long as they round-trip properly.**

`61e9540 → Infinity → .inf` is not a round-trip, so the value must not be auto-tagged as a float.

## Solution

Added a `matchDefault` predicate to `ScalarTag` that is evaluated **only during automatic tag detection** (i.e. when no explicit tag is present). The `floatExp` tag in both the core and YAML 1.1 schemas sets `matchDefault` to reject values for which `parseFloat()` returns a non-finite result, letting them fall through to the string tag.

Explicit `!!float` tags are **unaffected**: they still resolve to `Infinity` when the exponent overflows, which matches the behaviour of other YAML libraries (e.g. PyYAML).

```js
// Before
YAML.parse('gitsha: 61e9540')   // { gitsha: Infinity }  ❌
YAML.parse('value: -61e9540')   // { value: -Infinity }  ❌

// After
YAML.parse('gitsha: 61e9540')   // { gitsha: '61e9540' }  ✅
YAML.parse('value: -61e9540')   // { value: '-61e9540' }  ✅

// Explicit tag still resolves as float
YAML.parse('value: !!float 61e9540')  // { value: Infinity }  ✅ (unchanged)

// Normal finite exponentials unchanged
YAML.parse('value: 6.1e3')  // { value: 6100 }  ✅
```

## Changes

- `src/schema/types.ts` — new optional `matchDefault` on `ScalarTag`
- `src/compose/compose-scalar.ts` — `findScalarTagByTest` now also checks `matchDefault` when present
- `src/schema/core/float.ts` — `floatExp.matchDefault` guards against overflow
- `src/schema/yaml-1.1/float.ts` — same for YAML 1.1 floatExp
- `tests/doc/types.ts` — two new tests covering core and YAML 1.1 schemas