### PR TITLE
fix: keep indent indicator on empty block scalar before a comment

### DIFF
--- a/src/stringify/stringifyString.ts
+++ b/src/stringify/stringifyString.ts
@@ -201,7 +201,13 @@ function blockString(
         : type === Scalar.BLOCK_LITERAL
           ? true
           : !lineLengthOverLimit(value, lineWidth, indent.length)
-  if (!value) return literal ? '|\n' : '>\n'
+  if (!value) {
+    // An empty block scalar followed by a document comment needs an explicit
+    // indent indicator; without it the comment is parsed back as the scalar's
+    // own content rather than staying a comment (#687).
+    const indicator = ctx.forceBlockIndent ? (indent ? '2' : '1') : ''
+    return `${literal ? '|' : '>'}${indicator}\n`
+  }
 
   // determine chomping from whitespace at value end
   let chomp: '' | '-' | '+'

--- a/tests/doc/comments.ts
+++ b/tests/doc/comments.ts
@@ -79,6 +79,17 @@ describe('parse comments', () => {
       expect(doc.value.value).toBe('value')
       expect(doc.value.range).toMatchObject([4, 18, 18])
     })
+
+    test('empty block scalar followed by comment (#687)', () => {
+      const doc = YAML.parseDocument<YAML.Scalar, false>('|5\n#comment')
+      expect(doc.value.value).toBe('')
+      expect(doc.comment).toBe('comment')
+      // Round-trip must keep the comment a comment; without an explicit indent
+      // indicator on the empty block scalar it gets parsed back as its content.
+      const rt = YAML.parseDocument<YAML.Scalar, false>(doc.toString())
+      expect(rt.value.value).toBe('')
+      expect(rt.comment).toBe('comment')
+    })
   })
 
   describe('seq entry comments', () => {


### PR DESCRIPTION
## Problem

`Document.toString()` corrupts an empty block scalar that is followed by a document comment — the comment round-trips back as the scalar's content:

```js
const doc = parseDocument('|5\n#comment')
doc.toJSON() // '' — correct: #comment is at indent 0 < 5, so it's a comment, not content

const out = doc.toString() // '|\n\n\n#comment\n'
parseDocument(out).toJSON() // '\n\n#comment\n'  ← should be ''
```

Fixes #687.

## Cause

`blockString()` returns a bare `|`/`>` for an empty value, dropping the indent indicator even when `ctx.forceBlockIndent` is set — which `stringifyDocument` sets precisely when a document comment follows. Without the indicator the empty scalar has no explicit extent, so the trailing comment is absorbed as its content on re-parse.

## Fix

Emit the indent indicator for the empty-value case when `forceBlockIndent` is set, mirroring the existing `indentSize` logic a few lines below.

## Tests

Added a round-trip regression test in `tests/doc/comments.ts`. The full suite passes, including the YAML and JSON test suites — no regressions.

---
*🤖 This pull request was written with AI assistance (Claude Code).*
