### PR TITLE
fix: Parse a flow collection map key preceded by a blank line or comment

### DIFF
--- a/src/parse/parser.ts
+++ b/src/parse/parser.ts
@@ -698,7 +698,14 @@ export class Parser {
                 })
                 return
               }
-            } else if (atMapIndent) {
+            } else if (
+              atMapIndent &&
+              (it.sep || it.explicitKey || start.length > 0)
+            ) {
+              // Only open a new item when the current one already has content;
+              // otherwise reuse a preceding empty item that holds just a blank
+              // line or comment, rather than orphaning it before this key. An
+              // empty item is only valid at the very end of a block map.
               map.items.push({ start })
             }
             this.stack.push(bv)

--- a/src/parse/parser.ts
+++ b/src/parse/parser.ts
@@ -702,10 +702,6 @@ export class Parser {
               atMapIndent &&
               (it.sep || it.explicitKey || start.length > 0)
             ) {
-              // Only open a new item when the current one already has content;
-              // otherwise reuse a preceding empty item that holds just a blank
-              // line or comment, rather than orphaning it before this key. An
-              // empty item is only valid at the very end of a block map.
               map.items.push({ start })
             }
             this.stack.push(bv)

--- a/tests/doc/parse.ts
+++ b/tests/doc/parse.ts
@@ -219,6 +219,39 @@ describe('flow collection keys', () => {
     )
   })
 
+  test('flow collection key after a blank line (#646)', () => {
+    const doc = YAML.parseDocument('1: 2\n\n[3]: 4')
+    expect(doc.errors).toHaveLength(0)
+    expect(doc.value).toMatchObject(
+      _map([
+        [1, 2],
+        [_seq(3), 4]
+      ])
+    )
+  })
+
+  test('flow collection key after a comment line (#646)', () => {
+    const doc = YAML.parseDocument('1: 2\n# c\n[3]: 4')
+    expect(doc.errors).toHaveLength(0)
+    expect(doc.value).toMatchObject(
+      _map([
+        [1, 2],
+        [_seq(3), 4]
+      ])
+    )
+  })
+
+  test('flow collection key after an empty explicit key (#646)', () => {
+    const doc = YAML.parseDocument('?\n[3]: 4')
+    expect(doc.errors).toHaveLength(0)
+    expect(doc.value).toMatchObject(
+      _map([
+        [null, { key: { value: null }, value: null }],
+        [_seq(3), 4]
+      ])
+    )
+  })
+
   test('empty scalar as last flow collection value (#550)', () => {
     const doc = YAML.parseDocument<YAML.YAMLMap, false>('{c:}')
     expect(doc.value).toMatchObject(_map({ c: { value: null } }))


### PR DESCRIPTION
Fixes #646.

A flow collection used as an implicit block map key threw `IMPOSSIBLE` when a blank line or comment preceded it, e.g. `YAML.parse('1: 2\n\n[3]: 4')`.

Per your diagnosis: a value followed by a newline opens a new empty CST item, and when the next key is a flow collection at map indent, `blockMap`'s `atMapIndent` branch pushed a second empty item, orphaning the first mid-collection, which `resolveBlockMap` then rejects. The fix only opens a new item when the current one already has content; otherwise the flow collection assigns to the existing empty item on pop. Two regression tests (blank-line and comment) fail on `main`, pass here; suite, eslint, prettier, tsc green.

That branch is shared by block scalars and explicit keys, but only a flow collection reaches it as a new implicit key after a blank line (the others already parse fine), so the guard is effectively scoped, happy to narrow it.

Disclosure: I used an LLM to assist with investigation only. All code changes are my own. I've reviewed and understand every change, and I'm confident it's correct.