### PR TITLE
fix: keep newline-separated comments separate at document start (#600)

### DIFF
--- a/src/compose/composer.ts
+++ b/src/compose/composer.ts
@@ -43,10 +43,21 @@ function parsePrelude(prelude: string[]) {
   let comment = ''
   let atComment = false
   let afterEmptyLine = false
+  let commentBefore = ''
   for (let i = 0; i < prelude.length; ++i) {
     const source = prelude[i]
     switch (source[0]) {
       case '#':
+        // A comment group separated from the next one by an empty line is
+        // detached from it. Keep such groups separate so that leading detached
+        // comments are assigned to the document and only the value-adjacent
+        // group to the value node, rather than merging them together (#600).
+        if (afterEmptyLine && comment !== '') {
+          commentBefore = commentBefore
+            ? `${commentBefore}\n\n${comment}`
+            : comment
+          comment = ''
+        }
         comment +=
           (comment === '' ? '' : afterEmptyLine ? '\n\n' : '\n') +
           (source.substring(1) || ' ')
@@ -63,7 +74,7 @@ function parsePrelude(prelude: string[]) {
         atComment = false
     }
   }
-  return { comment, afterEmptyLine }
+  return { comment, afterEmptyLine, commentBefore }
 }
 
 /**
@@ -103,21 +114,44 @@ export class Composer<
   }
 
   private decorate(doc: Document.Parsed<Value, Strict>, afterDoc: boolean) {
-    const { comment, afterEmptyLine } = parsePrelude(this.prelude)
-    if (comment) {
+    const { comment, afterEmptyLine, commentBefore } = parsePrelude(
+      this.prelude
+    )
+    if (comment || commentBefore) {
       const dc = doc.value
       if (afterDoc) {
-        doc.comment = doc.comment ? `${doc.comment}\n${comment}` : comment
-      } else if (afterEmptyLine || doc.directives.docStart) {
-        doc.commentBefore = comment
-      } else if (isCollection(dc) && !dc.flow && dc.size > 0) {
-        let it = Array.isArray(dc) ? dc[0] : dc.values.values().next().value!
-        if (it instanceof Pair) it = it.key
-        const cb = it.commentBefore
-        it.commentBefore = cb ? `${comment}\n${cb}` : comment
+        const trailing = commentBefore
+          ? comment
+            ? `${commentBefore}\n\n${comment}`
+            : commentBefore
+          : comment
+        doc.comment = doc.comment ? `${doc.comment}\n${trailing}` : trailing
       } else {
-        const cb = dc.commentBefore
-        dc.commentBefore = cb ? `${comment}\n${cb}` : comment
+        // Detached leading comment groups belong to the document, not the
+        // value node (#600).
+        if (commentBefore) {
+          doc.commentBefore = doc.commentBefore
+            ? `${commentBefore}\n${doc.commentBefore}`
+            : commentBefore
+        }
+        // The value-adjacent comment group, if any.
+        if (comment) {
+          if (afterEmptyLine || doc.directives.docStart) {
+            doc.commentBefore = doc.commentBefore
+              ? `${doc.commentBefore}\n\n${comment}`
+              : comment
+          } else if (isCollection(dc) && !dc.flow && dc.size > 0) {
+            let it = Array.isArray(dc)
+              ? dc[0]
+              : dc.values.values().next().value!
+            if (it instanceof Pair) it = it.key
+            const cb = it.commentBefore
+            it.commentBefore = cb ? `${comment}\n${cb}` : comment
+          } else {
+            const cb = dc.commentBefore
+            dc.commentBefore = cb ? `${comment}\n${cb}` : comment
+          }
+        }
       }
     }
 
@@ -146,7 +180,14 @@ export class Composer<
     warnings: YAMLWarning[]
   } {
     return {
-      comment: parsePrelude(this.prelude).comment,
+      comment: (() => {
+        const { comment, commentBefore } = parsePrelude(this.prelude)
+        return commentBefore
+          ? comment
+            ? `${commentBefore}\n\n${comment}`
+            : commentBefore
+          : comment
+      })(),
       directives: this.directives,
       errors: this.errors,
       warnings: this.warnings

--- a/tests/doc/comments.ts
+++ b/tests/doc/comments.ts
@@ -366,6 +366,31 @@ describe('stringify comments', () => {
         string
       `)
     })
+
+    test('keep newline-separated comments separate at document start (#600)', () => {
+      // A single comment block before the value attaches to the value.
+      const one = YAML.parseDocument('#foo\n\n42')
+      expect(one.commentBefore).toBe('foo')
+      expect((one.value as YAML.Scalar).commentBefore).toBeUndefined()
+
+      // A comment block detached by an empty line belongs to the document,
+      // the value-adjacent block to the value -- not merged into one.
+      const two = YAML.parseDocument('#foo\n\n#bar\n42')
+      expect(two.commentBefore).toBe('foo')
+      expect((two.value as YAML.Scalar).commentBefore).toBe('bar')
+      expect(String(two)).toBe('#foo\n\n#bar\n42\n')
+
+      // Same for a mapping: the detached comment goes to the document, the
+      // adjacent one to the first key (the original #600 report).
+      const map = YAML.parseDocument('#foo\n\n#bar\nversion: v1.7')
+      expect(map.commentBefore).toBe('foo')
+      expect(String(map)).toBe('#foo\n\n#bar\nversion: v1.7\n')
+
+      // Adjacent comments (no empty line) are still kept together.
+      const adj = YAML.parseDocument('#foo\n#bar\n42')
+      expect(adj.commentBefore).toBeNull()
+      expect((adj.value as YAML.Scalar).commentBefore).toBe('foo\nbar')
+    })
   })
 
   describe('seq comments', () => {
@@ -1019,8 +1044,11 @@ map:
         - v2
       `
       const doc = YAML.parseDocument(src)
+      // `c1` is separated from `c2` by an empty line, so it is detached and
+      // assigned to the document rather than merged into the first item (#600).
+      expect(doc.commentBefore).toBe(' c1')
       expect(doc.value).toMatchObject([
-        { commentBefore: ' c1\n\n c2', comment: ' c3' },
+        { commentBefore: ' c2', comment: ' c3' },
         { commentBefore: ' c4', spaceBefore: true }
       ])
       expect(doc.toString()).toBe(source`


### PR DESCRIPTION
Fixes #600.

## Problem

At document start, comment groups separated by an empty line are merged into a single `commentBefore` on the value instead of staying separate:

```js
parseDocument('#foo\n\n#bar\n42').value.commentBefore // 'foo\n\nbar'
```

`foo` is detached from the value by an empty line, so it should belong to the document, with only `bar` on the value (as noted in the issue).

## Root cause

`parsePrelude` (`src/compose/composer.ts`) concatenated every prelude comment line into one string, and `decorate` routed that whole blob to a single node using one `afterEmptyLine` flag.

## Fix

`parsePrelude` now splits the prelude: comment groups followed by an empty line are detached into `commentBefore`, and only the final value-adjacent group stays in `comment`. `decorate` assigns the detached part to the document and the adjacent part to the value (or first collection key):

```js
const doc = parseDocument('#foo\n\n#bar\n42')
doc.commentBefore       // 'foo'
doc.value.commentBefore // 'bar'
```

Single-block and adjacent (no empty line) cases are unchanged, and round-tripping is preserved.

This also corrects the analogous collection case — the original report was a mapping — so the existing `seq comments without #` test was updated: a leading comment detached by an empty line now attaches to the document rather than the first item.

## Tests

Added a regression test in `tests/doc/comments.ts` (scalar, mapping and adjacent-comment cases). The full suite passes, and `tsc --noEmit` / `eslint` / `prettier --check` are clean.

---
*This pull request was written with AI assistance (Claude).*
