### PR TITLE
Update contributing guide with LLM restrictions

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -62,5 +62,18 @@ Note that the CI environment runs tests in both Node.js and browsers, so using n
 If you're intending to contribute to the upstream repo, please make sure that your code style matches the Prettier and ESLint rules.
 The easiest way to do that is to configure your editor to do that for you, but `lint` and `prettier` npm scripts are also provided.
 
-If you use an LLM when writing pull requests, this must be explicitly declared in the pull request.
-If there is indication of undeclared LLM assistance, the pull request will be declined.
+Do not rebase or squash a PR while it's being reviewed.
+Instead, add new commits or (if necessary to resolve conflicts)
+merge from the `main` branch to your feature branch.
+
+## Use of LLMs and Similar Tools
+
+Prose contributions and comments must be your own writing,
+not the product of large language models (LLMs) or other tools.
+This includes code comments added in PRs, as well as all issue and PR contents.
+
+If you would like to use an LLM to contribute code to `yaml`,
+please request and discuss this in an appropriate issue first.
+LLM use must be clearly indicated and pre-approved.
+If there is indication of undeclared LLM assistance,
+the issue or pull request will be declined.


### PR DESCRIPTION
I'm getting quite tired of having conversations with other people's LLMs, and so I'm tightening the policy that's applied to this project. This text is now getting added to the [contributing guide](https://github.com/eemeli/yaml/blob/main/docs/CONTRIBUTING.md):

> Prose contributions and comments must be your own writing, not the product of large language models (LLMs) or other tools. This includes code comments added in PRs, as well as all issue and PR contents.
>
> If you would like to use an LLM to contribute code to `yaml`, please request and discuss this in an appropriate issue first. LLM use must be clearly indicated and pre-approved. If there is indication of undeclared LLM assistance, the issue or pull request will be declined.

In other words, I continue to welcome new contributions here. I don't really care that much what tools you're using to write code, but I am completely uninterested in interacting with those tools directly, or needing to process the excessively verbose text they produce. Do note that _all_ LLM use without pre-approval is unacceptable, and I'll likely be quite aggressive in making the determination of what smells like LLM.

Apologies if this seems harsh, but I'm maintaining this in my spare time, and would prefer to enjoy doing so.