### PR TITLE
fix: Preserve block scalar content indent in CST.setScalarValue

### DIFF
--- a/src/parse/cst-scalar.ts
+++ b/src/parse/cst-scalar.ts
@@ -162,6 +162,25 @@ export function setScalarValue(
   let { afterKey = false, implicitKey = false, inFlow = false, type } = context
   let indent = 'indent' in token ? token.indent : null
   if (afterKey && typeof indent === 'number') indent += 2
+  if (token.type === 'block-scalar') {
+    // `token.indent` is the indentation of the node, not of the block scalar's
+    // content. Stringifying the new value against it drops the content
+    // indentation and produces invalid YAML (#349); recover the content indent
+    // from the header's explicit indentation indicator, or else from the
+    // indentation of the existing block body.
+    const header = token.props[0]
+    if (header?.type === 'block-scalar-header' && header.indent > 0) {
+      indent = token.indent + header.indent
+    } else {
+      for (const line of token.source.split('\n')) {
+        const ci = line.length - line.replace(/^ +/, '').length
+        if (ci < line.length) {
+          indent = ci
+          break
+        }
+      }
+    }
+  }
   if (!type)
     switch (token.type) {
       case 'single-quoted-scalar':

--- a/tests/cst.ts
+++ b/tests/cst.ts
@@ -107,6 +107,23 @@ describe('CST.visit', () => {
     `)
   })
 
+  test('preserve block scalar indentation when replacing its value (#349)', () => {
+    const doc = cstDoc(source`
+      key: |-
+          line one
+          line two
+    `)
+    CST.visit(doc, item => {
+      if (item.value && CST.isScalar(item.value))
+        CST.setScalarValue(item.value, 'new one\nnew two')
+    })
+    expect(CST.stringify(doc)).toBe(source`
+      key: |-
+          new one
+          new two
+    `)
+  })
+
   test('add item', () => {
     const doc = cstDoc(source`
       -  " foo"


### PR DESCRIPTION
## Problem

`CST.setScalarValue()` drops a block scalar's indentation when the scalar is the value of a less-indented (e.g. unindented) mapping, producing invalid YAML that no longer round-trips:

```js
import { CST, Parser } from 'yaml'

const tokens = [...new Parser().parse('key: |-\n    line one\n    line two\n')]
const doc = tokens.find(t => t.type === 'document')
CST.visit(doc, item => {
  if (item.value && CST.isScalar(item.value))
    CST.setScalarValue(item.value, 'new one\nnew two')
})
CST.stringify(doc)
// => 'key: |-\nnew one\nnew two\n'
// content is at column 0; this reparses as { key: '', 'new one new two': null }
```

## Cause

In `setScalarValue`, `indent` is read from `token.indent`. For a block scalar nested under a mapping at indent 0, `token.indent` is the *node* indentation (0), not the block scalar's *content* indentation (4). The `indent > 0` guard then takes the empty-indent branch, so the new value is stringified with no indentation.

## Fix

For an existing block-scalar token, recover the content indent from the header's explicit indentation indicator (`token.indent + header.indent`, the same `trimIndent` that `resolveBlockScalar` computes) or, lacking an indicator, from the indentation of the existing block body — instead of using `token.indent`.

## Tests

Adds a regression test in `tests/cst.ts`. The existing suite passes, and I verified the fix round-trips literal, folded, explicitly-indicated (`|3`), and more-deeply-nested block scalars.

Fixes #349

### LLM assistance

Per the contributing guidelines: this PR was prepared with substantial LLM assistance. An AI coding agent (Claude) reproduced #349, instrumented `src/parse/cst-scalar.ts` to observe that `indent` was being read from `token.indent` (the node indent, `0`) rather than the block scalar's content indent, then wrote the fix and the regression test and verified them locally (repro, `npm test`, ESLint, Prettier, build). Reviewed before submission.
