### PR TITLE
fix: Round-trip block scalars with leading space on first line

### DIFF
--- a/src/stringify/stringifyString.ts
+++ b/src/stringify/stringifyString.ts
@@ -240,12 +240,18 @@ function blockString(
     0,
     startNlPos < startEnd ? startNlPos + 1 : startEnd
   )
+  const indentSize = indent ? '2' : '1' // root is at -1
+  // At the document root `indent` is empty, but the indentation indicator is
+  // still '1', so body lines must be indented by a single space to match.
+  const bodyIndent = startWithSpace && !indent ? ' ' : indent
+  // The first body line is prefixed with `bodyIndent` in the output, so it must
+  // be accounted for when checking whether that line is "more-indented".
+  const firstLineIndent = bodyIndent !== indent ? bodyIndent : ''
   if (start) {
     value = value.substring(start.length)
-    start = start.replace(/\n+/g, `$&${indent}`)
+    start = start.replace(/\n+/g, `$&${bodyIndent}`)
   }
 
-  const indentSize = indent ? '2' : '1' // root is at -1
   // Leading | or > is added later
   let header = (startWithSpace ? indentSize : '') + chomp
   if (comment) {
@@ -258,7 +264,7 @@ function blockString(
       .replace(/\n+/g, '\n$&')
       .replace(/(?:^|\n)([\t ].*)(?:([\n\t ]*)\n(?![\n\t ]))?/g, '$1$2') // more-indented lines aren't folded
       //                ^ more-ind. ^ empty     ^ capture next empty lines only at end of indent
-      .replace(/\n+/g, `$&${indent}`)
+      .replace(/\n+/g, `$&${bodyIndent}`)
     let literalFallback = false
     const foldOptions = getFoldOptions(ctx, true)
     if (blockQuote !== 'folded' && type !== Scalar.BLOCK_FOLDED) {
@@ -267,16 +273,17 @@ function blockString(
       }
     }
     const body = foldFlowLines(
-      `${start}${foldedValue}${end}`,
-      indent,
+      `${firstLineIndent}${start}${foldedValue}${end}`,
+      bodyIndent,
       FOLD_BLOCK,
       foldOptions
     )
-    if (!literalFallback) return `>${header}\n${indent}${body}`
+    if (!literalFallback)
+      return `>${header}\n${firstLineIndent ? '' : bodyIndent}${body}`
   }
 
-  value = value.replace(/\n+/g, `$&${indent}`)
-  return `|${header}\n${indent}${start}${value}${end}`
+  value = value.replace(/\n+/g, `$&${bodyIndent}`)
+  return `|${header}\n${bodyIndent}${start}${value}${end}`
 }
 
 function plainString(

--- a/src/stringify/stringifyString.ts
+++ b/src/stringify/stringifyString.ts
@@ -190,7 +190,7 @@ function blockString(
     return quotedString(value, ctx)
   }
 
-  const indent =
+  let indent =
     ctx.indent ||
     (ctx.forceBlockIndent || containsDocumentMarker(value) ? '  ' : '')
   const literal =
@@ -243,13 +243,17 @@ function blockString(
   const indentSize = indent ? '2' : '1' // root is at -1
   // At the document root `indent` is empty, but the indentation indicator is
   // still '1', so body lines must be indented by a single space to match.
-  const bodyIndent = startWithSpace && !indent ? ' ' : indent
-  // The first body line is prefixed with `bodyIndent` in the output, so it must
-  // be accounted for when checking whether that line is "more-indented".
-  const firstLineIndent = bodyIndent !== indent ? bodyIndent : ''
+  // The first body line is prefixed with this indent in the output, so when we
+  // have to introduce it here it must also be accounted for when checking
+  // whether that line is "more-indented".
+  let firstLineIndent = ''
+  if (startWithSpace && !indent) {
+    indent = ' '
+    firstLineIndent = indent
+  }
   if (start) {
     value = value.substring(start.length)
-    start = start.replace(/\n+/g, `$&${bodyIndent}`)
+    start = start.replace(/\n+/g, `$&${indent}`)
   }
 
   // Leading | or > is added later
@@ -264,7 +268,7 @@ function blockString(
       .replace(/\n+/g, '\n$&')
       .replace(/(?:^|\n)([\t ].*)(?:([\n\t ]*)\n(?![\n\t ]))?/g, '$1$2') // more-indented lines aren't folded
       //                ^ more-ind. ^ empty     ^ capture next empty lines only at end of indent
-      .replace(/\n+/g, `$&${bodyIndent}`)
+      .replace(/\n+/g, `$&${indent}`)
     let literalFallback = false
     const foldOptions = getFoldOptions(ctx, true)
     if (blockQuote !== 'folded' && type !== Scalar.BLOCK_FOLDED) {
@@ -274,16 +278,20 @@ function blockString(
     }
     const body = foldFlowLines(
       `${firstLineIndent}${start}${foldedValue}${end}`,
-      bodyIndent,
+      indent,
       FOLD_BLOCK,
       foldOptions
     )
     if (!literalFallback)
-      return `>${header}\n${firstLineIndent ? '' : bodyIndent}${body}`
+      return `>${header}\n${firstLineIndent ? '' : indent}${body}`
   }
 
-  value = value.replace(/\n+/g, `$&${bodyIndent}`)
-  return `|${header}\n${bodyIndent}${start}${value}${end}`
+  // For literal scalars the body is emitted verbatim, with every line — the
+  // first one included — prefixed by `indent`. When a leading space promoted
+  // `indent` to ' ' above, that single space is therefore already applied to
+  // the first line, so no separate `firstLineIndent` accounting is needed here.
+  value = value.replace(/\n+/g, `$&${indent}`)
+  return `|${header}\n${indent}${start}${value}${end}`
 }
 
 function plainString(

--- a/tests/doc/foldFlowLines.ts
+++ b/tests/doc/foldFlowLines.ts
@@ -321,7 +321,8 @@ describe('end-to-end', () => {
   test('More-indented first line (#55)', () => {
     const str = ' first more-indented line\nnext line\n'
     const ys = YAML.stringify(str, foldOptions)
-    expect(ys).toBe('>1\n first more-indented line\nnext line\n')
+    expect(ys).toBe('>1\n  first more-indented line\n next line\n')
+    expect(YAML.parse(ys)).toBe(str)
   })
 
   test('plain string', () => {

--- a/tests/doc/stringify.ts
+++ b/tests/doc/stringify.ts
@@ -914,6 +914,23 @@ describe('scalar styles', () => {
   })
 })
 
+describe('block scalar with leading-space first line round-trips (#692)', () => {
+  for (const str of [
+    '  a\n  b',
+    '  indented\nlines',
+    ' a\nb',
+    '   x\n y\nz',
+    '    deep\nshallow',
+    '  a\n  b\n',
+    ' first more-indented line\nnext line\n'
+  ]) {
+    test(JSON.stringify(str), () => {
+      const ys = YAML.stringify(str)
+      expect(YAML.parse(ys)).toBe(str)
+    })
+  }
+})
+
 describe('simple keys', () => {
   test('key with no value', () => {
     const doc = YAML.parseDocument('? ~')

--- a/tests/doc/stringify.ts
+++ b/tests/doc/stringify.ts
@@ -929,6 +929,13 @@ describe('block scalar with leading-space first line round-trips (#692)', () => 
       expect(YAML.parse(ys)).toBe(str)
     })
   }
+
+  test('BLOCK_LITERAL with leading space and document-start indicator', () => {
+    const str = ' ---\nfoo'
+    const ys = YAML.stringify(str, { defaultStringType: 'BLOCK_LITERAL' })
+    expect(ys).toBe('|1-\n  ---\n foo\n')
+    expect(YAML.parse(ys)).toBe(str)
+  })
 })
 
 describe('simple keys', () => {


### PR DESCRIPTION
Fixes #692.

### Problem

`stringify()` of a multiline string whose first content line starts with a space produced a block scalar whose declared indentation indicator did not match the body indentation. At the document root `ctx.indent` is `''`, but the indicator was emitted as `1`, while body lines were prefixed with the (empty) root indent. As a result the output either silently dropped a leading space per line or was not parseable by `parse()`:

```js
parse(stringify('  a\n  b'))           // => " a\n b"  (lost a leading space)
parse(stringify('  indented\nlines'))  // throws YAMLParseError
```

### Fix

In `blockString` (`src/stringify/stringifyString.ts`) introduce a `bodyIndent` that honors the declared indicator at the root (a single space when the value starts with a space and `indent` is empty), and use it for the body in both the literal and folded paths. The folded path additionally accounts for this added indent when deciding whether the first line is "more-indented", so a more-indented first line is no longer incorrectly folded.

Non-root and non-leading-space behavior is unchanged.

### Tests

- Added round-trip regression tests in `tests/doc/stringify.ts` covering several leading-space cases. These fail on `main` and pass with the fix.
- Updated the existing `tests/doc/foldFlowLines.ts` "More-indented first line (#55)" test: it was asserting the buggy output, whose expected string was itself unparseable. It now asserts the corrected, round-trippable output and additionally checks that the output parses back to the original.

The full `vitest run` suite passes (the two external test-suite files require submodule data and fail identically on a pristine tree).

### LLM assistance

This pull request was prepared with the assistance of an LLM (declared per CONTRIBUTING.md). All changes were reviewed and verified locally.
