### PR TITLE
fix: only treat --- and ... as document markers

### DIFF
--- a/src/parse/lexer.ts
+++ b/src/parse/lexer.ts
@@ -20,7 +20,7 @@ const isNotAnchorChar = (ch: string) => !ch || invalidAnchorChars.has(ch)
 const blockScalarHeader = /([|>][^\s#]*)([ \t]*)((?:.|\r(?!\n))*)$/my
 const blockStart = /([-?:])(?=[ \n\r\t]|$)([ \t]*)/y
 const directiveLine = /(%.*?)(?:([ \t]+)(#.*)?)?$/my
-const docMarker = /[-.]{3}(?=[ \n\r\t]|$)(?:([ \t]+)(#.*)?)?/y
+const docMarker = /(?:-{3}|\.{3})(?=[ \n\r\t]|$)(?:([ \t]+)(#.*)?)?/y
 const emptyLineOrComment = /([ \t]*)(#.*)?$/my
 const indicator =
   //  |anchor       |explicit tag |implicit tag                                 |block start           |block start in flow   |spaces

--- a/tests/lexer.ts
+++ b/tests/lexer.ts
@@ -76,3 +76,11 @@ test('trailing comments on ...', () => {
     '\n'
   ])
 })
+
+test('mixed - and . are plain scalars, not document markers', () => {
+  // Only the exact sequences '---' and '...' are document markers;
+  // any other 3-char combination of '-' and '.' is a plain scalar.
+  for (const src of ['-.-', '--.', '.--', '-..', '..-', '.-.']) {
+    expect(lex(src)).toEqual([DOC, SCALAR, src])
+  }
+})


### PR DESCRIPTION
Six mixed dash/dot strings (`-.-`, `--.`, `.--`, `-..`, `..-`, `.-.`) are misparsed as document markers, so valid plain scalars throw and round-trip breaks.

## Repro

```js
import { parse, stringify } from 'yaml'

parse('-.-')                 // throws: Not a YAML token: -.-
parse('a: -.-')              // works: { a: '-.-' }
parse(stringify('-.-'))      // throws (round-trip broken)
```

`stringify('-.-')` produces `-.-\n`, but feeding that back to `parse` throws, so a value the library emits cannot be read back.

## Root cause

```js
const docMarker = /[-.]{3}(?=[ \n\r\t]|$)(?:([ \t]+)(#.*)?)?/y
```

The `[-.]{3}` character class matches any three-char combination of `-` and `.`, so all six strings above are treated as document markers. When such a value is the whole top-level document, the lexer emits it without the preceding scalar marker, the parser calls `tokenType('-.-')` which returns null, and it raises "Not a YAML token". As a mapping value (`a: -.-`) the same string is lexed as a plain scalar, hence the inconsistency.

## Fix

Replace the character class with an alternation of the two literal markers:

```js
const docMarker = /(?:-{3}|\.{3})(?=[ \n\r\t]|$)(?:([ \t]+)(#.*)?)?/y
```

Per YAML 1.2 only `---` (directives-end, §9.1.6) and `...` (document-end, §9.1.9) are document markers; every other line is content. The downstream `line.startsWith('-')` branch still distinguishes `---` from `...`.

## Verification

- New lexer test in `tests/lexer.ts` asserts each of the six strings lexes as `[DOC, SCALAR, src]`. It fails on the old pattern and passes with the fix.
- `---` and `...` still parse as markers, including multi-document input (`--- a\n--- b` -> `['a', 'b']`) and trailing document-end.
- yaml-test-suite conformance count is identical before and after (2089 passed / 4 skipped), so there are no conformance regressions. The rest of the unit suite passes (json-test-suite skipped locally, submodule data not fetched).
