### PR TITLE
fix: report C0 control characters in scalar values as errors (#703)

### DIFF
--- a/src/compose/resolve-block-scalar.ts
+++ b/src/compose/resolve-block-scalar.ts
@@ -3,6 +3,7 @@ import { Scalar } from '../nodes/Scalar.ts'
 import type { BlockScalar } from '../parse/cst.ts'
 import type { ComposeContext } from './compose-node.ts'
 import type { ComposeErrorHandler } from './composer.ts'
+import { checkPrintableChars } from './util-check-printable.ts'
 
 export function resolveBlockScalar(
   ctx: ComposeContext,
@@ -19,6 +20,8 @@ export function resolveBlockScalar(
   if (!header)
     return { value: '', type: null, comment: '', range: [start, start, start] }
   const type = header.mode === '>' ? Scalar.BLOCK_FOLDED : Scalar.BLOCK_LITERAL
+  if (scalar.source)
+    checkPrintableChars(scalar.source, start + header.length, onError)
   const lines = scalar.source ? splitLines(scalar.source) : []
 
   // determine the end of content & start of chomping

--- a/src/compose/resolve-flow-scalar.ts
+++ b/src/compose/resolve-flow-scalar.ts
@@ -4,6 +4,7 @@ import { Scalar } from '../nodes/Scalar.ts'
 import type { FlowScalar } from '../parse/cst.ts'
 import type { ComposeErrorHandler } from './composer.ts'
 import { resolveEnd } from './resolve-end.ts'
+import { checkPrintableChars } from './util-check-printable.ts'
 
 type FlowScalarErrorHandler = (
   offset: number,
@@ -26,6 +27,7 @@ export function resolveFlowScalar(
   let value: string
   const _onError: FlowScalarErrorHandler = (rel, code, msg) =>
     onError(offset + rel, code, msg)
+  checkPrintableChars(source, offset, onError)
   switch (type) {
     case 'scalar':
       _type = Scalar.PLAIN

--- a/src/compose/util-check-printable.ts
+++ b/src/compose/util-check-printable.ts
@@ -1,0 +1,39 @@
+import type { ComposeErrorHandler } from './composer.ts'
+
+/**
+ * C0 control characters that are excluded from the YAML 1.2 `c-printable`
+ * production, i.e. every C0 control other than the allowed `\t` (#x9),
+ * `\n` (#xA) and `\r` (#xD).
+ *
+ * See https://yaml.org/spec/1.2.2/#rule-c-printable
+ */
+const controlCharRe = /[\x00-\x08\x0b\x0c\x0e-\x1f]/g
+
+/**
+ * Reports a `CONTROL_CHAR` error for each C0 control character found in
+ * `source`, positioned at `offset + index`.
+ *
+ * The check is applied to the raw scalar source rather than its resolved
+ * value, so escape sequences in double-quoted scalars (e.g. `\t` or `\x07`)
+ * are not affected.
+ */
+export function checkPrintableChars(
+  source: string,
+  offset: number,
+  onError: ComposeErrorHandler
+): void {
+  controlCharRe.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = controlCharRe.exec(source)) !== null) {
+    const hex = match[0]
+      .charCodeAt(0)
+      .toString(16)
+      .padStart(2, '0')
+      .toUpperCase()
+    onError(
+      offset + match.index,
+      'CONTROL_CHAR',
+      `Control character \\x${hex} is not allowed and must be escaped`
+    )
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,6 +10,7 @@ export type ErrorCode =
   | 'BAD_SCALAR_START'
   | 'BLOCK_AS_IMPLICIT_KEY'
   | 'BLOCK_IN_FLOW'
+  | 'CONTROL_CHAR'
   | 'DUPLICATE_KEY'
   | 'IMPOSSIBLE'
   | 'KEY_OVER_1024_CHARS'

--- a/tests/doc/errors.ts
+++ b/tests/doc/errors.ts
@@ -70,6 +70,47 @@ describe('flow scalars', () => {
   })
 })
 
+describe('non-printable characters (#703)', () => {
+  test('control character in plain scalar', () => {
+    const doc = YAML.parseDocument('a\x07b')
+    expect(doc.errors).toMatchObject([{ code: 'CONTROL_CHAR' }])
+  })
+
+  test('control character in single-quoted scalar', () => {
+    const doc = YAML.parseDocument("'a\x07b'")
+    expect(doc.errors).toMatchObject([{ code: 'CONTROL_CHAR' }])
+  })
+
+  test('literal control character in double-quoted scalar', () => {
+    const doc = YAML.parseDocument('"a\x07b"')
+    expect(doc.errors).toMatchObject([{ code: 'CONTROL_CHAR' }])
+  })
+
+  test('control character in block scalar', () => {
+    const doc = YAML.parseDocument('|\n a\x07b\n')
+    expect(doc.errors).toMatchObject([{ code: 'CONTROL_CHAR' }])
+  })
+
+  test('multiple control characters are each reported', () => {
+    const doc = YAML.parseDocument('a\x01b\x1fc')
+    expect(doc.errors).toMatchObject([
+      { code: 'CONTROL_CHAR' },
+      { code: 'CONTROL_CHAR' }
+    ])
+  })
+
+  test('escaped control characters in double-quoted scalar are allowed', () => {
+    const doc = YAML.parseDocument('"a\\tb\\x07c"')
+    expect(doc.errors).toHaveLength(0)
+    expect(doc.toJS()).toBe('a\tb\x07c')
+  })
+
+  test('tab and NEL are allowed', () => {
+    const doc = YAML.parseDocument('"a\tb\x85c"')
+    expect(doc.errors).toHaveLength(0)
+  })
+})
+
 describe('block collections', () => {
   test('mapping with bad indentation', () => {
     const src = 'foo: "1"\n bar: 2\n'


### PR DESCRIPTION
## Summary

Literal C0 control characters (other than the permitted `\t`, `\n` and `\r`) are
excluded from the YAML 1.2 `c-printable` production, but the composer accepted
them silently in plain, quoted and block scalars.

Fixes #703.

## Changes

- `src/compose/util-check-printable.ts`: new `checkPrintableChars` helper — scans
  the raw scalar **source** and emits a `CONTROL_CHAR` error for each disallowed C0
  control. It runs on the raw source rather than the resolved value, so escape
  sequences such as `\t` or `\x07` in double-quoted scalars remain valid.
- `src/compose/resolve-flow-scalar.ts` / `src/compose/resolve-block-scalar.ts`:
  wire in the check for plain/single/double-quoted and block scalars.
- `src/errors.ts`: add the `CONTROL_CHAR` error code.
- `tests/doc/errors.ts`: new tests covering control chars in each scalar style,
  plus regression guards for escaped controls and permitted whitespace (tab/NEL).

## Scope note

Scoped to C0 controls only (`\x00–\x08`, `\x0b`, `\x0c`, `\x0e–\x1f`), matching the
issue title. DEL (`\x7f`) and C1 controls are intentionally left accepted so the
official JSON test suite (`y_string_with_del_character`,
`y_string_unescaped_char_delete`) keeps passing — JSON permits unescaped DEL and
this parser is deliberately JSON-compatible. Happy to extend further if you'd
rather also revisit those JSON-compat cases.

## Testing

Full suite passes: `npx vitest run` — 3386 tests passed, 11 skipped, 0 failed,
including the official `yaml-test-suite` and `JSONTestSuite` submodules.
`tsc --noEmit`, `eslint`, and `prettier --check` are all clean. The 5 new
"should error" tests were confirmed to fail on the pre-fix code and pass with
the fix; the 2 regression-guard tests pass throughout.

## LLM use disclosure

Per this project's CONTRIBUTING.md, disclosing as required: this PR was produced
by an autonomous coding agent (Claude). A human reviewed the diff and test results
before submission.
