### PR TITLE
fix: quote a string whose first line is whitespace-only

### DIFF
--- a/src/stringify/stringifyString.ts
+++ b/src/stringify/stringifyString.ts
@@ -186,7 +186,13 @@ function blockString(
   const { blockQuote, commentString, lineWidth } = ctx.options
   // 1. Block can't end in whitespace unless the last line is non-empty.
   // 2. Strings consisting of only whitespace are best rendered explicitly.
-  if (!blockQuote || /\n[\t ]+$/.test(value)) {
+  // 3. A leading whitespace-only line is read back as an empty line, dropping
+  //    its spaces, so such values can't survive a block scalar round-trip.
+  if (
+    !blockQuote ||
+    /\n[\t ]+$/.test(value) ||
+    /^\n*[\t ]+(\n|$)/.test(value)
+  ) {
     return quotedString(value, ctx)
   }
 

--- a/tests/doc/foldFlowLines.ts
+++ b/tests/doc/foldFlowLines.ts
@@ -282,6 +282,17 @@ describe('block scalar', () => {
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     `)
   })
+
+  test('leading whitespace-only line round-trips', () => {
+    // A line that is only spaces/tabs is read back as an empty line, so a value
+    // whose first content line is whitespace-only must not use a block scalar.
+    for (const str of ['  \n', ' \n', ' \t\n', '  \n\n', '  \nx', '\n  \n']) {
+      const ys = YAML.stringify(str)
+      const doc = YAML.parseDocument(ys)
+      expect(doc.errors).toHaveLength(0)
+      expect(YAML.parse(ys)).toBe(str)
+    }
+  })
 })
 
 describe('end-to-end', () => {


### PR DESCRIPTION
### Problem

Round-trip `parse(stringify(x)) === x` is broken when `x` is a string whose first non-empty line is whitespace-only:

```js
parse(stringify('  \n'))   // => '\n'  (the two spaces are dropped)
parse(stringify('  \nx'))  // throws YAMLParseError (UNEXPECTED_TOKEN)
```

`stringify()` emits a literal block scalar, but on parse YAML treats a whitespace-only line as an empty line and trims its indentation, so the leading spaces vanish (silent data loss) or the result no longer parses. Per YAML 1.2.2 8.1, a whitespace-only line inside a block scalar is read as empty, so a value whose first content line is whitespace-only is not representable as a block scalar.

### Fix

`blockString` already intends to quote whitespace-ish strings (the existing `\n[\t ]+$` guard), but that regex only catches a trailing whitespace-only line. This adds one more clause so a leading whitespace-only line also forces a quoted string:

```js
if (!blockQuote || /\n[\t ]+$/.test(value) || /^\n*[\t ]+(\n|$)/.test(value)) {
  return quotedString(value, ctx)
}
```

The new clause is carved to exactly this case: it only matches when the first content line is whitespace-only. Legitimate block scalars that merely contain a whitespace-only interior or leading-empty line (`'\na\nb'`, `'x\n  \ny'`, `'a\n  \nb'`) keep block style and continue to round-trip.

### Relationship to #693 (orthogonal, not a duplicate)

#693 / #692 handle the leading-space-followed-by-content family (e.g. `'  a\n  b'`, `'  indented\nlines'`) by fixing the block-scalar body indent, and that PR explicitly excludes whitespace-only strings. This PR handles only the whitespace-only-first-line family, which a block scalar cannot represent at all. The two changes are independent and compose: #693 fixes block-scalar indentation for content lines; this fixes the case where no valid block scalar exists and the value must be quoted.

### Tests

Added a round-trip regression in `tests/doc/foldFlowLines.ts` covering `'  \n'`, `' \n'`, `' \t\n'`, `'  \n\n'`, `'  \nx'`, `'\n  \n'`. It fails on a pristine tree (spaces dropped / parse error) and passes with the fix. The full `vitest run` suite stays green, including the vendored official yaml-test-suite.
